### PR TITLE
Update to go 1.23

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,11 @@
 {
   "name": "Kubebuilder DevContainer",
-  "image": "golang:1.22",
+  "image": "mcr.microsoft.com/devcontainers/go:1.23-bookworm",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-    "ghcr.io/devcontainers/features/git:1": {}
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {}
   },
 
   "runArgs": ["--network=host"],
@@ -22,4 +24,3 @@
 
   "onCreateCommand": "bash .devcontainer/post-install.sh"
 }
-

--- a/.devcontainer/post-install.sh
+++ b/.devcontainer/post-install.sh
@@ -3,16 +3,11 @@ set -x
 
 curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
 chmod +x ./kind
-mv ./kind /usr/local/bin/kind
+sudo mv ./kind /usr/local/bin/kind
 
 curl -L -o kubebuilder https://go.kubebuilder.io/dl/latest/linux/amd64
 chmod +x kubebuilder
-mv kubebuilder /usr/local/bin/
-
-KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
-curl -LO "https://dl.k8s.io/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl"
-chmod +x kubectl
-mv kubectl /usr/local/bin/kubectl
+sudo mv kubebuilder /usr/local/bin/
 
 docker network create -d=bridge --subnet=172.19.0.0/24 kind
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: 'go.mod'
 
       - name: Install the latest version of kind
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.22'
+          go-version-file: 'go.mod'
 
       - name: Running Tests
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,14 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 ## Getting Started
 
 ### Prerequisites
-- go version v1.22.0+
+
+- go version v1.23.0+
 - docker version 17.03+.
 - kubectl version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.
 
 ### To Deploy on the cluster
+
 **Build and push your image to the location specified by `IMG`:**
 
 ```sh
@@ -60,6 +62,7 @@ kubectl apply -k config/samples/
 >**NOTE**: Ensure that the samples has default values to test it out.
 
 ### To Uninstall
+
 **Delete the instances (CRs) from the cluster:**
 
 ```sh
@@ -102,6 +105,7 @@ kubectl apply -f https://raw.githubusercontent.com/<org>/etcd-operator/<tag or b
 ```
 
 ## Contributing
+
 // TODO(user): Add detailed information on how you would like others to contribute to this project
 
 **NOTE:** Run `make help` for more information on all potential `make` targets

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module go.etcd.io/etcd-operator
 
-go 1.22.0
+toolchain go1.23.4
+
+go 1.23
 
 require (
 	github.com/onsi/ginkgo/v2 v2.19.0


### PR DESCRIPTION
Let's try and keep the operator aligned with our other etcd-io projects.

-  Use go version from go.mod in actions workflows.
- Update to go 1.23.
- Align devcontainer with `etcd-io/etcd`.
