### PR TITLE
update controller-gen annotations of base crd

### DIFF
--- a/config/crd/bases/operator.etcd.io_etcdclusters.yaml
+++ b/config/crd/bases/operator.etcd.io_etcdclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: etcdclusters.operator.etcd.io
 spec:
   group: operator.etcd.io


### PR DESCRIPTION

Updating the crd base annotation as controller-tools version is updated to `v0.21.0`

https://github.com/etcd-io/etcd-operator/blob/ddb834e92a45121addf5f7b672821fb4cd67e29b/tools/mod/go.mod#L12