### PR TITLE
fix: accept day suffix in validityDuration as documented

### DIFF
--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"maps"
 	"net"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -576,12 +577,24 @@ func getPeerCertName(etcdClusterName string) string {
 	return peerCertName
 }
 
+// validityDurationDayPrefix matches a leading integer day segment, e.g. "365d" or the "100d" in "100d12h".
+var validityDurationDayPrefix = regexp.MustCompile(`^(\d+)d`)
+
 // parseValidityDuration parses a duration string and returns the parsed duration.
 // If the customizedDuration is empty, it returns the defaultDuration.
+// A leading day segment (e.g. "365d", "100d12h") is expanded to hours, since
+// time.ParseDuration does not support the "d" unit.
 // Returns an error if the duration string cannot be parsed.
 func parseValidityDuration(customizedDuration string, defaultDuration time.Duration) (time.Duration, error) {
 	if customizedDuration == "" {
 		return defaultDuration, nil
+	}
+	if m := validityDurationDayPrefix.FindStringSubmatch(customizedDuration); m != nil {
+		days, err := strconv.Atoi(m[1])
+		if err != nil {
+			return 0, fmt.Errorf("failed to parse ValidityDuration: %w", err)
+		}
+		customizedDuration = fmt.Sprintf("%dh%s", days*24, customizedDuration[len(m[0]):])
 	}
 	duration, err := time.ParseDuration(customizedDuration)
 	if err != nil {

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -1090,3 +1090,33 @@ func TestCreateCMCertificateConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestParseValidityDuration(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    time.Duration
+		expectedErr bool
+	}{
+		{name: "day suffix", input: "365d", expected: 365 * 24 * time.Hour},
+		{name: "days and hours", input: "100d12h", expected: 100*24*time.Hour + 12*time.Hour},
+		{name: "plain go duration", input: "24h", expected: 24 * time.Hour},
+		{name: "minutes", input: "90m", expected: 90 * time.Minute},
+		{name: "empty returns default", input: "", expected: certInterface.DefaultCertManagerValidity},
+		{name: "invalid string", input: "abc", expectedErr: true},
+		{name: "day unit without value", input: "d", expectedErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			duration, err := parseValidityDuration(tt.input, certInterface.DefaultCertManagerValidity)
+			if tt.expectedErr {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, "failed to parse ValidityDuration")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, duration)
+		})
+	}
+}


### PR DESCRIPTION
Setting `validityDuration` to the documented day format (e.g. `365d`, used by both TLS samples in config/samples) makes reconciliation fail permanently with `failed to parse ValidityDuration: time: unknown unit "d" in duration "365d"`, because `parseValidityDuration` delegates directly to `time.ParseDuration`, which does not support the `d` unit the API doc promises (`100d12h`). This change expands a leading day segment to hours before parsing, leaving plain Go durations and the empty-string default untouched. Adds table-driven tests for `parseValidityDuration` covering day-suffix, mixed, plain, default, and invalid inputs.

---

### PR series — operability fixes & TLS
<!-- pr-stack:begin -->
Small single-purpose PRs from live kind-cluster testing of the operator. Each stands alone unless an *After* is listed. → = this PR.

| | PR | Lands | After |
|---|----|-------|-------|
| | **Reviewable now — small, any order** | | |
| 🟢 | #374 | Requeue instead of swallowing the client-cert provisioning error | — |
| 🟢 | #391 | Grant `events.k8s.io` RBAC so operator Events are actually recorded | — |
| 🟢 | #392 | Correlate `members[]`/`leaderID` from one health snapshot (consistent leader) | — |
| 🟢 | #393 | Propagate user-supplied `altNames.ipAddresses` into certificates | — |
| 🟢→ | #394 | Accept day-suffix `validityDuration` (`365d`, `100d12h`) as documented | — |
| 🟢 | #395 | Surface early reconcile errors as a `Degraded` condition (was empty status) | — |
| 🟢 | #379 | Configurable reconcile worker pool (`--max-concurrent-reconciles`) | — |
| 🟢 | #369 | kind-based stress/scale e2e harness (1/3/7 members, churn, quorum watcher) | — |
| 🟢 | #398 | `podTemplate.spec` scheduling fields: topologySpread, resources, priorityClass, schedulerName | — |
| 🟢 | #397 | First-class Helm chart covering the full `config/` surface | — |
| 🟢 | #399 | Quorum-aware PodDisruptionBudget per EtcdCluster | — |
| 🟢 | #400 | Scale-in removes the right member and transfers leadership first | — |
| 🟢 | #401 | Backend quota + auto-compaction spec fields, NOSPACE alarm surfacing | — |
| 🟢 | #402 | Reconcile-loop gates replace the blocking StatefulSet-ready wait | — |
| 🟢 | #403 | Quorum-gated one-pod-at-a-time version upgrades via OnDelete | — |
| | **TLS stack — in order** | | |
| 🟢 | #376 | Independent `spec.tls.{peer,client}` surfaces (breaking alpha API) | — |
| ⚪ | #377 | `TLSReady` condition + TLS lifecycle Events | #376 |
| ⚪ | #378 | Multi-member TLS quorum e2e + `PeerCANotShared` | #377 |
| | **EtcdMirror — in order** | | |
| 🟢 | #406 | `EtcdMirror` CRD: one-way cross-cluster replication API (types + CEL) | — |
| 🟢 | #407 | `pkg/mirroragent` replication engine (fenced checkpoint-in-target) | #406 |
| 🟢 | #408 | Periodic reconciliation pass wired into the engine's steady-state loop | #407 |
| 🟢 | #412 | `mirror-agent` binary: config/TLS-reload/statusz/metrics + kind e2e | #408 |
| 🟢 | #413 | EtcdMirror controller: Deployment rendering, statusz-driven conditions, guards, fenced finalizer | #412 |
| 🟢 | #414 | CRD/sample/editor+viewer-role kustomize wiring | #413 |
| 🟢 | #415 | Controller-side phase/condition gauges, shipped PrometheusRule + dashboard | #414 |
| 🟢 | #416 | Full-lifecycle kind e2e: fence overlap, compaction+prune, restart resume, cert rotation, cutover/reversal | #415 |
| | **Parked as drafts pending #363** | | |
| ⚪ | #382 | Per-cluster domain metrics on the operator `/metrics` endpoint | — |
| ⚪ | #384 | EtcdCluster admission webhooks (consolidating with #328) | #363 |
| ⚪ | #386 | `EtcdBackup` CR → object storage (S3/GCS) | #363 |
| ⚪ | #387 | Automatic quorum-loss disaster recovery (bootstrap-latch guarded) | #363 |

🟢 ready · ⚪ draft
<!-- pr-stack:end -->