### PR TITLE
Set `GOTOOLCHAIN` environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,18 @@ ENVTEST_K8S_VERSION = 1.31.0
 # The version of ETCD to run e2e tests against
 E2E_ETCD_VERSION ?= $(shell go list -m -f {{.Version}} go.etcd.io/etcd/api/v3)
 
+# Adapted from k/k, simplified to use the go.mod and the Makefile:
+# https://github.com/kubernetes/kubernetes/blob/17854f0e0a153b06f9d0db096e2cd8ab2fa89c11/hack/lib/golang.sh#L510-L520
+# Set the GOTOOLCHAIN to force the toolchain defined in go.mod
+GOTOOLCHAIN ?= auto
+ifeq (auto,$(GOTOOLCHAIN)) # User didn't specify the GOTOOLCHAIN, or is set to auto.
+ifeq (,$(FORCE_HOST_GO)) # User didn't provide FORCE_HOST_GO, use go.mod's toolchain
+	export GOTOOLCHAIN=$(shell grep '^toolchain go' go.mod | cut -d' ' -f2)
+else # User provided FORCE_HOST_GO, use the local version
+	export GOTOOLCHAIN=local
+endif
+endif
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin


### PR DESCRIPTION
Implements a minimal version of setting the `GOTOOLCHAIN` environment similar to what we have in etcd: https://github.com/etcd-io/etcd/commit/e094139b05244c5eab0e62172f92ac5e90feb73b.

Part of https://github.com/etcd-io/etcd/issues/20576.

Unblocks #196.