### PR TITLE
Update "ValidateCertificateSecret" interface signature

### DIFF
--- a/pkg/certificate/interfaces/interface.go
+++ b/pkg/certificate/interfaces/interface.go
@@ -52,9 +52,9 @@ type Provider interface {
 	// - cfg: Configuration to validate against.
 	//
 	// Returns:
-	// - true if the Secret is valid, false otherwise, along with
+	// - nil if the Secret is valid, otherwise returns
 	//   an error if validation fails.
-	ValidateCertificateSecret(ctx context.Context, secretName string, namespace string, cfg *Config) (bool, error)
+	ValidateCertificateSecret(ctx context.Context, secretName string, namespace string, cfg *Config) error
 
 	// DeleteCertificateSecret explicitly deletes the Secret containing
 	// the certificate. This should only be used if the certificate


### PR DESCRIPTION
This PR will update the `ValidateCertificateSecret` interface signature to return only error instead of (bool, error), which will suggest if the validation is successful or not.

cc @ahrtr @ivanvc