### PR TITLE
Update golangci-lint installation to use installation script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ $(KIND): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(LOCALBIN) $(GOLANGCI_LINT_VERSION)
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary


### PR DESCRIPTION
Installing via `go get`/`go install` is discouraged by the golangci-lint manual. Reference:
https://golangci-lint.run/welcome/install/#install-from-sources

We're not bound to the host Go version if we install using their preferred method. And in cases like Prow where updates to the base image take longer, this could slow down Go version upgrades.