### PR TITLE
test(e2e): add scaling & KV functionality tests; extract shared helpers

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -125,3 +125,263 @@ func TestClusterHealthy(t *testing.T) {
 	// 'testEnv' is the env.Environment you set up in TestMain
 	_ = testEnv.Test(t, feature.Feature())
 }
+
+func TestScaling(t *testing.T) {
+	testCases := []struct {
+		name            string
+		initialSize     int
+		scaleTo         int
+		expectedMembers int
+	}{
+		{name: "ScaleInFrom3To1", initialSize: 3, scaleTo: 1, expectedMembers: 1},
+		{name: "ScaleOutFrom1To3", initialSize: 1, scaleTo: 3, expectedMembers: 3},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			feature := features.New(tc.name)
+			etcdClusterName := fmt.Sprintf("etcd-%s", strings.ToLower(tc.name))
+
+			feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+				createEtcdClusterWithPVC(ctx, t, c, etcdClusterName, tc.initialSize)
+				waitForSTSReadiness(t, c, etcdClusterName, tc.initialSize)
+				return ctx
+			})
+
+			feature.Assess(
+				fmt.Sprintf("scale to %d", tc.scaleTo),
+				func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+					scaleEtcdCluster(ctx, t, c, etcdClusterName, tc.scaleTo)
+					// Wait until StatefulSet spec/status reflect the scaled size and are ready
+					waitForSTSReadiness(t, c, etcdClusterName, tc.scaleTo)
+					return ctx
+				},
+			)
+
+			feature.Assess("verify member list", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+				podName := fmt.Sprintf("%s-0", etcdClusterName)
+				ml := getEtcdMemberListPB(t, c, podName)
+
+				if len(ml.Members) != tc.expectedMembers {
+					t.Errorf("Expected to find %d members in member list, but got %d",
+						tc.expectedMembers, len(ml.Members))
+				}
+
+				// Verify controller promoted all learners to voting members
+				for _, m := range ml.Members {
+					if m.IsLearner {
+						t.Errorf("Found unpromoted learner after scaling completed: member %s (%d)", m.Name, m.ID)
+					}
+				}
+				return ctx
+			})
+
+			feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+				cleanupEtcdCluster(ctx, t, c, etcdClusterName)
+				return ctx
+			})
+
+			_ = testEnv.Test(t, feature.Feature())
+		})
+	}
+}
+
+func TestPodRecovery(t *testing.T) {
+	feature := features.New("multi-node-pod-recovery")
+	etcdClusterName := "etcd-recovery-test"
+
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		createEtcdClusterWithPVC(ctx, t, c, etcdClusterName, 3)
+		waitForSTSReadiness(t, c, etcdClusterName, 3)
+		return ctx
+	})
+
+	feature.Assess("verify multi-node cluster recovery after pod deletion",
+		func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+			var sts appsv1.StatefulSet
+			if err := c.Client().Resources().Get(ctx, etcdClusterName, namespace, &sts); err != nil {
+				t.Fatalf("Failed to get StatefulSet: %v", err)
+			}
+
+			initialReplicas := *sts.Spec.Replicas
+			podName := fmt.Sprintf("%s-0", etcdClusterName)
+			targetPodName := fmt.Sprintf("%s-1", etcdClusterName)
+
+			// Verify PVC usage before test
+			verifyPodUsesPVC(t, c, targetPodName, "etcd-data-"+etcdClusterName)
+
+			// Get initial member IDs for consistency verification
+			initialMembers := getEtcdMembersName2IDMapping(t, c, podName)
+			initialMemberCount := len(initialMembers)
+
+			// Delete one pod to simulate failure
+			var pod corev1.Pod
+			if err := c.Client().Resources().Get(ctx, targetPodName, namespace, &pod); err != nil {
+				t.Fatalf("Failed to get pod: %v", err)
+			}
+
+			deletedPodUID := pod.UID
+			if err := c.Client().Resources().Delete(ctx, &pod); err != nil {
+				t.Fatalf("Failed to delete pod: %v", err)
+			}
+
+			// Wait for pod recreation
+			if err := wait.For(func(ctx context.Context) (done bool, err error) {
+				var newPod corev1.Pod
+				if err := c.Client().Resources().Get(ctx, targetPodName, namespace, &newPod); err != nil {
+					return false, nil
+				}
+				return newPod.UID != deletedPodUID && newPod.Status.Phase == corev1.PodRunning, nil
+			}, wait.WithTimeout(3*time.Minute), wait.WithInterval(10*time.Second)); err != nil {
+				t.Fatalf("Pod failed to be recreated: %v", err)
+			}
+
+			// Wait for full StatefulSet readiness
+			waitForSTSReadiness(t, c, etcdClusterName, int(initialReplicas))
+
+			// Verify PVC usage after recovery
+			verifyPodUsesPVC(t, c, targetPodName, "etcd-data-"+etcdClusterName)
+
+			// Verify member ID consistency
+			finalMembers := getEtcdMembersName2IDMapping(t, c, podName)
+			if len(finalMembers) != initialMemberCount {
+				t.Errorf("Member count changed after recovery: expected %d, got %d", initialMemberCount, len(finalMembers))
+			}
+
+			// Verify the recovered pod maintains the same member ID
+			if targetMemberID, exists := initialMembers[targetPodName]; exists {
+				if finalMemberID, exists := finalMembers[targetPodName]; exists {
+					if targetMemberID != finalMemberID {
+						t.Errorf("Member ID changed for %s: expected %d, got %d", targetPodName, targetMemberID, finalMemberID)
+					}
+				} else {
+					t.Errorf("Member %s not found after recovery", targetPodName)
+				}
+			}
+
+			// Verify cluster replication works across recovered pod
+			_, stderr, err := execInPod(t, c, podName, namespace, []string{"etcdctl", "put", "replication-test", "value"})
+			if err != nil {
+				t.Fatalf("Failed to write data after recovery: %v, stderr: %s", err, stderr)
+			}
+
+			stdout, stderr, err := execInPod(t, c, targetPodName, namespace, []string{"etcdctl", "get", "replication-test"})
+			if err != nil {
+				t.Fatalf("Failed to read data from recovered pod: %v, stderr: %s", err, stderr)
+			}
+
+			if !strings.Contains(stdout, "value") {
+				t.Errorf("Data replication to recovered pod failed. Expected 'value', got: %s", stdout)
+			}
+
+			return ctx
+		})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		cleanupEtcdCluster(ctx, t, c, etcdClusterName)
+		return ctx
+	})
+
+	_ = testEnv.Test(t, feature.Feature())
+}
+
+func TestEtcdClusterFunctionality(t *testing.T) {
+	feature := features.New("etcd-cluster-functionality")
+	etcdClusterName := "etcd-functionality-test"
+	testKey := "test-key"
+	testValue := "test-value"
+
+	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		createEtcdClusterWithPVC(ctx, t, c, etcdClusterName, 3)
+		waitForSTSReadiness(t, c, etcdClusterName, 3)
+		return ctx
+	})
+
+	feature.Assess("verify cluster health", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		podName := fmt.Sprintf("%s-0", etcdClusterName)
+
+		// Wait until all members are promoted to voting members (no learners),
+		// otherwise endpoint health will fail on learners.
+		waitForNoLearners(t, c, podName, 3)
+
+		// Check health for the whole cluster rather than a single member
+		command := []string{"etcdctl", "endpoint", "health", "--cluster"}
+		stdout, stderr, err := execInPod(t, c, podName, namespace, command)
+		if err != nil {
+			t.Fatalf("Failed to check endpoint health: %v, stderr: %s", err, stderr)
+		}
+
+		// Determine expected members dynamically from member list
+		ml := getEtcdMemberListPB(t, c, podName)
+		expected := len(ml.Members)
+
+		// Count healthy lines; expect all members are healthy
+		healthy := 0
+		for _, line := range strings.Split(strings.TrimSpace(stdout), "\n") {
+			if strings.Contains(line, "is healthy") {
+				healthy++
+			}
+		}
+		if healthy != expected {
+			t.Errorf("Expected %d healthy endpoints, but got %d. Output: %s", expected, healthy, stdout)
+		}
+		return ctx
+	})
+
+	feature.Assess("test data operations", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		podName := fmt.Sprintf("%s-0", etcdClusterName)
+
+		// Write key-value data
+		command := []string{"etcdctl", "put", testKey, testValue}
+		_, stderr, err := execInPod(t, c, podName, namespace, command)
+		if err != nil {
+			t.Fatalf("Failed to write data: %v, stderr: %s", err, stderr)
+		}
+
+		// Read key-value data
+		command = []string{"etcdctl", "get", testKey}
+		stdout, stderr, err := execInPod(t, c, podName, namespace, command)
+		if err != nil {
+			t.Fatalf("Failed to read data: %v, stderr: %s", err, stderr)
+		}
+
+		lines := strings.Split(strings.TrimSpace(stdout), "\n")
+		if len(lines) < 2 || lines[0] != testKey || lines[1] != testValue {
+			t.Errorf("Expected key-value pair [%s=%s], but got output: %s", testKey, testValue, stdout)
+		}
+		return ctx
+	})
+
+	feature.Assess("verify data consistency with hashkv",
+		func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+			// Use --cluster to fetch hashkv from all members in one call
+			podName := fmt.Sprintf("%s-0", etcdClusterName)
+			responses := getClusterEndpointHashKVs(t, c, podName)
+			if len(responses) != 3 {
+				t.Errorf("Expected 3 hashkv responses, got %d", len(responses))
+			}
+
+			hashes := make(map[uint32]struct{})
+			for _, r := range responses {
+				hashes[r.Hash] = struct{}{}
+			}
+			if len(hashes) != 1 {
+				t.Errorf("Expected identical hashkv across all members, but got %d distinct hashes", len(hashes))
+			}
+
+			// Clean up - delete the key
+			command := []string{"etcdctl", "del", testKey}
+			_, stderr, err := execInPod(t, c, podName, namespace, command)
+			if err != nil {
+				t.Fatalf("Failed to delete data: %v, stderr: %s", err, stderr)
+			}
+			return ctx
+		})
+
+	feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+		cleanupEtcdCluster(ctx, t, c, etcdClusterName)
+		return ctx
+	})
+
+	_ = testEnv.Test(t, feature.Feature())
+}

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+
+	ecv1alpha1 "go.etcd.io/etcd-operator/api/v1alpha1"
+	etcdserverpb "go.etcd.io/etcd/api/v3/etcdserverpb"
+)
+
+// getAvailableStorageClass returns an available StorageClass name
+func getAvailableStorageClass(ctx context.Context, t *testing.T, c *envconf.Config) string {
+	t.Helper()
+
+	// First check environment variable
+	if storageClass := os.Getenv("ETCD_E2E_STORAGECLASS"); storageClass != "" {
+		return storageClass
+	}
+
+	// Try to find default StorageClass
+	var storageClasses storagev1.StorageClassList
+	if err := c.Client().Resources().List(ctx, &storageClasses); err != nil {
+		t.Skip("Cannot list StorageClasses, skipping PVC test")
+	}
+
+	// Look for default StorageClass
+	for _, sc := range storageClasses.Items {
+		if sc.Annotations["storageclass.kubernetes.io/is-default-class"] == "true" {
+			return sc.Name
+		}
+	}
+
+	// Fallback to common StorageClass names
+	commonNames := []string{"standard", "gp2", "default"}
+	for _, name := range commonNames {
+		for _, sc := range storageClasses.Items {
+			if sc.Name == name {
+				return name
+			}
+		}
+	}
+
+	t.Skip("No suitable StorageClass found for PVC test")
+	return ""
+}
+
+// createEtcdClusterWithPVC creates an EtcdCluster with persistent storage
+func createEtcdClusterWithPVC(ctx context.Context, t *testing.T, c *envconf.Config, name string, size int) {
+	t.Helper()
+	storageClassName := getAvailableStorageClass(ctx, t, c)
+
+	etcdCluster := &ecv1alpha1.EtcdCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: ecv1alpha1.EtcdClusterSpec{
+			Size:    size,
+			Version: etcdVersion,
+			StorageSpec: &ecv1alpha1.StorageSpec{
+				AccessModes:       corev1.ReadWriteOnce,
+				StorageClassName:  storageClassName,
+				VolumeSizeRequest: resource.MustParse("64Mi"),
+				VolumeSizeLimit:   resource.MustParse("64Mi"),
+			},
+		},
+	}
+	if err := c.Client().Resources().Create(ctx, etcdCluster); err != nil {
+		t.Fatalf("Failed to create EtcdCluster with PVC: %v", err)
+	}
+}
+
+func waitForSTSReadiness(t *testing.T, c *envconf.Config, name string, expectedReplicas int) {
+	t.Helper()
+	var sts appsv1.StatefulSet
+	err := wait.For(func(ctx context.Context) (done bool, err error) {
+		if err := c.Client().Resources().Get(ctx, name, namespace, &sts); err != nil {
+			return false, err
+		}
+
+		// Ensure spec has been updated by the controller to the expected replica count
+		if sts.Spec.Replicas == nil || *sts.Spec.Replicas != int32(expectedReplicas) {
+			return false, nil
+		}
+
+		// Ensure status reflects latest generation
+		if sts.Status.ObservedGeneration < sts.Generation {
+			return false, nil
+		}
+
+		// Ensure the controller created the expected number of replicas and they are ready
+		if sts.Status.Replicas != int32(expectedReplicas) {
+			return false, nil
+		}
+		if sts.Status.ReadyReplicas != int32(expectedReplicas) {
+			return false, nil
+		}
+		return true, nil
+	}, wait.WithTimeout(5*time.Minute), wait.WithInterval(10*time.Second))
+	if err != nil {
+		t.Fatalf("StatefulSet %s failed to reach spec/status readiness for %d replicas: %v", name, expectedReplicas, err)
+	}
+}
+
+func execInPod(
+	t *testing.T, cfg *envconf.Config, podName string, namespace string, command []string,
+) (string, string, error) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	client := cfg.Client()
+
+	// Find the pod
+	var pod corev1.Pod
+	if err := client.Resources().Get(t.Context(), podName, namespace, &pod); err != nil {
+		return "", "", fmt.Errorf("failed to get pod %s/%s: %w", namespace, podName, err)
+	}
+
+	// Find the container
+	if len(pod.Spec.Containers) == 0 {
+		return "", "", fmt.Errorf("no containers in pod %s/%s", namespace, podName)
+	}
+	containerName := pod.Spec.Containers[0].Name
+
+	// Exec command
+	err := client.Resources().ExecInPod(t.Context(), namespace, podName, containerName, command, &stdout, &stderr)
+	return stdout.String(), stderr.String(), err
+}
+
+func scaleEtcdCluster(ctx context.Context, t *testing.T, c *envconf.Config, name string, size int) {
+	t.Helper()
+	var etcdCluster ecv1alpha1.EtcdCluster
+	if err := c.Client().Resources().Get(ctx, name, namespace, &etcdCluster); err != nil {
+		t.Fatalf("Failed to get EtcdCluster: %v", err)
+	}
+
+	etcdCluster.Spec.Size = size
+	if err := c.Client().Resources().Update(ctx, &etcdCluster); err != nil {
+		t.Fatalf("Failed to update EtcdCluster: %v", err)
+	}
+}
+
+func cleanupEtcdCluster(ctx context.Context, t *testing.T, c *envconf.Config, name string) {
+	t.Helper()
+	var etcdCluster ecv1alpha1.EtcdCluster
+	if err := c.Client().Resources().Get(ctx, name, namespace, &etcdCluster); err == nil {
+		if err := c.Client().Resources().Delete(ctx, &etcdCluster); err != nil {
+			t.Logf("Failed to delete EtcdCluster: %v", err)
+		}
+	}
+}
+
+// getEtcdMembersName2IDMapping retrieves the etcd cluster member list as name->ID mapping using etcd's native types
+func getEtcdMembersName2IDMapping(t *testing.T, c *envconf.Config, podName string) map[string]uint64 {
+	t.Helper()
+	memberList := getEtcdMemberListPB(t, c, podName)
+
+	// Create name->ID mapping
+	memberMap := make(map[string]uint64)
+	for _, member := range memberList.Members {
+		memberMap[member.Name] = member.ID
+	}
+	return memberMap
+}
+
+// getEtcdMemberListPB returns the etcdserverpb.MemberListResponse by calling etcdctl -w json.
+func getEtcdMemberListPB(t *testing.T, c *envconf.Config, podName string) *etcdserverpb.MemberListResponse {
+	t.Helper()
+	stdout, stderr, err := execInPod(t, c, podName, namespace, []string{"etcdctl", "member", "list", "-w", "json"})
+	if err != nil {
+		t.Fatalf("Failed to get etcd member list: %v, stderr: %s", err, stderr)
+	}
+	var memberList etcdserverpb.MemberListResponse
+	if err := json.Unmarshal([]byte(stdout), &memberList); err != nil {
+		t.Fatalf("Failed to parse etcd member list JSON: %v", err)
+	}
+	return &memberList
+}
+
+// waitForNoLearners waits until the member list has the expected number of members
+// and all members are voting (i.e., no learners remain).
+func waitForNoLearners(t *testing.T, c *envconf.Config, podName string, expectedMembers int) {
+	t.Helper()
+	err := wait.For(func(ctx context.Context) (bool, error) {
+		ml := getEtcdMemberListPB(t, c, podName)
+		if len(ml.Members) != expectedMembers {
+			return false, nil
+		}
+		for _, m := range ml.Members {
+			if m.IsLearner {
+				return false, nil
+			}
+		}
+		return true, nil
+	}, wait.WithTimeout(3*time.Minute), wait.WithInterval(5*time.Second))
+	if err != nil {
+		t.Fatalf("Timeout waiting for %d voting members with no learners: %v", expectedMembers, err)
+	}
+}
+
+// verifyPodUsesPVC checks that a pod is using PVC for persistent storage
+func verifyPodUsesPVC(t *testing.T, c *envconf.Config, podName string, expectedPVCPrefix string) {
+	t.Helper()
+	var pod corev1.Pod
+	if err := c.Client().Resources().Get(t.Context(), podName, namespace, &pod); err != nil {
+		t.Fatalf("Failed to get pod %s: %v", podName, err)
+	}
+
+	// Check for PVC volumes
+	for _, volume := range pod.Spec.Volumes {
+		if volume.PersistentVolumeClaim != nil {
+			if strings.HasPrefix(volume.PersistentVolumeClaim.ClaimName, expectedPVCPrefix) {
+				return
+			}
+		}
+	}
+
+	t.Errorf("Pod %s does not use expected PVC with prefix %s", podName, expectedPVCPrefix)
+}
+
+// getClusterEndpointHashKVs executes `etcdctl endpoint hashkv --cluster -w json` inside the given pod
+// and returns the parsed HashKV responses from all known endpoints using etcd's native types.
+func getClusterEndpointHashKVs(t *testing.T, c *envconf.Config, podName string) []etcdserverpb.HashKVResponse {
+	t.Helper()
+	cmd := []string{"etcdctl", "endpoint", "hashkv", "--cluster", "-w", "json"}
+	stdout, stderr, err := execInPod(t, c, podName, namespace, cmd)
+	if err != nil {
+		t.Fatalf("Failed to get cluster endpoint hashkv from %s: %v, stderr: %s", podName, err, stderr)
+	}
+
+	// Expected JSON: array of objects like {"Endpoint":"...","HashKV":{...}}
+	var entries []struct {
+		Endpoint string                      `json:"Endpoint"`
+		HashKV   etcdserverpb.HashKVResponse `json:"HashKV"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &entries); err != nil {
+		t.Fatalf("Failed to parse endpoint hashkv JSON: %v. Raw: %s", err, stdout)
+	}
+	out := make([]etcdserverpb.HashKVResponse, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.HashKV)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

This PR **extends the E2E suite under `test/e2e/`** with realistic cluster-lifecycle scenarios, **PVC-backed clusters**, and shared helpers to reduce duplication and flakiness. It adds **scaling**, **pod recovery with persistent storage**, and **KV/replication** checks using `etcdctl` **from inside cluster pods**.
**No controller or production code changes** are included.

## What’s in this PR

* **`test/e2e/e2e_test.go`**

  * Keeps existing `TestInvalidClusterSize`, `TestClusterHealthy`.
  * **New:** `TestScaling` (table-driven: `ScaleInFrom3To1`, `ScaleOutFrom1To3`)

    * Verifies the controller updates **StatefulSet replicas**.
    * Checks etcd **member list** count and ensures **no learners** remain after scaling.
  * **New:** `TestPodRecovery`

    * Starts a **3-node PVC-backed** cluster, deletes one pod, waits for recreation, and **verifies it reuses the PVC**.
    * Asserts **member ID consistency** before/after recovery (no unintended re-adds).
    * Validates **replication** by `put` on one member and `get` from the recovered member.
  * **Updated:** `TestEtcdClusterFunctionality`

    * Runs on a **PVC-backed 3-node** cluster.
    * Validates endpoint health; `put/get/del`; cross-member read for **replication**; and ensures **no learners** in a healthy cluster.

* **`test/e2e/helpers_test.go`** (new)

  * **Cluster + storage**

    * `createEtcdClusterWithPVC` — creates an `EtcdCluster` with `StorageSpec` (64Mi) and PVC.
    * `getAvailableStorageClass` — resolves StorageClass via **`ETCD_E2E_STORAGECLASS` env** or default SC; **skips** if none suitable.
  * **Lifecycle / waiting**

    * `waitForSTSReadiness` — waits for **StatefulSet `ReadyReplicas`** using e2e-framework `wait` (tuned timeouts/intervals).
    * `scaleEtcdCluster` — patches `spec.size` and waits for STS readiness.
    * `cleanupEtcdCluster` — best-effort deletion.
  * **Introspection**

    * `execInPod` — runs `etcdctl` inside pods and returns stdout/stderr.
    * `getEtcdMembers` — parses `etcdctl member list -w json` into typed structs to build **name → memberID** map (more robust than string parsing).
    * `verifyPodUsesPVC` — asserts a pod mounts the expected PVC (by prefix).
  * **Types:** `EtcdMember`, `EtcdMemberList`.

## Motivation

* Address prior review feedback to **split the large refactor** into focused pieces.
* Add coverage for scenarios that require a real cluster (DNS/networking/storage) and are not reliable at unit-test level:

  * **Scaling:** keeps `spec.size`, **StatefulSet replicas**, and etcd **member list** in sync; ensures learners are promoted.
  * **Persistence & recovery:** validates **PVC reuse** and **member ID stability** across pod recreation.
  * **Data-path checks:** `etcdctl` health + KV + cross-member reads to prove **replication**.

## How it validates behavior

* Executes `etcdctl` **inside pods** (`execInPod`) to observe **internal cluster state** (health, member list, KV).
* Uses **JSON parsing** for membership (`getEtcdMembers`) to avoid brittle string checks.
* `waitForSTSReadiness` and targeted `wait.For` loops reduce flakes by waiting for **ReadyReplicas** and **pod recreation**.
* Storage-aware helpers ensure tests run with **PVC-backed** clusters and **skip gracefully** when no StorageClass is available.

## Prior work
Huge thanks to **#51** by @abdurrehman107! It inspired the feature-based layout with sigs.k8s.io/e2e-framework, the **Setup - Assess - Teardown** flow and the use of wait.For + conditions.ResourceScaled for readiness. Appreciate the groundwork!

## Notes for reviewers

* If your cluster has no default StorageClass, it's best to **`ETCD_E2E_STORAGECLASS=<your-sc>`** before running E2E.
* Timeouts are conservative (**5m** for STS readiness; **3m** for pod recreation) to minimize flakes; happy to tune based on CI signal.
