### PR TITLE
Set logger for unit test

### DIFF
--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -25,8 +25,10 @@ import (
 	"testing"
 
 	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	operatorv1alpha1 "go.etcd.io/etcd-operator/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
@@ -64,6 +66,8 @@ func TestMain(m *testing.M) {
 	if cfg == nil {
 		logger.Fatalf("Test environment started with nil config")
 	}
+
+	ctrl.SetLogger(zap.New())
 
 	// Teardown after tests
 	defer func() {


### PR DESCRIPTION
see https://github.com/etcd-io/etcd-operator/pull/143#issuecomment-2890241826

see @ivanvc @jmhbnz @frederiko @abdurrehman107 

New output of the test:
```
=== RUN   TestControllerReconcile
    etcdcluster_controller_test.go:46: Checking for EtcdCluster resource
    etcdcluster_controller_test.go:49: Creating EtcdCluster resource
{"level":"info","ts":"2025-05-19T10:15:15+01:00","msg":"Reconciling EtcdCluster","spec":{"size":1,"version":""}}
{"level":"info","ts":"2025-05-19T10:15:15+01:00","msg":"Creating StatefulSet with 0 replica","expectedSize":1}
{"level":"info","ts":"2025-05-19T10:15:15+01:00","msg":"Now updating configmap","name":"test-etcd-cluster-state","namespace":"default"}
{"level":"info","ts":"2025-05-19T10:15:15+01:00","msg":"Now creating/updating statefulset","name":"test-etcd-cluster","namespace":"default","replicas":0}
{"level":"info","ts":"2025-05-19T10:15:15+01:00","msg":"Stateful set created/updated","name":"test-etcd-cluster","namespace":"default","replicas":0}
{"level":"info","ts":"2025-05-19T10:15:15+01:00","msg":"Now checking the readiness of statefulset","name":"test-etcd-cluster","namespace":"default"}
{"level":"info","ts":"2025-05-19T10:15:15+01:00","msg":"StatefulSet is ready","name":"test-etcd-cluster","namespace":"default"}
{"level":"info","ts":"2025-05-19T10:15:15+01:00","msg":"StatefulSet has 0 replicas. Trying to create a new cluster with 1 member"}
{"level":"info","ts":"2025-05-19T10:15:15+01:00","msg":"Now updating configmap","name":"test-etcd-cluster-state","namespace":"default"}
{"level":"info","ts":"2025-05-19T10:15:15+01:00","msg":"Now creating/updating statefulset","name":"test-etcd-cluster","namespace":"default","replicas":1}
{"level":"info","ts":"2025-05-19T10:15:15+01:00","msg":"Stateful set created/updated","name":"test-etcd-cluster","namespace":"default","replicas":1}
{"level":"info","ts":"2025-05-19T10:15:15+01:00","msg":"Now checking the readiness of statefulset","name":"test-etcd-cluster","namespace":"default"}
{"level":"info","ts":"2025-05-19T10:15:15+01:00","msg":"StatefulSet is not ready","ReadyReplicas":"0","DesiredReplicas":"1"}
{"level":"info","ts":"2025-05-19T10:15:18+01:00","msg":"StatefulSet is not ready","ReadyReplicas":"0","DesiredReplicas":"1"}
{"level":"info","ts":"2025-05-19T10:15:24+01:00","msg":"StatefulSet is not ready","ReadyReplicas":"0","DesiredReplicas":"1"}
{"level":"info","ts":"2025-05-19T10:15:36+01:00","msg":"StatefulSet is not ready","ReadyReplicas":"0","DesiredReplicas":"1"}
{"level":"info","ts":"2025-05-19T10:16:00+01:00","msg":"StatefulSet is not ready","ReadyReplicas":"0","DesiredReplicas":"1"}
    etcdcluster_controller_test.go:68: Cleaning up the EtcdCluster resource
--- PASS: TestControllerReconcile (47.08s)

```