### PR TITLE
update controller-gen annotations of base crd

### DIFF
--- a/config/crd/bases/operator.etcd.io_etcdclusters.yaml
+++ b/config/crd/bases/operator.etcd.io_etcdclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: etcdclusters.operator.etcd.io
 spec:
   group: operator.etcd.io


### PR DESCRIPTION
Since controller-tools version was updated to v0.20.1

https://github.com/etcd-io/etcd-operator/blob/9b44df9f98087cc8aceb46eef18b84abcd707275/tools/mod/go.mod#L12

