### PR TITLE
fix: correlate member status with health report by member ID

### DIFF
--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -422,22 +422,30 @@ func (r *EtcdClusterReconciler) updateStatus(ctx context.Context, s *reconcileSt
 	if s.memberListResp != nil {
 		s.cluster.Status.MemberCount = int32(len(s.memberListResp.Members))
 
+		// The member list is ordered by member ID while the health report is
+		// ordered by endpoint, so health info must be correlated by member ID
+		// rather than by index.
+		leader, leaderStatus := etcdutils.FindLeaderStatus(s.memberHealth, logger)
+		healthByID := make(map[uint64]etcdutils.EpHealth, len(s.memberHealth))
+		for _, health := range s.memberHealth {
+			if health.Status != nil {
+				healthByID[health.Status.Header.MemberId] = health
+			}
+		}
+
 		// Update individual member statuses
 		s.cluster.Status.Members = make([]ecv1alpha1.MemberStatus, 0, len(s.memberListResp.Members))
-		for i, member := range s.memberListResp.Members {
+		for _, member := range s.memberListResp.Members {
 			memberStatus := ecv1alpha1.MemberStatus{
 				ID:   fmt.Sprintf("%x", member.ID),
 				Name: member.Name,
 			}
 
 			// Find health info for this member
-			if i < len(s.memberHealth) {
-				health := s.memberHealth[i]
+			if health, ok := healthByID[member.ID]; ok {
 				memberStatus.IsHealthy = health.Health
-				if health.Status != nil {
-					memberStatus.Version = health.Status.Version
-					memberStatus.IsLeader = health.Status.Header.MemberId == health.Status.Leader
-				}
+				memberStatus.Version = health.Status.Version
+				memberStatus.IsLeader = leader != 0 && member.ID == leader
 			}
 
 			memberStatus.IsLearner = member.IsLearner
@@ -445,9 +453,8 @@ func (r *EtcdClusterReconciler) updateStatus(ctx context.Context, s *reconcileSt
 		}
 
 		// Update leader ID
-		_, leaderStatus := etcdutils.FindLeaderStatus(s.memberHealth, logger)
 		if leaderStatus != nil {
-			s.cluster.Status.LeaderID = fmt.Sprintf("%x", leaderStatus.Leader)
+			s.cluster.Status.LeaderID = fmt.Sprintf("%x", leader)
 		}
 
 		// Update current version from leader or first healthy member

--- a/internal/controller/etcdcluster_controller_test.go
+++ b/internal/controller/etcdcluster_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,6 +32,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	ecv1alpha1 "go.etcd.io/etcd-operator/api/v1alpha1"
+	"go.etcd.io/etcd-operator/internal/etcdutils"
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 // TestFetchAndValidateState describes the scenarios for the fetchAndValidateState
@@ -570,4 +574,106 @@ func TestBootstrapStatefulSet(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, storedCM.Data, fetchedCM.Data)
 	})
+}
+
+// TestUpdateStatusMemberHealthCorrelation verifies that member statuses are
+// correlated with health reports by member ID. The member list from etcd is
+// ordered by member ID while the health report is ordered by endpoint, so the
+// two lists cannot be paired by index.
+func TestUpdateStatusMemberHealthCorrelation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = ecv1alpha1.AddToScheme(scheme)
+
+	ec := &ecv1alpha1.EtcdCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "etcd",
+			Namespace: "default",
+		},
+		Spec: ecv1alpha1.EtcdClusterSpec{Size: 3, Version: "3.5.17"},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ec).
+		WithStatusSubresource(ec).
+		Build()
+	r := &EtcdClusterReconciler{Client: fakeClient, Scheme: scheme}
+
+	// etcd-2 is the leader and has the lowest member ID, so it comes first in
+	// the ID-ordered member list while its health entry comes last in the
+	// endpoint-ordered health report.
+	const (
+		leaderID    uint64 = 0x100 // etcd-2
+		followerID0 uint64 = 0x200 // etcd-0
+		followerID1 uint64 = 0x300 // etcd-1
+	)
+
+	state := &reconcileState{
+		cluster: ec,
+		memberListResp: &clientv3.MemberListResponse{
+			Members: []*etcdserverpb.Member{
+				{ID: leaderID, Name: "etcd-2"},
+				{ID: followerID0, Name: "etcd-0"},
+				{ID: followerID1, Name: "etcd-1"},
+			},
+		},
+		memberHealth: []etcdutils.EpHealth{
+			{
+				Ep:     "http://etcd-0.etcd.default.svc.cluster.local:2379",
+				Health: true,
+				Status: &clientv3.StatusResponse{
+					Header:  &etcdserverpb.ResponseHeader{MemberId: followerID0},
+					Leader:  leaderID,
+					Version: "3.5.17",
+				},
+			},
+			{
+				Ep:     "http://etcd-1.etcd.default.svc.cluster.local:2379",
+				Health: true,
+				Status: &clientv3.StatusResponse{
+					Header:  &etcdserverpb.ResponseHeader{MemberId: followerID1},
+					Leader:  leaderID,
+					Version: "3.5.16",
+				},
+			},
+			{
+				Ep:     "http://etcd-2.etcd.default.svc.cluster.local:2379",
+				Health: true,
+				Status: &clientv3.StatusResponse{
+					Header:  &etcdserverpb.ResponseHeader{MemberId: leaderID},
+					Leader:  leaderID,
+					Version: "3.5.17",
+				},
+			},
+		},
+	}
+
+	require.NoError(t, r.updateStatus(t.Context(), state))
+
+	status := ec.Status
+	assert.Equal(t, fmt.Sprintf("%x", leaderID), status.LeaderID)
+	require.Len(t, status.Members, 3)
+
+	leaders := 0
+	for _, m := range status.Members {
+		if m.IsLeader {
+			leaders++
+			assert.Equal(t, status.LeaderID, m.ID, "isLeader member must match status.leaderID")
+		}
+	}
+	assert.Equal(t, 1, leaders, "exactly one member should be leader")
+
+	byName := map[string]ecv1alpha1.MemberStatus{}
+	for _, m := range status.Members {
+		byName[m.Name] = m
+	}
+	assert.True(t, byName["etcd-2"].IsLeader)
+	assert.False(t, byName["etcd-0"].IsLeader)
+	assert.False(t, byName["etcd-1"].IsLeader)
+	assert.Equal(t, "3.5.17", byName["etcd-0"].Version)
+	assert.Equal(t, "3.5.16", byName["etcd-1"].Version)
+	assert.Equal(t, "3.5.17", byName["etcd-2"].Version)
+	for _, m := range status.Members {
+		assert.True(t, m.IsHealthy, "member %s should be healthy", m.Name)
+	}
 }


### PR DESCRIPTION
On a healthy 3-member cluster, `status.leaderID` reported one member (`799d0cd98f5cac87`) while `status.members[]` simultaneously marked a different member with `isLeader: true`. `updateStatus` paired `memberListResp.Members` (ordered by member ID) with `memberHealth` (ordered by endpoint) by index, so `isLeader`/`isHealthy`/`version` could attach to the wrong member. Health entries are now looked up by `Status.Header.MemberId`, and both `members[].isLeader` and `status.leaderID` derive from the same `FindLeaderStatus` result. Added a unit test with an ID-ordered member list and endpoint-ordered health report that fails on the previous code and passes with this change.

---

### PR series — operability fixes & TLS
<!-- pr-stack:begin -->
Small single-purpose PRs from live kind-cluster testing of the operator. Each stands alone unless an *After* is listed. → = this PR.

| | PR | Lands | After |
|---|----|-------|-------|
| | **Reviewable now — small, any order** | | |
| 🟢 | #374 | Requeue instead of swallowing the client-cert provisioning error | — |
| 🟢 | #391 | Grant `events.k8s.io` RBAC so operator Events are actually recorded | — |
| 🟢→ | #392 | Correlate `members[]`/`leaderID` from one health snapshot (consistent leader) | — |
| 🟢 | #393 | Propagate user-supplied `altNames.ipAddresses` into certificates | — |
| 🟢 | #394 | Accept day-suffix `validityDuration` (`365d`, `100d12h`) as documented | — |
| 🟢 | #395 | Surface early reconcile errors as a `Degraded` condition (was empty status) | — |
| 🟢 | #379 | Configurable reconcile worker pool (`--max-concurrent-reconciles`) | — |
| 🟢 | #369 | kind-based stress/scale e2e harness (1/3/7 members, churn, quorum watcher) | — |
| 🟢 | #398 | `podTemplate.spec` scheduling fields: topologySpread, resources, priorityClass, schedulerName | — |
| 🟢 | #397 | First-class Helm chart covering the full `config/` surface | — |
| 🟢 | #399 | Quorum-aware PodDisruptionBudget per EtcdCluster | — |
| 🟢 | #400 | Scale-in removes the right member and transfers leadership first | — |
| 🟢 | #401 | Backend quota + auto-compaction spec fields, NOSPACE alarm surfacing | — |
| 🟢 | #402 | Reconcile-loop gates replace the blocking StatefulSet-ready wait | — |
| 🟢 | #403 | Quorum-gated one-pod-at-a-time version upgrades via OnDelete | — |
| | **TLS stack — in order** | | |
| 🟢 | #376 | Independent `spec.tls.{peer,client}` surfaces (breaking alpha API) | — |
| ⚪ | #377 | `TLSReady` condition + TLS lifecycle Events | #376 |
| ⚪ | #378 | Multi-member TLS quorum e2e + `PeerCANotShared` | #377 |
| | **EtcdMirror — in order** | | |
| 🟢 | #406 | `EtcdMirror` CRD: one-way cross-cluster replication API (types + CEL) | — |
| 🟢 | #407 | `pkg/mirroragent` replication engine (fenced checkpoint-in-target) | #406 |
| 🟢 | #408 | Periodic reconciliation pass wired into the engine's steady-state loop | #407 |
| 🟢 | #412 | `mirror-agent` binary: config/TLS-reload/statusz/metrics + kind e2e | #408 |
| 🟢 | #413 | EtcdMirror controller: Deployment rendering, statusz-driven conditions, guards, fenced finalizer | #412 |
| 🟢 | #414 | CRD/sample/editor+viewer-role kustomize wiring | #413 |
| 🟢 | #415 | Controller-side phase/condition gauges, shipped PrometheusRule + dashboard | #414 |
| 🟢 | #416 | Full-lifecycle kind e2e: fence overlap, compaction+prune, restart resume, cert rotation, cutover/reversal | #415 |
| | **Parked as drafts pending #363** | | |
| ⚪ | #382 | Per-cluster domain metrics on the operator `/metrics` endpoint | — |
| ⚪ | #384 | EtcdCluster admission webhooks (consolidating with #328) | #363 |
| ⚪ | #386 | `EtcdBackup` CR → object storage (S3/GCS) | #363 |
| ⚪ | #387 | Automatic quorum-loss disaster recovery (bootstrap-latch guarded) | #363 |

🟢 ready · ⚪ draft
<!-- pr-stack:end -->