### PR TITLE
chore: bump golang to 1.24.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24.0-bookworm@sha256:6260304a09fb81a1983db97c9e6bfc1779ebce33d39581979a511b3c7991f076 AS builder
+FROM golang:1.24.1-bookworm@sha256:d7d795d0a9f51b00d9c9bfd17388c2c626004a50c6ed7c581e095122507fe1ab AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 The official Kubernetes operator for etcd.
 
-
 ## Community, discussion, contribution, and support
 
 Learn how to engage with the Kubernetes community on the [community page](http://kubernetes.io/community/).
@@ -20,7 +19,7 @@ Participation in the Kubernetes community is governed by the [Kubernetes Code of
 
 ### Prerequisites
 
-- go version v1.24.0+
+- go version v1.24+
 - docker version 17.03+.
 - kubectl version v1.11.3+.
 - Access to a Kubernetes v1.11.3+ cluster.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.etcd.io/etcd-operator
 
-toolchain go1.24.0
+toolchain go1.24.1
 
 go 1.24
 

--- a/tools/mod/go.mod
+++ b/tools/mod/go.mod
@@ -1,6 +1,6 @@
 module go.etcd.io/etcd-operator/tools/mod
 
-toolchain go1.24.0
+toolchain go1.24.1
 
 go 1.24
 


### PR DESCRIPTION
Relates to https://github.com/etcd-io/etcd/issues/19524
fixes #91

/cc @ivanvc @ahrtr
