### PR TITLE
feat: mount server/peer cert secrets into the etcd container

### DIFF
--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -37,6 +37,14 @@ import (
 const (
 	etcdDataDir = "/var/lib/etcd"
 	volumeName  = "etcd-data"
+
+	// TLS cert secret volume names and mount paths. The volume names must match
+	// the cert Volumes added in createOrPatchStatefulSet; the mount paths are the
+	// locations the etcd TLS flags will reference once those flags land.
+	serverCertVolumeName = "server-secret"
+	peerCertVolumeName   = "peer-secret"
+	serverCertMountPath  = "/etc/etcd/server-tls/"
+	peerCertMountPath    = "/etc/etcd/peer-tls/"
 )
 
 type etcdClusterState string
@@ -194,18 +202,33 @@ func createOrPatchStatefulSet(ctx context.Context, logger logr.Logger, ec *ecv1a
 	peerCertName := getPeerCertName(ec.Name)
 	if ec.Spec.TLS != nil {
 		serverCertVolume := corev1.Volume{
-			Name: "server-secret",
+			Name: serverCertVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{SecretName: serverCertName},
 			},
 		}
 		peerCertVolume := corev1.Volume{
-			Name: "peer-secret",
+			Name: peerCertVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{SecretName: peerCertName},
 			},
 		}
 		certVolume = append(certVolume, serverCertVolume, peerCertVolume)
+
+		// Mount the cert secrets into the etcd container so etcd can read them.
+		// Gated on TLS (not StorageSpec): a TLS cluster without persistent
+		// storage must still receive the cert mounts. The flags that consume
+		// these paths land in a follow-up; the mounts alone are a safe no-op.
+		podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts,
+			corev1.VolumeMount{
+				Name:      serverCertVolumeName,
+				MountPath: serverCertMountPath,
+			},
+			corev1.VolumeMount{
+				Name:      peerCertVolumeName,
+				MountPath: peerCertMountPath,
+			},
+		)
 	}
 	if len(certVolume) != 0 {
 		podSpec.Volumes = certVolume
@@ -254,11 +277,14 @@ func createOrPatchStatefulSet(ctx context.Context, logger logr.Logger, ec *ecv1a
 
 	if ec.Spec.StorageSpec != nil {
 
-		stsSpec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{{
-			Name:        volumeName,
-			MountPath:   etcdDataDir,
-			SubPathExpr: "$(POD_NAME)",
-		}}
+		// Append (not assign) so any TLS cert mounts added above are preserved.
+		stsSpec.Template.Spec.Containers[0].VolumeMounts = append(
+			stsSpec.Template.Spec.Containers[0].VolumeMounts,
+			corev1.VolumeMount{
+				Name:        volumeName,
+				MountPath:   etcdDataDir,
+				SubPathExpr: "$(POD_NAME)",
+			})
 		// Create a new volume claim template
 		if ec.Spec.StorageSpec.VolumeSizeRequest.Cmp(resource.MustParse("1Mi")) < 0 {
 			return fmt.Errorf("VolumeSizeRequest must be at least 1Mi")

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -1086,6 +1087,106 @@ func TestCreateCMCertificateConfig(t *testing.T) {
 				assert.Equal(t, tt.expected.AltNames.DNSNames, result.AltNames.DNSNames)
 				assert.Equal(t, tt.expected.AltNames.IPs, result.AltNames.IPs)
 				assert.Equal(t, tt.expected.ExtraConfig, result.ExtraConfig)
+			}
+		})
+	}
+}
+
+// findVolumeMount returns the VolumeMount with the given name, or false if absent.
+func findVolumeMount(mounts []corev1.VolumeMount, name string) (corev1.VolumeMount, bool) {
+	for _, m := range mounts {
+		if m.Name == name {
+			return m, true
+		}
+	}
+	return corev1.VolumeMount{}, false
+}
+
+func TestCreateOrPatchStatefulSetTLSCertMounts(t *testing.T) {
+	ctx := t.Context()
+	logger := log.FromContext(ctx)
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = ecv1alpha1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+
+	tests := []struct {
+		name        string
+		tls         *ecv1alpha1.TLSCertificate
+		storageSpec *ecv1alpha1.StorageSpec
+		expectMount bool
+	}{
+		{
+			name:        "TLS configured mounts server and peer cert secrets",
+			tls:         &ecv1alpha1.TLSCertificate{},
+			expectMount: true,
+		},
+		{
+			name:        "TLS configured without storage still mounts cert secrets",
+			tls:         &ecv1alpha1.TLSCertificate{},
+			storageSpec: nil,
+			expectMount: true,
+		},
+		{
+			name: "TLS configured alongside storage keeps both data dir and cert mounts",
+			tls:  &ecv1alpha1.TLSCertificate{},
+			storageSpec: &ecv1alpha1.StorageSpec{
+				VolumeSizeRequest: resource.MustParse("1Gi"),
+			},
+			expectMount: true,
+		},
+		{
+			name:        "TLS nil adds no cert mounts",
+			tls:         nil,
+			expectMount: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+			ec := &ecv1alpha1.EtcdCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-etcd-tls",
+					Namespace: "default",
+				},
+				Spec: ecv1alpha1.EtcdClusterSpec{
+					Size:        3,
+					Version:     "3.5.17",
+					TLS:         tt.tls,
+					StorageSpec: tt.storageSpec,
+				},
+			}
+
+			err := createOrPatchStatefulSet(ctx, logger, ec, fakeClient, 3, scheme)
+			require.NoError(t, err)
+
+			sts := &appsv1.StatefulSet{}
+			err = fakeClient.Get(ctx, client.ObjectKey{Name: ec.Name, Namespace: "default"}, sts)
+			require.NoError(t, err)
+
+			require.Len(t, sts.Spec.Template.Spec.Containers, 1)
+			mounts := sts.Spec.Template.Spec.Containers[0].VolumeMounts
+
+			serverMount, serverOK := findVolumeMount(mounts, "server-secret")
+			peerMount, peerOK := findVolumeMount(mounts, "peer-secret")
+
+			if tt.expectMount {
+				require.True(t, serverOK, "expected server-secret VolumeMount to be present")
+				require.True(t, peerOK, "expected peer-secret VolumeMount to be present")
+				assert.Equal(t, "/etc/etcd/server-tls/", serverMount.MountPath)
+				assert.Equal(t, "/etc/etcd/peer-tls/", peerMount.MountPath)
+			} else {
+				assert.False(t, serverOK, "did not expect server-secret VolumeMount when TLS is nil")
+				assert.False(t, peerOK, "did not expect peer-secret VolumeMount when TLS is nil")
+			}
+
+			// When storage is requested, the data-dir mount must coexist with the cert mounts.
+			if tt.storageSpec != nil {
+				_, dataOK := findVolumeMount(mounts, volumeName)
+				assert.True(t, dataOK, "expected data-dir VolumeMount to be present alongside cert mounts")
 			}
 		})
 	}


### PR DESCRIPTION
## What

Mount the already-provisioned server and peer cert secrets into the etcd container.

When `spec.tls` is set, the operator already provisions the server/peer
`Certificate`s and adds their secret `Volume`s to the StatefulSet pod spec
(`createOrPatchStatefulSet`). However, the etcd container never mounts those
volumes, so the certificates are present in the pod spec but **invisible to
etcd**. This PR adds the missing `VolumeMount`s.

## Change

- Add `VolumeMount`s on the etcd container for the server and peer cert secrets:
  - `server-secret` → `/etc/etcd/server-tls/`
  - `peer-secret` → `/etc/etcd/peer-tls/`
- Gated on `spec.tls != nil`, and appended **independently of `StorageSpec`** so
  a TLS cluster without persistent storage still receives the cert mounts.
- The data-dir mount inside the `StorageSpec != nil` branch now **appends**
  rather than assigns the `VolumeMounts` slice, so the cert mounts are preserved
  when both TLS and storage are configured.
- Volume names reuse the existing cert `Volume` names; paths are factored into
  constants so the follow-up TLS-flags change references exactly the same paths.

## Why this is safe / why now

Mounting cert files with **no TLS flags** is a no-op: etcd ignores files it is
not told to use. This keeps the change independently shippable and the cluster
always bootable. It is the first step of wiring TLS into the etcd data path; the
flags that consume these mount paths (`--cert-file`, `--peer-cert-file`, …,
plus the `https://` scheme flip) land in a separate follow-up PR so each step
stays independently reviewable.

## Migration note

The StatefulSet pod template is immutable for existing clusters, so this takes
effect for **new or recreated clusters**. TLS is a create-time property — a
running cleartext cluster should be migrated to a fresh TLS cluster rather than
flipped in place.

## Test

Extended the controller unit tests with `TestCreateOrPatchStatefulSetTLSCertMounts`,
which renders the StatefulSet through the real `createOrPatchStatefulSet` path
(controller-runtime fake client) and asserts both cert `VolumeMount`s are present
with the correct names and mount paths when `spec.tls != nil`, absent when nil,
and that the data-dir mount coexists with the cert mounts when `StorageSpec` is
also set. Verified the test fails against the unmodified code and passes after
the change.

Refs #371


---

### Related work — etcd TLS data-path enablement

The operator provisions cert-manager certificates but currently runs etcd in cleartext. This PR is one step of a small, dependency-ordered series wiring TLS through the data path (`→` marks this PR):

| | Step | Change | Issue | PR |
|--|------|--------|-------|----|
|   | T0 | stop swallowing the client-certificate error | #370 | #374 |
| → | T2 | mount server/peer cert secrets into the etcd container | #371 | #375 |
|   | T3 | emit etcd TLS flags + https endpoints (single scheme source-of-truth) | #372 | _pending_ |
|   | T4 | thread an optional `*tls.Config` through the operator's etcd client | #373 | _pending_ |
|   | — | kind stress/e2e harness (the TLS end-to-end test will extend it) | — | #369 |
