### PR TITLE
cleanup: refactor code with wait.ExponentialBackoffWithContext

### DIFF
--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -132,7 +132,7 @@ func TestWaitForStatefulSetReady(t *testing.T) {
 				},
 			},
 			expectedResult: false,
-			expectedError:  errors.New("StatefulSet default/test-sts did not become ready after 5 attempts"),
+			expectedError:  errors.New("StatefulSet default/test-sts did not become ready: timed out waiting for the condition"),
 		},
 		{
 			name:           "StatefulSet does not exist",


### PR DESCRIPTION
using `wait.ExponentialBackoffWithContext` to refactor `waitForStatefulSetReady` function.