### PR TITLE
Setup gofail for e2e tests

### DIFF
--- a/tools/mod/go.mod
+++ b/tools/mod/go.mod
@@ -7,6 +7,7 @@ toolchain go1.25.5
 require (
 	github.com/elastic/crd-ref-docs v0.2.0
 	github.com/golangci/golangci-lint/v2 v2.7.2
+	go.etcd.io/gofail v0.2.0
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20250106171007-7436275c4311 // @release-0.19
 	sigs.k8s.io/controller-tools v0.20.0
 	sigs.k8s.io/kind v0.31.0

--- a/tools/mod/go.sum
+++ b/tools/mod/go.sum
@@ -554,6 +554,8 @@ go.augendre.info/arangolint v0.3.1 h1:n2E6p8f+zfXSFLa2e2WqFPp4bfvcuRdd50y6cT65pS
 go.augendre.info/arangolint v0.3.1/go.mod h1:6ZKzEzIZuBQwoSvlKT+qpUfIbBfFCE5gbAoTg0/117g=
 go.augendre.info/fatcontext v0.9.0 h1:Gt5jGD4Zcj8CDMVzjOJITlSb9cEch54hjRRlN3qDojE=
 go.augendre.info/fatcontext v0.9.0/go.mod h1:L94brOAT1OOUNue6ph/2HnwxoNlds9aXDF2FcUntbNw=
+go.etcd.io/gofail v0.2.0 h1:p19drv16FKK345a09a1iubchlw/vmRuksmRzgBIGjcA=
+go.etcd.io/gofail v0.2.0/go.mod h1:nL3ILMGfkXTekKI3clMBNazKnjUZjYLKmBHzsVAnC1o=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 h1:F7Jx+6hwnZ41NSFTO5q4LYDtJRXBf2PD0rNBkeB/lus=

--- a/tools/mod/tools.go
+++ b/tools/mod/tools.go
@@ -23,6 +23,7 @@ package mod
 import (
 	_ "github.com/elastic/crd-ref-docs"
 	_ "github.com/golangci/golangci-lint/v2/cmd/golangci-lint"
+	_ "go.etcd.io/gofail"
 	_ "sigs.k8s.io/controller-runtime/tools/setup-envtest"
 	_ "sigs.k8s.io/controller-tools/cmd/controller-gen"
 	_ "sigs.k8s.io/kind"


### PR DESCRIPTION
Set up `gofail`, the prerequisite for #26 and #130.  

cc @ahrtr @ivanvc 