### PR TITLE
Refactor e2e test to reuse verifyDataOperations

### DIFF
--- a/test/e2e/cert_manager_test.go
+++ b/test/e2e/cert_manager_test.go
@@ -251,7 +251,7 @@ func TestClusterCertCreation(t *testing.T) {
 	feature.Assess("Verify Data Operations",
 		func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 			// verify etcdCluster is accessible via client certificate with put and get
-			verifyDataOperations(t, c, etcdClusterName)
+			verifyDataOperations(t, c, etcdClusterName, "test-key", "test-value")
 			return ctx
 		},
 	)

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 
 	ecv1alpha1 "go.etcd.io/etcd-operator/api/v1alpha1"
-	etcdserverpb "go.etcd.io/etcd/api/v3/etcdserverpb"
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
 )
 
 // getAvailableStorageClass returns an available StorageClass name
@@ -272,9 +272,7 @@ func getClusterEndpointHashKVs(t *testing.T, c *envconf.Config, podName string) 
 	return out
 }
 
-func verifyDataOperations(t *testing.T, c *envconf.Config, etcdClusterName string) {
-	testKey := "test-key"
-	testValue := "test-value"
+func verifyDataOperations(t *testing.T, c *envconf.Config, etcdClusterName, testKey, testValue string) {
 	podName := fmt.Sprintf("%s-0", etcdClusterName)
 
 	// Write key-value data


### PR DESCRIPTION
This PR will refactor e2e test data operations to reuse the common helper function `verifyDataOperations`

Fixes: https://github.com/etcd-io/etcd-operator/pull/173#discussion_r2366264432