### PR TITLE
Update golang toolchain to 1.23.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23.4-bookworm@sha256:6f085f2a025fcd189fefd7dc51c98ad34fa40c749f73b5522aa53b27278e4ec1 AS builder
+FROM golang:1.23.5-bookworm@sha256:3149bc5043fa58cf127fd8db1fdd4e533b6aed5a40d663d4f4ae43d20386665f AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.etcd.io/etcd-operator
 
-toolchain go1.23.4
+toolchain go1.23.5
 
 go 1.23.0
 

--- a/tools/mod/go.mod
+++ b/tools/mod/go.mod
@@ -1,6 +1,6 @@
 module go.etcd.io/etcd-operator/tools/mod
 
-toolchain go1.23.4
+toolchain go1.23.5
 
 go 1.23.0
 


### PR DESCRIPTION
etcd-operator: update golang toolchain to 1.23.5

Subtask from Issue: https://github.com/etcd-io/etcd/issues/19210

1. Retrieve `golang:1.23.5-bookworm` digest from docker hub (use the list-manifest for make to work would work with multi-arch):
```
TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:library/golang:pull" | jq -r .token)
curl -s -I -H "Authorization: Bearer $TOKEN" -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" "https://registry.hub.docker.com/v2/library/golang/manifests/1.23.5-bookworm" | grep -i "Docker-Content-Digest"
```

2. Verify able to build and run unit-tests as -

```
make build
make docker-build
make test
```
