### PR TITLE
Defaults to ReadWriteOnce when it's empty or not provided

### DIFF
--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -246,7 +246,7 @@ func createOrPatchStatefulSet(ctx context.Context, logger logr.Logger, ec *ecv1a
 				{
 					ObjectMeta: pvcObjectMeta,
 					Spec: corev1.PersistentVolumeClaimSpec{
-						AccessModes: []corev1.PersistentVolumeAccessMode{ec.Spec.StorageSpec.AccessModes},
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 						Resources:   pvcResources,
 					},
 				},


### PR DESCRIPTION
When `ec.Spec.StorageSpec.AccessModes` is empty, or not configured at all, we should defaults to `corev1.ReadWriteOnce`. The current implementation is just to set an empty string.


Still we should add test for the storage.

cc @ivanvc @gdasson 