### PR TITLE
Include `pkg/` directory when building operator image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN go mod download
 COPY cmd/main.go cmd/main.go
 COPY api/ api/
 COPY internal/ internal/
+COPY pkg/ pkg/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command


### PR DESCRIPTION
This commit will include the `pkg/` directory which contains the certificate logic when building the operator image.