### PR TITLE
Add e2e tests with gofail panic after scaling in and out

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ IMG ?= controller:latest
 ENVTEST_K8S_VERSION = 1.31.0
 # The version of ETCD to run e2e tests against
 E2E_ETCD_VERSION ?= $(shell go list -m -f {{.Version}} go.etcd.io/etcd/api/v3)
+# Deployment mode
+DEPLOY_MODE ?= default
 
 # Adapted from k/k, simplified to use the go.mod and the Makefile:
 # https://github.com/kubernetes/kubernetes/blob/17854f0e0a153b06f9d0db096e2cd8ab2fa89c11/hack/lib/golang.sh#L510-L520
@@ -185,11 +187,11 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
+	$(KUSTOMIZE) build config/$(DEPLOY_MODE) | $(KUBECTL) apply -f -
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/default | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
+	$(KUSTOMIZE) build config/$(DEPLOY_MODE) | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
 ##@ Documentation
 

--- a/config/e2e/kustomization.yaml
+++ b/config/e2e/kustomization.yaml
@@ -1,0 +1,8 @@
+resources:
+  - ../default
+
+patches:
+  - path: patch-env.yaml
+    target:
+      kind: Deployment
+      name: controller-manager

--- a/config/e2e/patch-env.yaml
+++ b/config/e2e/patch-env.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: etcd-operator
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          env:
+            - name: GOFAIL_HTTP
+              value: ":22381"

--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -340,6 +340,8 @@ func (r *EtcdClusterReconciler) reconcileClusterState(ctx context.Context, s *re
 
 		logger.Info("Learner member added successfully", "peerURLs", peerURL)
 
+		// gofail: var exceptionAfterMemberAdd struct{}
+
 		if s.sts, err = reconcileStatefulSet(ctx, logger, s.cluster, r.Client, targetReplica, r.Scheme); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -359,6 +361,8 @@ func (r *EtcdClusterReconciler) reconcileClusterState(ctx context.Context, s *re
 		if err := etcdutils.RemoveMember(eps, memberID); err != nil {
 			return ctrl.Result{}, err
 		}
+
+		// gofail: var exceptionAfterMemberDelete struct{}
 
 		if s.sts, err = reconcileStatefulSet(ctx, logger, s.cluster, r.Client, targetReplica, r.Scheme); err != nil {
 			return ctrl.Result{}, err

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -120,7 +120,7 @@ func TestMain(m *testing.M) {
 			log.Println("Deploying components...")
 
 			log.Println("Deploying controller-manager resources...")
-			cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", imageName))
+			cmd = exec.Command("make", "deploy", "DEPLOY_MODE=e2e", fmt.Sprintf("IMG=%s", imageName))
 			if _, err := test_utils.Run(cmd); err != nil {
 				log.Printf("Failed to deploy resource configurations: %s", err)
 				return ctx, err
@@ -161,7 +161,7 @@ func TestMain(m *testing.M) {
 
 			// undeploy etcd operator
 			log.Println("Undeploy etcd controller...")
-			cmd := exec.Command("make", "undeploy", "ignore-not-found=true")
+			cmd := exec.Command("make", "undeploy", "DEPLOY_MODE=e2e", "ignore-not-found=true")
 			if _, err := test_utils.Run(cmd); err != nil {
 				log.Printf("Warning: Failed to undeploy controller: %s", err)
 			}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -66,7 +66,6 @@ func TestInvalidClusterSize(t *testing.T) {
 
 	for name, size := range tt {
 		feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-
 			// update cluster name
 			etcdClusterSpec.Name = strings.Join([]string{etcdClusterName, name}, "-")
 			etcdClusterSpec.Spec.Size = size
@@ -81,7 +80,6 @@ func TestInvalidClusterSize(t *testing.T) {
 
 		feature.Assess(fmt.Sprintf("etcdCluster %s should not be created when etcdCluster.Spec.Size is %d", name, size),
 			func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-
 				var etcdCluster ecv1alpha1.EtcdCluster
 				err := c.Client().Resources().Get(ctx, etcdClusterName, namespace, &etcdCluster)
 				if !errors.IsNotFound(err) {
@@ -132,9 +130,20 @@ func TestScaling(t *testing.T) {
 		initialSize     int
 		scaleTo         int
 		expectedMembers int
+		failpoint, term string
 	}{
 		{name: "ScaleInFrom3To1", initialSize: 3, scaleTo: 1, expectedMembers: 1},
+		{
+			name:        "ScaleInFrom3To1WithPanicFailpoint",
+			initialSize: 3, scaleTo: 1, expectedMembers: 1,
+			failpoint: "exceptionAfterMemberDelete", term: "panic",
+		},
 		{name: "ScaleOutFrom1To3", initialSize: 1, scaleTo: 3, expectedMembers: 3},
+		{
+			name:        "ScaleOutFrom1To3WithPanicFailpoint",
+			initialSize: 1, scaleTo: 3, expectedMembers: 3,
+			failpoint: "exceptionAfterMemberAdd", term: "panic",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -143,6 +152,15 @@ func TestScaling(t *testing.T) {
 			etcdClusterName := fmt.Sprintf("etcd-%s", strings.ToLower(tc.name))
 
 			feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+				if tc.failpoint != "" {
+					etcdOperator, err := getEtcdOperatorPod(t, c.Client())
+					if err != nil {
+						t.Errorf("Unable to get the etcd-operator pod: %s", err)
+					}
+					if err := enableGoFailPoint(t, c, etcdOperator, tc.failpoint, tc.term); err != nil {
+						t.Errorf("Unable to enable the go failpoint %s on pod %s: %s", tc.failpoint, etcdOperator.Name, err)
+					}
+				}
 				createEtcdClusterWithPVC(ctx, t, c, etcdClusterName, tc.initialSize)
 				waitForSTSReadiness(t, c, etcdClusterName, tc.initialSize)
 				return ctx
@@ -167,6 +185,8 @@ func TestScaling(t *testing.T) {
 						tc.expectedMembers, len(ml.Members))
 				}
 
+				waitForNoLearners(t, c, podName, tc.expectedMembers, 3*time.Minute)
+
 				// Verify controller promoted all learners to voting members
 				for _, m := range ml.Members {
 					if m.IsLearner {
@@ -177,6 +197,15 @@ func TestScaling(t *testing.T) {
 			})
 
 			feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+				if tc.failpoint != "" {
+					etcdOperator, err := getEtcdOperatorPod(t, c.Client())
+					if err != nil {
+						t.Errorf("Unable to get the etcd-operator pod: %s", err)
+					}
+					if err := disableGoFailPoint(t, c, etcdOperator, tc.failpoint); err != nil {
+						t.Errorf("Unable to disable to go failpoint %s: %s", tc.failpoint, err)
+					}
+				}
 				cleanupEtcdCluster(ctx, t, c, etcdClusterName)
 				return ctx
 			})
@@ -298,7 +327,7 @@ func TestEtcdClusterFunctionality(t *testing.T) {
 
 		// Wait until all members are promoted to voting members (no learners),
 		// otherwise endpoint health will fail on learners.
-		waitForNoLearners(t, c, podName, 3)
+		waitForNoLearners(t, c, podName, 3, 3*time.Minute)
 
 		// Check health for the whole cluster rather than a single member
 		command := []string{"etcdctl", "endpoint", "health", "--cluster"}

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -31,6 +31,10 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	rest "k8s.io/client-go/rest"
+	"sigs.k8s.io/e2e-framework/klient"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 	"sigs.k8s.io/e2e-framework/klient/wait"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 
@@ -208,7 +212,7 @@ func getEtcdMemberListPB(t *testing.T, c *envconf.Config, podName string) *etcds
 
 // waitForNoLearners waits until the member list has the expected number of members
 // and all members are voting (i.e., no learners remain).
-func waitForNoLearners(t *testing.T, c *envconf.Config, podName string, expectedMembers int) {
+func waitForNoLearners(t *testing.T, c *envconf.Config, podName string, expectedMembers int, waitFor time.Duration) {
 	t.Helper()
 	err := wait.For(func(ctx context.Context) (bool, error) {
 		ml := getEtcdMemberListPB(t, c, podName)
@@ -221,7 +225,7 @@ func waitForNoLearners(t *testing.T, c *envconf.Config, podName string, expected
 			}
 		}
 		return true, nil
-	}, wait.WithTimeout(3*time.Minute), wait.WithInterval(5*time.Second))
+	}, wait.WithTimeout(waitFor), wait.WithInterval(5*time.Second))
 	if err != nil {
 		t.Fatalf("Timeout waiting for %d voting members with no learners: %v", expectedMembers, err)
 	}
@@ -293,4 +297,44 @@ func verifyDataOperations(t *testing.T, c *envconf.Config, etcdClusterName, test
 	if len(lines) < 2 || lines[0] != testKey || lines[1] != testValue {
 		t.Errorf("Expected key-value pair [%s=%s], but got output: %s", testKey, testValue, stdout)
 	}
+}
+
+const (
+	gofailPort    = "22381"                            // from config/e2e/patch-env.yaml
+	labelSelector = "control-plane=controller-manager" // from config/manager/manager.yaml,
+)
+
+// enableGoFailPoint enables the specified gofail failpoint on the specified pod via HTTP
+func enableGoFailPoint(t *testing.T, cfg *envconf.Config, pod corev1.Pod, failpoint, term string) error {
+	client := kubernetes.NewForConfigOrDie(cfg.Client().RESTConfig())
+	r := client.CoreV1().RESTClient().Put()
+	return httpViaProxy(t.Context(), r, pod, failpoint, term)
+}
+
+// disableGoFailPoint disables the specified gofail failpoint on the specified pod via HTTP
+func disableGoFailPoint(t *testing.T, cfg *envconf.Config, pod corev1.Pod, failpoint string) error {
+	client := kubernetes.NewForConfigOrDie(cfg.Client().RESTConfig())
+	r := client.CoreV1().RESTClient().Delete()
+	return httpViaProxy(t.Context(), r, pod, failpoint, "")
+}
+
+func getEtcdOperatorPod(t *testing.T, client klient.Client) (corev1.Pod, error) {
+	var pods corev1.PodList
+	err := client.Resources(namespace).List(t.Context(), &pods,
+		resources.WithLabelSelector(labelSelector))
+	if err != nil {
+		return corev1.Pod{}, err
+	}
+	return pods.Items[0], nil
+}
+
+func httpViaProxy(ctx context.Context, r *rest.Request, pod corev1.Pod, failpoint, term string) error {
+	result := r.Namespace(pod.Namespace).
+		Resource("pods").
+		SubResource("proxy").
+		Name(fmt.Sprintf("%s:%s", pod.Name, gofailPort)).
+		Suffix(failpoint).
+		Body(strings.NewReader(term)).
+		Do(ctx)
+	return result.Error()
 }


### PR DESCRIPTION
Fix: #26 

Sorry to keep you guys waiting, but this was not as simple as I thought + each e2e run took some time to complete...  But anyway, I think this should now achieves what we want for adding fail points as proposed in the issue.

# Details for verification

## Fail points exist
```bash
~/w/cn/etcd-operator> k run probe --image=docker.io/curlimages/curl --restart=Never -n etcd-operator-system -- sleep 1000000
pod/probe created
~/w/cn/etcd-operator> k exec -it probe -n etcd-operator-system -- /bin/sh
~ $ curl http://10.244.0.6:22381 # 10.244.0.6 is the pod IP
exceptionAfterMemberAdd=
exceptionAfterMemberDelete=
~ $
```

## Logs during scaling in with failpoint enabled
```bash
2026-03-02T14:28:40Z    ERROR   Observed a panic        {"controller": "etcdcluster", "controllerGroup": "operator.etcd.io", "controllerKind": "EtcdCluster", "EtcdCluster": {"name":"etcd-scaleinfrom3to1withpanicfailpoint","namespace":"etcd-operator-system"}, "namespace": "etcd-operator-system", "name": "etcd-scaleinfrom3to1withpanicfailpoint", "reconcileID": "f8421f6c-cd29-4b40-bec1-e86bfcc6ac4d", "panic": "failpoint panic: {}", "stacktrace": "goroutine 183 [running]:\nk8s.io/apimachinery/pkg/util/runtime.logPanic({0x23c46c8, 0x8b9f7172cf0}, {0x1de9aa0, 0x8b9f6c57c50})\n\t/go/pkg/mod/k8s.io/apimachinery@v0.35.1/pkg/util/runtime/runtime.go:132 +0xbc\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1()\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:202 +0x103\npanic({0x1de9aa0?, 0x8b9f6c57c50?})\n\t/usr/local/go/src/runtime/panic.go:860 +0x13a\ngo.etcd.io/gofail/runtime.actPanic(0x0?)\n\t/go/pkg/mod/go.etcd.io/gofail@v0.2.0/runtime/terms.go:324 +0xc5\ngo.etcd.io/gofail/runtime.(*term).do(...)\n\t/go/pkg/mod/go.etcd.io/gofail@v0.2.0/runtime/terms.go:293\ngo.etcd.io/gofail/runtime.(*terms).eval(0x8b9f6c70640)\n\t/go/pkg/mod/go.etcd.io/gofail@v0.2.0/runtime/terms.go:108 +0xde\ngo.etcd.io/gofail/runtime.(*Failpoint).Acquire(0x8b9f72dc600?)\n\t/go/pkg/mod/go.etcd.io/gofail@v0.2.0/runtime/failpoint.go:45 +0x6e\ngo.etcd.io/etcd-operator/internal/controller.(*EtcdClusterReconciler).reconcileClusterState(0x8b9f570b700, {0x23c46c8, 0x8b9f7172cf0}, 0x8b9f7172ed0)\n\t/workspace/internal/controller/etcdcluster_controller.go:365 +0x6be\ngo.etcd.io/etcd-operator/internal/controller.(*EtcdClusterReconciler).Reconcile(0x8b9f570b700, {0x23c46c8, 0x8b9f7172cf0}, {{{0x8b9f72f3590?, 0x16cef05?}, {0x8b9f7308ff0?, 0x0?}}})\n\t/workspace/internal/controller/etcdcluster_controller.go:96 +0x116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile(0x8b9f7172c60, {0x23c46c8?, 0x8b9f7172cf0}, {{{0x8b9f72f3590, 0x0?}, {0x8b9f7308ff0?, 0x0?}}})\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:222 +0x1ab\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler(0x23f21a0, {0x23c4700, 0x8b9f548c690}, {{{0x8b9f72f3590, 0x14}, {0x8b9f7308ff0, 0x26}}}, 0x0)\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:479 +0x39b\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem(0x23f21a0, {0x23c4700, 0x8b9f548c690})\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:438 +0x1f8\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1()\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:313 +0x85\ncreated by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1 in goroutine 110\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:309 +0x26b\n"}
k8s.io/apimachinery/pkg/util/runtime.logPanic
        /go/pkg/mod/k8s.io/apimachinery@v0.35.1/pkg/util/runtime/runtime.go:140
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:202
runtime.gopanic
        /usr/local/go/src/runtime/panic.go:860
go.etcd.io/gofail/runtime.actPanic
        /go/pkg/mod/go.etcd.io/gofail@v0.2.0/runtime/terms.go:324
go.etcd.io/gofail/runtime.(*term).do
        /go/pkg/mod/go.etcd.io/gofail@v0.2.0/runtime/terms.go:293
go.etcd.io/gofail/runtime.(*terms).eval
        /go/pkg/mod/go.etcd.io/gofail@v0.2.0/runtime/terms.go:108
go.etcd.io/gofail/runtime.(*Failpoint).Acquire
        /go/pkg/mod/go.etcd.io/gofail@v0.2.0/runtime/failpoint.go:45
go.etcd.io/etcd-operator/internal/controller.(*EtcdClusterReconciler).reconcileClusterState
        /workspace/internal/controller/etcdcluster_controller.go:365
go.etcd.io/etcd-operator/internal/controller.(*EtcdClusterReconciler).Reconcile
        /workspace/internal/controller/etcdcluster_controller.go:96
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:222
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:479
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:438
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:313
2026-03-02T14:28:40Z    ERROR   Reconciler error        {"controller": "etcdcluster", "controllerGroup": "operator.etcd.io", "controllerKind": "EtcdCluster", "EtcdCluster": {"name":"etcd-scaleinfrom3to1withpanicfailpoint","namespace":"etcd-operator-system"}, "namespace": "etcd-operator-system", "name": "etcd-scaleinfrom3to1withpanicfailpoint", "reconcileID": "f8421f6c-cd29-4b40-bec1-e86bfcc6ac4d", "error": "panic: failpoint panic: {} [recovered]"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:495
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:438
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:313
```

## Logs during scaling out with failpoint enabled
```bash
2026-03-02T14:30:30Z    ERROR   Observed a panic        {"controller": "etcdcluster", "controllerGroup": "operator.etcd.io", "controllerKind": "EtcdCluster", "EtcdCluster": {"name":"etcd-scaleoutfrom1to3withpanicfailpoint","namespace":"etcd-operator-system"}, "namespace": "etcd-operator-system", "name": "etcd-scaleoutfrom1to3withpanicfailpoint", "reconcileID": "769c23b3-4174-442a-a192-a0b50ccb17c1", "panic": "failpoint panic: {}", "stacktrace": "goroutine 183 [running]:\nk8s.io/apimachinery/pkg/util/runtime.logPanic({0x23c46c8, 0x8b9f6c98c90}, {0x1de9aa0, 0x8b9f58fd230})\n\t/go/pkg/mod/k8s.io/apimachinery@v0.35.1/pkg/util/runtime/runtime.go:132 +0xbc\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1()\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:202 +0x103\npanic({0x1de9aa0?, 0x8b9f58fd230?})\n\t/usr/local/go/src/runtime/panic.go:860 +0x13a\ngo.etcd.io/gofail/runtime.actPanic(0x0?)\n\t/go/pkg/mod/go.etcd.io/gofail@v0.2.0/runtime/terms.go:324 +0xc5\ngo.etcd.io/gofail/runtime.(*term).do(...)\n\t/go/pkg/mod/go.etcd.io/gofail@v0.2.0/runtime/terms.go:293\ngo.etcd.io/gofail/runtime.(*terms).eval(0x8b9f729d720)\n\t/go/pkg/mod/go.etcd.io/gofail@v0.2.0/runtime/terms.go:108 +0xde\ngo.etcd.io/gofail/runtime.(*Failpoint).Acquire(0x23cfe48?)\n\t/go/pkg/mod/go.etcd.io/gofail@v0.2.0/runtime/failpoint.go:45 +0x6e\ngo.etcd.io/etcd-operator/internal/controller.(*EtcdClusterReconciler).reconcileClusterState(0x8b9f570b700, {0x23c46c8, 0x8b9f6c98c90}, 0x8b9f6c98e10)\n\t/workspace/internal/controller/etcdcluster_controller.go:343 +0xa45\ngo.etcd.io/etcd-operator/internal/controller.(*EtcdClusterReconciler).Reconcile(0x8b9f570b700, {0x23c46c8, 0x8b9f6c98c90}, {{{0x8b9f72f2510?, 0x16cef05?}, {0x8b9f73472c0?, 0x0?}}})\n\t/workspace/internal/controller/etcdcluster_controller.go:96 +0x116\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile(0x8b9f6c98c00, {0x23c46c8?, 0x8b9f6c98c90}, {{{0x8b9f72f2510, 0x0?}, {0x8b9f73472c0?, 0x0?}}})\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:222 +0x1ab\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler(0x23f21a0, {0x23c4700, 0x8b9f548c690}, {{{0x8b9f72f2510, 0x14}, {0x8b9f73472c0, 0x27}}}, 0x0)\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:479 +0x39b\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem(0x23f21a0, {0x23c4700, 0x8b9f548c690})\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:438 +0x1f8\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1()\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:313 +0x85\ncreated by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1 in goroutine 110\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:309 +0x26b\n"}
k8s.io/apimachinery/pkg/util/runtime.logPanic
        /go/pkg/mod/k8s.io/apimachinery@v0.35.1/pkg/util/runtime/runtime.go:140
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:202
runtime.gopanic
        /usr/local/go/src/runtime/panic.go:860
go.etcd.io/gofail/runtime.actPanic
        /go/pkg/mod/go.etcd.io/gofail@v0.2.0/runtime/terms.go:324
go.etcd.io/gofail/runtime.(*term).do
        /go/pkg/mod/go.etcd.io/gofail@v0.2.0/runtime/terms.go:293
go.etcd.io/gofail/runtime.(*terms).eval
        /go/pkg/mod/go.etcd.io/gofail@v0.2.0/runtime/terms.go:108
go.etcd.io/gofail/runtime.(*Failpoint).Acquire
        /go/pkg/mod/go.etcd.io/gofail@v0.2.0/runtime/failpoint.go:45
go.etcd.io/etcd-operator/internal/controller.(*EtcdClusterReconciler).reconcileClusterState
        /workspace/internal/controller/etcdcluster_controller.go:343
go.etcd.io/etcd-operator/internal/controller.(*EtcdClusterReconciler).Reconcile
        /workspace/internal/controller/etcdcluster_controller.go:96
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:222
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:479
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:438
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:313
2026-03-02T14:30:30Z    ERROR   Reconciler error        {"controller": "etcdcluster", "controllerGroup": "operator.etcd.io", "controllerKind": "EtcdCluster", "EtcdCluster": {"name":"etcd-scaleoutfrom1to3withpanicfailpoint","namespace":"etcd-operator-system"}, "namespace": "etcd-operator-system", "name": "etcd-scaleoutfrom1to3withpanicfailpoint", "reconcileID": "769c23b3-4174-442a-a192-a0b50ccb17c1", "error": "panic: failpoint panic: {} [recovered]"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:495
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:438
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.23.1/pkg/internal/controller/controller.go:313
```
</details>

cc @ahrtr, @ivanvc and @ArkaSaha30 