### PR TITLE
Chore: Fix lint error

### DIFF
--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -21,9 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	ecv1alpha1 "go.etcd.io/etcd-operator/api/v1alpha1"
-	"go.etcd.io/etcd-operator/internal/etcdutils"
-	clientv3 "go.etcd.io/etcd/client/v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -32,6 +29,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	ecv1alpha1 "go.etcd.io/etcd-operator/api/v1alpha1"
+	"go.etcd.io/etcd-operator/internal/etcdutils"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 const (
@@ -144,6 +145,7 @@ func (r *EtcdClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// TODO: finish the logic later
 	if int(targetReplica) != memberCnt {
 		// TODO: finish the logic later
+		// nolint:staticcheck　// Temporarily disable staticcheck
 		if int(targetReplica) < memberCnt {
 			// a new added learner hasn't started yet
 

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -9,9 +9,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	ecv1alpha1 "go.etcd.io/etcd-operator/api/v1alpha1"
-	"go.etcd.io/etcd-operator/internal/etcdutils"
-	clientv3 "go.etcd.io/etcd/client/v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -23,6 +20,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	ecv1alpha1 "go.etcd.io/etcd-operator/api/v1alpha1"
+	"go.etcd.io/etcd-operator/internal/etcdutils"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 func prepareOwnerReference(ec *ecv1alpha1.EtcdCluster, scheme *runtime.Scheme) ([]metav1.OwnerReference, error) {

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -8,10 +8,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
-	ecv1alpha1 "go.etcd.io/etcd-operator/api/v1alpha1"
-	"go.etcd.io/etcd-operator/internal/etcdutils"
-	"go.etcd.io/etcd/api/v3/etcdserverpb"
-	clientv3 "go.etcd.io/etcd/client/v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,6 +17,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	ecv1alpha1 "go.etcd.io/etcd-operator/api/v1alpha1"
+	"go.etcd.io/etcd-operator/internal/etcdutils"
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 func TestMain(m *testing.M) {

--- a/internal/etcdutils/etcdutils.go
+++ b/internal/etcdutils/etcdutils.go
@@ -10,10 +10,11 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"go.uber.org/zap"
+
 	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	"go.etcd.io/etcd/client/pkg/v3/logutil"
 	clientv3 "go.etcd.io/etcd/client/v3"
-	"go.uber.org/zap"
 )
 
 func MemberList(eps []string) (*clientv3.MemberListResponse, error) {

--- a/internal/etcdutils/etcdutils_test.go
+++ b/internal/etcdutils/etcdutils_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/server/v3/embed"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -93,27 +93,27 @@ var _ = Describe("Manager", Ordered, func() {
 			cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
 			controllerLogs, err := utils.Run(cmd)
 			if err == nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, fmt.Sprintf("Controller logs:\n %s", controllerLogs))
+				_, _ = fmt.Fprintf(GinkgoWriter, "Controller logs:\n %s", controllerLogs)
 			} else {
-				_, _ = fmt.Fprintf(GinkgoWriter, fmt.Sprintf("Failed to get Controller logs: %s", err))
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get Controller logs: %s", err)
 			}
 
 			By("Fetching Kubernetes events")
 			cmd = exec.Command("kubectl", "get", "events", "-n", namespace, "--sort-by=.lastTimestamp")
 			eventsOutput, err := utils.Run(cmd)
 			if err == nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, fmt.Sprintf("Kubernetes events:\n%s", eventsOutput))
+				_, _ = fmt.Fprintf(GinkgoWriter, "Kubernetes events:\n%s", eventsOutput)
 			} else {
-				_, _ = fmt.Fprintf(GinkgoWriter, fmt.Sprintf("Failed to get Kubernetes events: %s", err))
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get Kubernetes events: %s", err)
 			}
 
 			By("Fetching curl-metrics logs")
 			cmd = exec.Command("kubectl", "logs", "curl-metrics", "-n", namespace)
 			metricsOutput, err := utils.Run(cmd)
 			if err == nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, fmt.Sprintf("Metrics logs:\n %s", metricsOutput))
+				_, _ = fmt.Fprintf(GinkgoWriter, "Metrics logs:\n %s", metricsOutput)
 			} else {
-				_, _ = fmt.Fprintf(GinkgoWriter, fmt.Sprintf("Failed to get curl-metrics logs: %s", err))
+				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get curl-metrics logs: %s", err)
 			}
 
 			By("Fetching controller manager pod description")


### PR DESCRIPTION
This pull request fixes the lint error on the workflow.
cf. https://github.com/etcd-io/etcd-operator/actions/runs/12767437613/job/35585812805

### Import Statement Reorganization:

* [`internal/controller/etcdcluster_controller.go`](diffhunk://#diff-7e023adf1c245d768f95e3f174cab882db08efd47023a9ce81e29a3a7767c12aL24-L26): Reorganized import statements to improve readability and maintainability. 
* [`internal/controller/utils.go`](diffhunk://#diff-2e75daf7fbfd686a57f8e7bd14cb6e04c7ca3ffb3406fa0f702641c72ff12b3dL12-L14): Reorganized import statements to improve readability and maintainability. 
* [`internal/controller/utils_test.go`](diffhunk://#diff-429334b066a97ed558217b47f55a1fc71836df740243033b9a4a6ac1829b12e5L11-L14): Reorganized import statements to improve readability and maintainability. 
* [`internal/etcdutils/etcdutils.go`](diffhunk://#diff-68b5cbdb3348f0bfb792dd522ca8ca567beccd1caae2a1601beca8eea584f737R13-L16): Reorganized import statements to improve readability and maintainability.
* [`internal/etcdutils/etcdutils_test.go`](diffhunk://#diff-38a2ec67f42904ce131a30c72a9b68694a627b7b8c1cbd53824e3475e93c0540R10): Added a blank line for better separation of import groups.

### Code Quality and Maintenance:

* [`internal/controller/etcdcluster_controller.go`](diffhunk://#diff-7e023adf1c245d768f95e3f174cab882db08efd47023a9ce81e29a3a7767c12aR148): Added a `nolint` directive to temporarily disable static analysis for a specific block of code.

### Logging Format Fix:

* [`test/e2e/e2e_test.go`](diffhunk://#diff-d5d12b6ea07b0a78c9ad1987e1486c565ecf16839f77a93e91b09475cf6c0e99L96-R116): Fixed the logging format in multiple places to remove redundant `fmt.Sprintf` calls.

### Check:
I checked the command below locally
```
$ make lint
/workspaces/etcd-operator/bin/golangci-lint run
WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar. 
```