### PR TITLE
Bump go toolchain to v1.24.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24.1-bookworm@sha256:fa1a01d362a7b9df68b021d59a124d28cae6d99ebd1a876e3557c4dd092f1b1d AS builder
+FROM golang:1.24.2-bookworm@sha256:5a45ca9d25ca01bba95a9ea0431c88739a516176f053061ae630914cd2c4d835 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.etcd.io/etcd-operator
 
-toolchain go1.24.1
+toolchain go1.24.2
 
 go 1.24
 

--- a/tools/mod/go.mod
+++ b/tools/mod/go.mod
@@ -1,6 +1,6 @@
 module go.etcd.io/etcd-operator/tools/mod
 
-toolchain go1.24.1
+toolchain go1.24.2
 
 go 1.24
 


### PR DESCRIPTION
Reference https://github.com/etcd-io/etcd/issues/19713