### PR TITLE
Remove make manifests from e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 # - PROMETHEUS_INSTALL_SKIP=true
 # - CERT_MANAGER_INSTALL_SKIP=true
 .PHONY: test-e2e
-test-e2e: manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
+test-e2e: generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
 	go test ./test/e2e/ -v
 
 .PHONY: lint

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -64,17 +64,9 @@ func TestMain(m *testing.M) {
 
 		// prepare the resources
 		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
-			// gen manifest files
-			log.Println("Generate manifests...")
-			cmd := exec.Command("make", "manifests")
-			if _, err := test_utils.Run(cmd); err != nil {
-				log.Printf("Failed to generate manifests: %s", err)
-				return ctx, err
-			}
-
 			// Build docker image
 			log.Println("Building docker image...")
-			cmd = exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", dockerImage))
+			cmd := exec.Command("make", "docker-build", fmt.Sprintf("IMG=%s", dockerImage))
 			if _, err := test_utils.Run(cmd); err != nil {
 				log.Printf("Failed to build docker image: %s", err)
 				return ctx, err

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -6,7 +6,7 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
--
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
Follow up from: https://github.com/etcd-io/etcd-operator/pull/72#discussion_r1957068496

And restore the Apache License header.