### PR TITLE
fix: grant RBAC for events.k8s.io Events emitted by the events/v1 recorder

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -62,6 +62,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
   - operator.etcd.io
   resources:
   - etcdclusters

--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -69,6 +69,7 @@ type reconcileState struct {
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch;get;list;update
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;patch;update;delete
 // +kubebuilder:rbac:groups="cert-manager.io",resources=certificates,verbs=get;list;watch;create;patch;update;delete
 // +kubebuilder:rbac:groups="cert-manager.io",resources=clusterissuers,verbs=get;list;watch


### PR DESCRIPTION
On a real cluster every operator-emitted Event is rejected by the API server: `Server rejected event (will not retry!) ... User "system:serviceaccount:etcd-operator-system:etcd-operator-controller-manager" cannot create resource "events" in API group "events.k8s.io"`, so `kubectl describe etcdcluster` always shows `Events: <none>`. The recorder wired in `SetupWithManager` via `mgr.GetEventRecorder` writes `events.k8s.io/v1` Events, but `role.yaml` only grants events verbs in the core (`""`) API group — envtest does not enforce RBAC, so tests never catch this. This adds an `events.k8s.io` events `create;patch` RBAC marker (the two verbs the client-go `tools/events` broadcaster uses) and regenerates `config/rbac/role.yaml`. Verified with `go build ./...` and `go test ./internal/... ./api/...`.

---

### PR series — operability fixes & TLS
<!-- pr-stack:begin -->
Small single-purpose PRs from live kind-cluster testing of the operator. Each stands alone unless an *After* is listed. → = this PR.

| | PR | Lands | After |
|---|----|-------|-------|
| | **Reviewable now — small, any order** | | |
| 🟢 | #374 | Requeue instead of swallowing the client-cert provisioning error | — |
| 🟢→ | #391 | Grant `events.k8s.io` RBAC so operator Events are actually recorded | — |
| 🟢 | #392 | Correlate `members[]`/`leaderID` from one health snapshot (consistent leader) | — |
| 🟢 | #393 | Propagate user-supplied `altNames.ipAddresses` into certificates | — |
| 🟢 | #394 | Accept day-suffix `validityDuration` (`365d`, `100d12h`) as documented | — |
| 🟢 | #395 | Surface early reconcile errors as a `Degraded` condition (was empty status) | — |
| 🟢 | #379 | Configurable reconcile worker pool (`--max-concurrent-reconciles`) | — |
| 🟢 | #369 | kind-based stress/scale e2e harness (1/3/7 members, churn, quorum watcher) | — |
| 🟢 | #398 | `podTemplate.spec` scheduling fields: topologySpread, resources, priorityClass, schedulerName | — |
| 🟢 | #397 | First-class Helm chart covering the full `config/` surface | — |
| 🟢 | #399 | Quorum-aware PodDisruptionBudget per EtcdCluster | — |
| 🟢 | #400 | Scale-in removes the right member and transfers leadership first | — |
| 🟢 | #401 | Backend quota + auto-compaction spec fields, NOSPACE alarm surfacing | — |
| 🟢 | #402 | Reconcile-loop gates replace the blocking StatefulSet-ready wait | — |
| 🟢 | #403 | Quorum-gated one-pod-at-a-time version upgrades via OnDelete | — |
| | **TLS stack — in order** | | |
| 🟢 | #376 | Independent `spec.tls.{peer,client}` surfaces (breaking alpha API) | — |
| ⚪ | #377 | `TLSReady` condition + TLS lifecycle Events | #376 |
| ⚪ | #378 | Multi-member TLS quorum e2e + `PeerCANotShared` | #377 |
| | **EtcdMirror — in order** | | |
| 🟢 | #406 | `EtcdMirror` CRD: one-way cross-cluster replication API (types + CEL) | — |
| 🟢 | #407 | `pkg/mirroragent` replication engine (fenced checkpoint-in-target) | #406 |
| 🟢 | #408 | Periodic reconciliation pass wired into the engine's steady-state loop | #407 |
| 🟢 | #412 | `mirror-agent` binary: config/TLS-reload/statusz/metrics + kind e2e | #408 |
| 🟢 | #413 | EtcdMirror controller: Deployment rendering, statusz-driven conditions, guards, fenced finalizer | #412 |
| 🟢 | #414 | CRD/sample/editor+viewer-role kustomize wiring | #413 |
| 🟢 | #415 | Controller-side phase/condition gauges, shipped PrometheusRule + dashboard | #414 |
| 🟢 | #416 | Full-lifecycle kind e2e: fence overlap, compaction+prune, restart resume, cert rotation, cutover/reversal | #415 |
| | **Parked as drafts pending #363** | | |
| ⚪ | #382 | Per-cluster domain metrics on the operator `/metrics` endpoint | — |
| ⚪ | #384 | EtcdCluster admission webhooks (consolidating with #328) | #363 |
| ⚪ | #386 | `EtcdBackup` CR → object storage (S3/GCS) | #363 |
| ⚪ | #387 | Automatic quorum-loss disaster recovery (bootstrap-latch guarded) | #363 |

🟢 ready · ⚪ draft
<!-- pr-stack:end -->