### PR TITLE
Move certificate interface into dedicated package to avoid cycle dependency

### DIFF
--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -1,0 +1,26 @@
+package certificate
+
+import (
+	"fmt"
+
+	certInterface "go.etcd.io/etcd-operator/pkg/certificate/interfaces"
+)
+
+type ProviderType string
+
+const (
+	Auto        ProviderType = "auto"
+	CertManager ProviderType = "cert-manager"
+	// add more ...
+)
+
+func NewProvider(pt ProviderType) (certInterface.Provider, error) {
+	switch pt {
+	case Auto:
+		return nil, nil // change me later
+	case CertManager:
+		return nil, nil // change me later
+	}
+
+	return nil, fmt.Errorf("unknown provider type: %s", pt)
+}

--- a/pkg/certificate/interfaces/interface.go
+++ b/pkg/certificate/interfaces/interface.go
@@ -2,29 +2,9 @@ package certificate
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"time"
 )
-
-type ProviderType string
-
-const (
-	Auto        ProviderType = "auto"
-	CertManager ProviderType = "cert-manager"
-	// add more ...
-)
-
-func NewProvider(pt ProviderType) (Provider, error) {
-	switch pt {
-	case Auto:
-		return nil, nil // change me later
-	case CertManager:
-		return nil, nil // change me later
-	}
-
-	return nil, fmt.Errorf("unknown provider type: %s", pt)
-}
 
 // AltNames contains the domain names and IP addresses that will be added
 // to the x509 certificate SubAltNames fields. The values will be passed


### PR DESCRIPTION
Each provider implementation (i.e. auto, cert-manager) needs to depend on the interface. The certificate framework depends on the interface, but it shouldn't depend on the each implementation based on the [Dependency Inversion Principle](https://en.wikipedia.org/wiki/Dependency_inversion_principle). 

Both the framework and each implementation shouldn't depend on each other, instead both of them should only depend on the interface(abstract). So move the interface into a dedicated package.


cc @ArkaSaha30 @hakman @jmhbnz @justinsb @neolit123