### PR TITLE
Bump go to 1.24.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23.6-bookworm@sha256:441f59f8a2104b99320e1f5aaf59a81baabbc36c81f4e792d5715ef09dd29355 AS builder
+FROM golang:1.24.0-bookworm@sha256:6260304a09fb81a1983db97c9e6bfc1779ebce33d39581979a511b3c7991f076 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 
 ### Prerequisites
 
-- go version v1.23.0+
+- go version v1.24.0+
 - docker version 17.03+.
 - kubectl version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module go.etcd.io/etcd-operator
 
-toolchain go1.23.6
+toolchain go1.24.0
 
-go 1.23.0
+go 1.24
 
 require (
 	github.com/go-logr/logr v1.4.2

--- a/tools/mod/go.mod
+++ b/tools/mod/go.mod
@@ -1,17 +1,17 @@
 module go.etcd.io/etcd-operator/tools/mod
 
-toolchain go1.23.6
+toolchain go1.24.0
 
-go 1.23.0
+go 1.24
 
 require (
 	github.com/elastic/crd-ref-docs v0.1.0
 	github.com/golangci/golangci-lint v1.64.5
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20250106171007-7436275c4311 // @release-0.19
 	sigs.k8s.io/controller-tools v0.17.2
-	sigs.k8s.io/kustomize/kustomize/v5 v5.6.0
 	sigs.k8s.io/kind v0.27.0
-) 
+	sigs.k8s.io/kustomize/kustomize/v5 v5.6.0
+)
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.2.1 // indirect


### PR DESCRIPTION
Upgrades Go to 1.24.0.

Part of etcd-io/etcd#19417.