### PR TITLE
etcd-operator: minimum size cluster validation

### DIFF
--- a/api/v1alpha1/etcdcluster_types.go
+++ b/api/v1alpha1/etcdcluster_types.go
@@ -33,7 +33,7 @@ type EtcdClusterSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// Size is the expected size of the etcd cluster.
-	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Minimum=1
 	Size int `json:"size"`
 	// Version is the expected version of the etcd container image.
 	Version string `json:"version"`

--- a/config/crd/bases/operator.etcd.io_etcdclusters.yaml
+++ b/config/crd/bases/operator.etcd.io_etcdclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: etcdclusters.operator.etcd.io
 spec:
   group: operator.etcd.io
@@ -48,7 +48,7 @@ spec:
                 type: array
               size:
                 description: Size is the expected size of the etcd cluster.
-                minimum: 0
+                minimum: 1
                 type: integer
               storageSpec:
                 description: StorageSpec is the name of the StorageSpec to use for

--- a/config/samples/operator_v1alpha1_etcdcluster.yaml
+++ b/config/samples/operator_v1alpha1_etcdcluster.yaml
@@ -6,5 +6,5 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: etcdcluster-sample
 spec:
-  version: v3.5.20
+  version: v3.5.21
   size: 3

--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -78,11 +78,6 @@ func (r *EtcdClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
-	if etcdCluster.Spec.Size == 0 {
-		logger.Info("EtcdCluster size is 0..Skipping next steps")
-		return ctrl.Result{}, nil
-	}
-
 	logger.Info("Reconciling EtcdCluster", "spec", etcdCluster.Spec)
 
 	// Get the statefulsets which has the same name as the EtcdCluster resource

--- a/internal/controller/etcdcluster_controller_test.go
+++ b/internal/controller/etcdcluster_controller_test.go
@@ -19,11 +19,11 @@ package controller
 import (
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	operatorv1alpha1 "go.etcd.io/etcd-operator/api/v1alpha1"
 )
@@ -31,7 +31,11 @@ import (
 func TestControllerReconcile(t *testing.T) {
 	ctx := t.Context()
 
-	const resourceName = "test-etcd-cluster"
+	const (
+		resourceName       = "test-etcd-cluster"
+		expectedSize int32 = 1
+	)
+
 	typeNamespacedName := types.NamespacedName{
 		Name:      resourceName,
 		Namespace: "default",
@@ -47,6 +51,9 @@ func TestControllerReconcile(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      resourceName,
 				Namespace: "default",
+			},
+			Spec: operatorv1alpha1.EtcdClusterSpec{
+				Size: int(expectedSize),
 			},
 		}
 		if createErr := k8sClient.Create(ctx, resource); createErr != nil {
@@ -74,11 +81,21 @@ func TestControllerReconcile(t *testing.T) {
 		Scheme: k8sClient.Scheme(),
 	}
 
-	_, err = reconciler.Reconcile(ctx, reconcile.Request{
+	// Reconcile, as it is, returns err since StatefulSet status.ReadyReplicas cannot report its actual status.
+	// This is due to envtest limitation. Envtest does not include kubelet, making pods to never report its readiness .
+	_, _ = reconciler.Reconcile(ctx, reconcile.Request{
 		NamespacedName: typeNamespacedName,
 	})
+
+	// Verify Statefulset has been created with expected replica size
+	etcdClusterSts := &appsv1.StatefulSet{}
+	err = k8sClient.Get(ctx, typeNamespacedName, etcdClusterSts)
 	if err != nil {
-		t.Fatalf("Reconciliation failed: %v", err)
+		t.Fatalf("Failed to find corresponding Statefulset for %s: %v", resourceName, err)
+	}
+
+	if *etcdClusterSts.Spec.Replicas != expectedSize {
+		t.Fatalf("Unexpected StatefulSet Size: expected %d, got: %d", expectedSize, *etcdClusterSts.Spec.Replicas)
 	}
 
 	// TODO: Add more specific checks (e.g., verifying status conditions or created resources).


### PR DESCRIPTION
After discussions, it has been decided that a minimum cluster size is `1`. 

This PR sets the spec marker validation, as well as adjusts its tests to check whether the api server returns anything other than `errors.Invalid()`.

It also deprecates the code where controller logs and quits when cluster size is set to zero. This condition will never happen, as CEL validation will not allow the CR to be persisted.