### PR TITLE
Change imagePullPolicy to IfNotPresent

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -64,6 +64,7 @@ spec:
           - --leader-elect
           - --health-probe-bind-address=:8081
         image: controller:latest
+        imagePullPolicy: IfNotPresent
         name: manager
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
By default, kubernetes sets the imagePullPolicy to Always.  I think we don't always need to pull every time.  For development, it should help with removing the need for an external image registry.