### PR TITLE
fix: stop swallowing the client-certificate error

### DIFF
--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -136,7 +136,11 @@ func (r *EtcdClusterReconciler) fetchAndValidateState(ctx context.Context, req c
 	// Ensure the operator has TLS credentials when the cluster requests TLS.
 	if ec.Spec.TLS != nil {
 		if err := createClientCertificate(ctx, ec, r.Client); err != nil {
-			logger.Error(err, "Failed to create Client Certificate.")
+			// The data path relies on this client certificate existing; do not
+			// proceed with reconciliation when it cannot be provisioned.
+			// Requeue with backoff so the failure is retried instead of swallowed.
+			logger.Error(err, "Failed to create Client Certificate. Requesting requeue")
+			return nil, ctrl.Result{RequeueAfter: requeueDuration}, nil
 		}
 	} else {
 		// TODO: instead of logging error, set default autoConfig

--- a/internal/controller/etcdcluster_controller_test.go
+++ b/internal/controller/etcdcluster_controller_test.go
@@ -410,6 +410,50 @@ func TestFetchAndValidateState(t *testing.T) {
 	}
 }
 
+// TestFetchAndValidateStateClientCertificateError verifies that when the cluster
+// requests TLS but the client certificate cannot be provisioned,
+// fetchAndValidateState requeues with backoff instead of swallowing the error and
+// proceeding. The fake client's scheme intentionally omits the cert-manager
+// types, so the certificate lookup performed by createClientCertificate fails
+// with a non-NotFound error, exercising the provisioning failure path.
+func TestFetchAndValidateStateClientCertificateError(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	_ = ecv1alpha1.AddToScheme(scheme)
+	// Note: cert-manager's certv1 scheme is deliberately NOT registered.
+
+	ec := &ecv1alpha1.EtcdCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "etcd",
+			Namespace: "default",
+			UID:       "1",
+		},
+		Spec: ecv1alpha1.EtcdClusterSpec{
+			Size:    1,
+			Version: "3.5.17",
+			TLS: &ecv1alpha1.TLSCertificate{
+				Provider: "cert-manager",
+			},
+		},
+	}
+
+	ctx := t.Context()
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec).Build()
+	r := &EtcdClusterReconciler{Client: fakeClient, Scheme: scheme}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "etcd", Namespace: "default"}}
+	state, res, err := r.fetchAndValidateState(ctx, req)
+
+	// Reconciliation must not proceed past cert provisioning: no state is
+	// returned, and the result is a requeue with the standard backoff.
+	assert.Nil(t, state, "reconcile should not proceed past client-certificate provisioning")
+	assert.NoError(t, err, "the failure should be surfaced via requeue, not a returned error")
+	assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, res, "expected a requeue with backoff")
+	assert.NotZero(t, res.RequeueAfter, "RequeueAfter must be non-zero")
+}
+
 // TestBootstrapStatefulSet outlines tests for ensuring StatefulSet and Service
 // creation and bootstrap logic.
 func TestBootstrapStatefulSet(t *testing.T) {


### PR DESCRIPTION
When an `EtcdCluster` requests TLS, `fetchAndValidateState` provisions the operator's client certificate via `createClientCertificate`. That error was logged and then ignored, so reconciliation proceeded even though the credential the TLS data path depends on was never created — the failure is invisible and surfaces later as a more confusing downstream error.

This returns a requeue with backoff (the existing `requeueDuration`, matching the sibling error paths in the same function) on failure, so provisioning is retried instead of silently swallowed.

Adds a unit test that drives `fetchAndValidateState` with a fake client whose scheme omits the cert-manager types (forcing the certificate lookup to fail) and asserts a non-zero `RequeueAfter` with no `reconcileState` returned (reconcile does not proceed past cert provisioning).

Refs #370

---

### PR series — operability fixes & TLS
<!-- pr-stack:begin -->
Small single-purpose PRs from live kind-cluster testing of the operator. Each stands alone unless an *After* is listed. → = this PR.

| | PR | Lands | After |
|---|----|-------|-------|
| | **Reviewable now — small, any order** | | |
| 🟢→ | #374 | Requeue instead of swallowing the client-cert provisioning error | — |
| 🟢 | #391 | Grant `events.k8s.io` RBAC so operator Events are actually recorded | — |
| 🟢 | #392 | Correlate `members[]`/`leaderID` from one health snapshot (consistent leader) | — |
| 🟢 | #393 | Propagate user-supplied `altNames.ipAddresses` into certificates | — |
| 🟢 | #394 | Accept day-suffix `validityDuration` (`365d`, `100d12h`) as documented | — |
| 🟢 | #395 | Surface early reconcile errors as a `Degraded` condition (was empty status) | — |
| 🟢 | #379 | Configurable reconcile worker pool (`--max-concurrent-reconciles`) | — |
| 🟢 | #369 | kind-based stress/scale e2e harness (1/3/7 members, churn, quorum watcher) | — |
| 🟢 | #398 | `podTemplate.spec` scheduling fields: topologySpread, resources, priorityClass, schedulerName | — |
| 🟢 | #397 | First-class Helm chart covering the full `config/` surface | — |
| 🟢 | #399 | Quorum-aware PodDisruptionBudget per EtcdCluster | — |
| 🟢 | #400 | Scale-in removes the right member and transfers leadership first | — |
| 🟢 | #401 | Backend quota + auto-compaction spec fields, NOSPACE alarm surfacing | — |
| 🟢 | #402 | Reconcile-loop gates replace the blocking StatefulSet-ready wait | — |
| 🟢 | #403 | Quorum-gated one-pod-at-a-time version upgrades via OnDelete | — |
| | **TLS stack — in order** | | |
| 🟢 | #376 | Independent `spec.tls.{peer,client}` surfaces (breaking alpha API) | — |
| ⚪ | #377 | `TLSReady` condition + TLS lifecycle Events | #376 |
| ⚪ | #378 | Multi-member TLS quorum e2e + `PeerCANotShared` | #377 |
| | **EtcdMirror — in order** | | |
| 🟢 | #406 | `EtcdMirror` CRD: one-way cross-cluster replication API (types + CEL) | — |
| 🟢 | #407 | `pkg/mirroragent` replication engine (fenced checkpoint-in-target) | #406 |
| 🟢 | #408 | Periodic reconciliation pass wired into the engine's steady-state loop | #407 |
| 🟢 | #412 | `mirror-agent` binary: config/TLS-reload/statusz/metrics + kind e2e | #408 |
| 🟢 | #413 | EtcdMirror controller: Deployment rendering, statusz-driven conditions, guards, fenced finalizer | #412 |
| 🟢 | #414 | CRD/sample/editor+viewer-role kustomize wiring | #413 |
| 🟢 | #415 | Controller-side phase/condition gauges, shipped PrometheusRule + dashboard | #414 |
| 🟢 | #416 | Full-lifecycle kind e2e: fence overlap, compaction+prune, restart resume, cert rotation, cutover/reversal | #415 |
| | **Parked as drafts pending #363** | | |
| ⚪ | #382 | Per-cluster domain metrics on the operator `/metrics` endpoint | — |
| ⚪ | #384 | EtcdCluster admission webhooks (consolidating with #328) | #363 |
| ⚪ | #386 | `EtcdBackup` CR → object storage (S3/GCS) | #363 |
| ⚪ | #387 | Automatic quorum-loss disaster recovery (bootstrap-latch guarded) | #363 |

🟢 ready · ⚪ draft
<!-- pr-stack:end -->