### PR TITLE
Fix the test flake in scaling

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -188,6 +188,7 @@ func TestScaling(t *testing.T) {
 				waitForNoLearners(t, c, podName, tc.expectedMembers, 3*time.Minute)
 
 				// Verify controller promoted all learners to voting members
+				ml = getEtcdMemberListPB(t, c, podName)
 				for _, m := range ml.Members {
 					if m.IsLearner {
 						t.Errorf("Found unpromoted learner after scaling completed: member %s (%d)", m.Name, m.ID)


### PR DESCRIPTION
Fix #299 

`waitForNoLearners` now has to pass the validation of no learners a few times (3 in the code).  I also made `TestScaling` retrieve the members again before the final validation for a more accurate result.

I tested this in my local five-six times and didn't run into the same flake.

cc @ivanvc @ahrtr 