### PR TITLE
Fix cert-manager scheme registration

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -49,6 +49,10 @@ func init() {
 
 	utilruntime.Must(operatorv1alpha1.AddToScheme(scheme))
 
+	// Register cert-manager scheme to enable CRD detection and optional watches
+	// Note: cert-manager CRDs don't need to be installed if only using auto provider.
+	// The controller will detect at startup whether cert-manager CRDs exist and
+	// conditionally enable Certificate watches only if they are present.
 	utilruntime.Must(certv1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }

--- a/test/e2e/auto_provider_test.go
+++ b/test/e2e/auto_provider_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsV1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -45,7 +44,6 @@ func TestAutoProvider(t *testing.T) {
 			client := cfg.Client()
 			_ = appsv1.AddToScheme(client.Resources().GetScheme())
 			_ = corev1.AddToScheme(client.Resources().GetScheme())
-			_ = certv1.AddToScheme(client.Resources().GetScheme())
 			_ = apiextensionsV1.AddToScheme(client.Resources().GetScheme())
 
 			return ctx
@@ -157,7 +155,6 @@ func TestClusterAutoCertCreation(t *testing.T) {
 		client := cfg.Client()
 		_ = appsv1.AddToScheme(client.Resources().GetScheme())
 		_ = corev1.AddToScheme(client.Resources().GetScheme())
-		_ = certv1.AddToScheme(client.Resources().GetScheme())
 		_ = apiextensionsV1.AddToScheme(client.Resources().GetScheme())
 
 		// create etcd cluster

--- a/test/e2e/cert_manager_test.go
+++ b/test/e2e/cert_manager_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"log"
 	"reflect"
 	"testing"
 	"time"
@@ -23,6 +24,7 @@ import (
 	ecv1alpha1 "go.etcd.io/etcd-operator/api/v1alpha1"
 	"go.etcd.io/etcd-operator/pkg/certificate/cert_manager"
 	interfaces "go.etcd.io/etcd-operator/pkg/certificate/interfaces"
+	test_utils "go.etcd.io/etcd-operator/test/utils"
 )
 
 const (
@@ -61,6 +63,11 @@ func TestCertManagerProvider(t *testing.T) {
 
 	feature.Setup(
 		func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			log.Println("Installing cert-manager...")
+			if err := test_utils.InstallCertManager(); err != nil {
+				log.Printf("Unable to install Cert Manager: %s", err)
+			}
+
 			client := cfg.Client()
 			_ = appsv1.AddToScheme(client.Resources().GetScheme())
 			_ = corev1.AddToScheme(client.Resources().GetScheme())
@@ -185,6 +192,11 @@ func TestClusterCertCreation(t *testing.T) {
 	}
 
 	feature.Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		log.Println("Installing cert-manager...")
+		if err := test_utils.InstallCertManager(); err != nil {
+			log.Printf("Unable to install Cert Manager: %s", err)
+		}
+
 		client := cfg.Client()
 		_ = appsv1.AddToScheme(client.Resources().GetScheme())
 		_ = corev1.AddToScheme(client.Resources().GetScheme())

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -88,16 +88,11 @@ func TestMain(m *testing.M) {
 			return ctx, nil
 		},
 
-		// install prometheus and cert-manager
+		// install prometheus
 		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
 			log.Println("Installing prometheus operator...")
 			if err := test_utils.InstallPrometheusOperator(); err != nil {
 				log.Printf("Unable to install Prometheus operator: %s", err)
-			}
-
-			log.Println("Installing cert-manager...")
-			if err := test_utils.InstallCertManager(); err != nil {
-				log.Printf("Unable to install Cert Manager: %s", err)
 			}
 
 			return ctx, nil


### PR DESCRIPTION
This PR will:
- fix default always install cert-manager in e2e test to install when cert-manager specific test is called optionally.
- fix default scheme registration of cert-manager

Fixes: https://github.com/etcd-io/etcd-operator/issues/232