### PR TITLE
Add cluster size validation marker

### DIFF
--- a/api/v1alpha1/etcdcluster_types.go
+++ b/api/v1alpha1/etcdcluster_types.go
@@ -33,6 +33,7 @@ type EtcdClusterSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// Size is the expected size of the etcd cluster.
+	// +kubebuilder:validation:Minimum=0
 	Size int `json:"size"`
 	// Version is the expected version of the etcd container image.
 	Version string `json:"version"`

--- a/config/crd/bases/operator.etcd.io_etcdclusters.yaml
+++ b/config/crd/bases/operator.etcd.io_etcdclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: etcdclusters.operator.etcd.io
 spec:
   group: operator.etcd.io
@@ -48,6 +48,7 @@ spec:
                 type: array
               size:
                 description: Size is the expected size of the etcd cluster.
+                minimum: 0
                 type: integer
               storageSpec:
                 description: StorageSpec is the name of the StorageSpec to use for

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: controller
+  newTag: latest

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: controller
-  newTag: latest
+  newName: etcd-operator
+  newTag: v0.1

--- a/config/samples/operator_v1alpha1_etcdcluster.yaml
+++ b/config/samples/operator_v1alpha1_etcdcluster.yaml
@@ -6,4 +6,5 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: etcdcluster-sample
 spec:
-  # TODO(user): Add fields here
+  version: v3.5.20
+  size: 3

--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -83,8 +83,6 @@ func (r *EtcdClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, nil
 	}
 
-	// TODO: Implement finalizer logic here
-
 	logger.Info("Reconciling EtcdCluster", "spec", etcdCluster.Spec)
 
 	// Get the statefulsets which has the same name as the EtcdCluster resource


### PR DESCRIPTION
This PR adds:
* minimum cluster size of 0 members
* generate CRD
* add defaults to config/samples  manifest