### PR TITLE
dependency: Bump to Go version 1.25.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25.3-bookworm@sha256:ee420c17fa013f71eca6b35c3547b854c838d4f26056a34eb6171bba5bf8ece4 AS builder
+FROM golang:1.25.4-bookworm@sha256:7419f544ffe9be4d7cbb5d2d2cef5bd6a77ec81996ae2ba15027656729445cc4 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module go.etcd.io/etcd-operator
 
 go 1.25.0
 
-toolchain go1.25.3
+toolchain go1.25.4
 
 require (
 	github.com/cert-manager/cert-manager v1.19.1

--- a/tools/mod/go.mod
+++ b/tools/mod/go.mod
@@ -2,7 +2,7 @@ module go.etcd.io/etcd-operator/tools/mod
 
 go 1.25
 
-toolchain go1.25.3
+toolchain go1.25.4
 
 require (
 	github.com/elastic/crd-ref-docs v0.2.0


### PR DESCRIPTION
Contributes to https://github.com/etcd-io/etcd/issues/20891