### PR TITLE
fix: surface reconcile errors as Degraded condition on EtcdCluster status

### DIFF
--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -89,7 +89,7 @@ func (r *EtcdClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// Defer status update to ensure it's called regardless of return path
 	defer func() {
 		if state != nil {
-			if statusErr := r.updateStatus(ctx, state); statusErr != nil {
+			if statusErr := r.updateStatus(ctx, state, err); statusErr != nil {
 				// Log but don't override the main reconciliation error
 				log.FromContext(ctx).Error(statusErr, "Failed to update status")
 			}
@@ -109,7 +109,8 @@ func (r *EtcdClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
-	return r.reconcileClusterState(ctx, state)
+	res, err = r.reconcileClusterState(ctx, state)
+	return res, err
 }
 
 // fetchAndValidateState retrieves the EtcdCluster and its StatefulSet and ensures
@@ -161,7 +162,9 @@ func (r *EtcdClusterReconciler) fetchAndValidateState(ctx context.Context, req c
 	if sts != nil {
 		if err := checkStatefulSetControlledByEtcdOperator(ec, sts); err != nil {
 			logger.Error(err, "StatefulSet is not controlled by this EtcdCluster resource")
-			return nil, ctrl.Result{}, err
+			// Omit the foreign StatefulSet so the status update cannot derive
+			// replica counts or Progressing from a resource we do not manage.
+			return &reconcileState{cluster: ec}, ctrl.Result{}, err
 		}
 
 		// If the version to be reconciled is unsupported, throw an error.
@@ -202,7 +205,7 @@ func (r *EtcdClusterReconciler) fetchAndValidateState(ctx context.Context, req c
 						"current", currentVersion,
 						"target", targetVersion,
 					)
-					return nil, ctrl.Result{}, err
+					return &reconcileState{cluster: ec, sts: sts}, ctrl.Result{}, err
 				}
 				logger.Info("upgrade path between current and target versions is supported",
 					"current", currentVersion,
@@ -404,7 +407,7 @@ func (r *EtcdClusterReconciler) reconcileClusterState(ctx context.Context, s *re
 
 // updateStatus updates the EtcdCluster status based on observed state.
 // It is called at the end of each reconciliation cycle.
-func (r *EtcdClusterReconciler) updateStatus(ctx context.Context, s *reconcileState) error {
+func (r *EtcdClusterReconciler) updateStatus(ctx context.Context, s *reconcileState, reconcileErr error) error {
 	logger := log.FromContext(ctx)
 
 	// Update ObservedGeneration
@@ -459,7 +462,7 @@ func (r *EtcdClusterReconciler) updateStatus(ctx context.Context, s *reconcileSt
 	}
 
 	// Update conditions
-	r.updateConditions(s)
+	r.updateConditions(s, reconcileErr)
 
 	// Persist status update
 	if err := r.Status().Update(ctx, s.cluster); err != nil {
@@ -471,7 +474,8 @@ func (r *EtcdClusterReconciler) updateStatus(ctx context.Context, s *reconcileSt
 }
 
 // updateConditions sets the standard Kubernetes conditions based on observed state
-func (r *EtcdClusterReconciler) updateConditions(s *reconcileState) {
+// and on the error, if any, returned by the current reconciliation cycle.
+func (r *EtcdClusterReconciler) updateConditions(s *reconcileState, reconcileErr error) {
 	now := metav1.Now()
 
 	// Determine if cluster is available (has quorum and healthy members)
@@ -562,6 +566,13 @@ func (r *EtcdClusterReconciler) updateConditions(s *reconcileState) {
 			degradedCondition.Reason = "UnhealthyMembers"
 			degradedCondition.Message = fmt.Sprintf("Unhealthy members: %s", strings.Join(unhealthyMembers, ", "))
 		}
+	}
+
+	// Surface the reconcile error so a failing cluster is visible via kubectl.
+	if reconcileErr != nil {
+		degradedCondition.Status = metav1.ConditionTrue
+		degradedCondition.Reason = "ReconcileFailed"
+		degradedCondition.Message = reconcileErr.Error()
 	}
 
 	// Update or append conditions

--- a/internal/controller/etcdcluster_controller_test.go
+++ b/internal/controller/etcdcluster_controller_test.go
@@ -17,12 +17,16 @@ limitations under the License.
 package controller
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -31,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	ecv1alpha1 "go.etcd.io/etcd-operator/api/v1alpha1"
+	"go.etcd.io/etcd-operator/internal/etcdutils"
 )
 
 // TestFetchAndValidateState describes the scenarios for the fetchAndValidateState
@@ -130,7 +135,8 @@ func TestFetchAndValidateState(t *testing.T) {
 			},
 			req: ctrl.Request{NamespacedName: types.NamespacedName{Name: "etcd", Namespace: "default"}},
 			assert: func(t *testing.T, state *reconcileState, res ctrl.Result, err error, _ *ecv1alpha1.EtcdCluster, _ *appsv1.StatefulSet) {
-				assert.Nil(t, state)
+				require.NotNil(t, state)
+				assert.Nil(t, state.sts) // foreign StatefulSet must not leak into status
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), "not controlled")
 				assert.Equal(t, ctrl.Result{}, res)
@@ -254,7 +260,7 @@ func TestFetchAndValidateState(t *testing.T) {
 			},
 			req: ctrl.Request{NamespacedName: types.NamespacedName{Name: "etcd", Namespace: "default"}},
 			assert: func(t *testing.T, state *reconcileState, res ctrl.Result, err error, ec *ecv1alpha1.EtcdCluster, sts *appsv1.StatefulSet) {
-				require.Nil(t, state)
+				require.NotNil(t, state)
 				assert.Error(t, err)
 				assert.Equal(t, ctrl.Result{}, res)
 			},
@@ -295,7 +301,7 @@ func TestFetchAndValidateState(t *testing.T) {
 			},
 			req: ctrl.Request{NamespacedName: types.NamespacedName{Name: "etcd", Namespace: "default"}},
 			assert: func(t *testing.T, state *reconcileState, res ctrl.Result, err error, ec *ecv1alpha1.EtcdCluster, sts *appsv1.StatefulSet) {
-				require.Nil(t, state)
+				require.NotNil(t, state)
 				assert.Error(t, err)
 				assert.Equal(t, ctrl.Result{}, res)
 			},
@@ -570,4 +576,155 @@ func TestBootstrapStatefulSet(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, storedCM.Data, fetchedCM.Data)
 	})
+}
+
+// TestReconcileErrorSetsDegradedCondition verifies that a reconcile error is
+// surfaced on the EtcdCluster status as a Degraded=True condition instead of
+// leaving the status empty.
+func TestReconcileErrorSetsDegradedCondition(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	_ = ecv1alpha1.AddToScheme(scheme)
+
+	ec := &ecv1alpha1.EtcdCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "etcd",
+			Namespace: "default",
+			UID:       "1",
+		},
+		Spec: ecv1alpha1.EtcdClusterSpec{
+			Size:    1,
+			Version: "3.5.17",
+			TLS: &ecv1alpha1.TLSCertificate{
+				Provider: "auto",
+				ProviderCfg: ecv1alpha1.ProviderConfig{
+					AutoCfg: &ecv1alpha1.ProviderAutoConfig{
+						CommonConfig: ecv1alpha1.CommonConfig{
+							ValidityDuration: "90days", // not a valid time.Duration
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&ecv1alpha1.EtcdCluster{}).
+		WithObjects(ec).
+		Build()
+	r := &EtcdClusterReconciler{Client: fakeClient, Scheme: scheme}
+
+	_, err := r.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: ec.Name, Namespace: ec.Namespace},
+	})
+	require.Error(t, err)
+
+	updated := &ecv1alpha1.EtcdCluster{}
+	require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKeyFromObject(ec), updated))
+
+	degraded := meta.FindStatusCondition(updated.Status.Conditions, "Degraded")
+	require.NotNil(t, degraded)
+	assert.Equal(t, metav1.ConditionTrue, degraded.Status)
+	assert.Equal(t, "ReconcileFailed", degraded.Reason)
+	assert.Contains(t, degraded.Message, "failed to parse ValidityDuration")
+}
+
+// TestReconcileNotOwnedStatefulSetStatus verifies that when reconciliation
+// fails because the StatefulSet is not owned by the EtcdCluster, the status
+// reports Degraded=ReconcileFailed without leaking the foreign StatefulSet's
+// replica counts or a Progressing=ScalingInProgress condition.
+func TestReconcileNotOwnedStatefulSetStatus(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	_ = ecv1alpha1.AddToScheme(scheme)
+
+	ec := &ecv1alpha1.EtcdCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "etcd",
+			Namespace: "default",
+			UID:       "1",
+		},
+		Spec: ecv1alpha1.EtcdClusterSpec{Size: 3, Version: "3.5.17"},
+	}
+	replicas := int32(5)
+	foreignSTS := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "etcd",
+			Namespace: "default",
+		},
+		Spec:   appsv1.StatefulSetSpec{Replicas: &replicas},
+		Status: appsv1.StatefulSetStatus{ReadyReplicas: replicas},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&ecv1alpha1.EtcdCluster{}).
+		WithObjects(ec, foreignSTS).
+		Build()
+	r := &EtcdClusterReconciler{Client: fakeClient, Scheme: scheme}
+
+	_, err := r.Reconcile(t.Context(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: ec.Name, Namespace: ec.Namespace},
+	})
+	require.Error(t, err)
+
+	updated := &ecv1alpha1.EtcdCluster{}
+	require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKeyFromObject(ec), updated))
+
+	degraded := meta.FindStatusCondition(updated.Status.Conditions, "Degraded")
+	require.NotNil(t, degraded)
+	assert.Equal(t, metav1.ConditionTrue, degraded.Status)
+	assert.Equal(t, "ReconcileFailed", degraded.Reason)
+
+	assert.Equal(t, int32(0), updated.Status.CurrentReplicas)
+	assert.Equal(t, int32(0), updated.Status.ReadyReplicas)
+	progressing := meta.FindStatusCondition(updated.Status.Conditions, "Progressing")
+	require.NotNil(t, progressing)
+	assert.Equal(t, metav1.ConditionFalse, progressing.Status)
+	assert.NotEqual(t, "ScalingInProgress", progressing.Reason)
+}
+
+// TestUpdateConditionsReconcileError verifies that a reconcile error forces
+// Degraded=ReconcileFailed even when all members are healthy, and that
+// Degraded reverts to False once the error clears.
+func TestUpdateConditionsReconcileError(t *testing.T) {
+	healthyState := func() *reconcileState {
+		return &reconcileState{
+			cluster: &ecv1alpha1.EtcdCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "etcd", Namespace: "default"},
+				Spec:       ecv1alpha1.EtcdClusterSpec{Size: 1, Version: "3.5.17"},
+			},
+			memberListResp: &clientv3.MemberListResponse{
+				Members: []*etcdserverpb.Member{{ID: 1, Name: "etcd-0"}},
+			},
+			memberHealth: []etcdutils.EpHealth{
+				{
+					Ep:     "http://etcd-0:2379",
+					Health: true,
+					Status: &clientv3.StatusResponse{
+						Header: &etcdserverpb.ResponseHeader{MemberId: 1},
+						Leader: 1,
+					},
+				},
+			},
+		}
+	}
+	r := &EtcdClusterReconciler{}
+
+	s := healthyState()
+	r.updateConditions(s, errors.New("couldn't find leader"))
+	degraded := meta.FindStatusCondition(s.cluster.Status.Conditions, "Degraded")
+	require.NotNil(t, degraded)
+	assert.Equal(t, metav1.ConditionTrue, degraded.Status)
+	assert.Equal(t, "ReconcileFailed", degraded.Reason)
+	assert.Equal(t, "couldn't find leader", degraded.Message)
+
+	r.updateConditions(s, nil)
+	degraded = meta.FindStatusCondition(s.cluster.Status.Conditions, "Degraded")
+	require.NotNil(t, degraded)
+	assert.Equal(t, metav1.ConditionFalse, degraded.Status)
+	assert.Equal(t, "ClusterHealthy", degraded.Reason)
 }


### PR DESCRIPTION
An EtcdCluster failing every reconcile could be invisible in .status: the ownership and unsupported-upgrade-path errors returned a nil state so the deferred status update never ran (completely empty status), while errors from later phases — e.g. an invalid TLS validityDuration failing during certificate creation — did update status but reported a misleading Degraded=False/ClusterHealthy because conditions were derived from member health alone. This returns a populated state on those early error paths (omitting a StatefulSet the operator does not own so its replica counts cannot leak into status), captures the cluster-state phase error for the deferred update, and threads the reconcile error into the status update so Degraded=True with reason ReconcileFailed and the error message. Tested with go test ./internal/... including new Reconcile-level tests through a fake client with the status subresource.

---

### PR series — operability fixes & TLS
<!-- pr-stack:begin -->
Small single-purpose PRs from live kind-cluster testing of the operator. Each stands alone unless an *After* is listed. → = this PR.

| | PR | Lands | After |
|---|----|-------|-------|
| | **Reviewable now — small, any order** | | |
| 🟢 | #374 | Requeue instead of swallowing the client-cert provisioning error | — |
| 🟢 | #391 | Grant `events.k8s.io` RBAC so operator Events are actually recorded | — |
| 🟢 | #392 | Correlate `members[]`/`leaderID` from one health snapshot (consistent leader) | — |
| 🟢 | #393 | Propagate user-supplied `altNames.ipAddresses` into certificates | — |
| 🟢 | #394 | Accept day-suffix `validityDuration` (`365d`, `100d12h`) as documented | — |
| 🟢→ | #395 | Surface early reconcile errors as a `Degraded` condition (was empty status) | — |
| 🟢 | #379 | Configurable reconcile worker pool (`--max-concurrent-reconciles`) | — |
| 🟢 | #369 | kind-based stress/scale e2e harness (1/3/7 members, churn, quorum watcher) | — |
| 🟢 | #398 | `podTemplate.spec` scheduling fields: topologySpread, resources, priorityClass, schedulerName | — |
| 🟢 | #397 | First-class Helm chart covering the full `config/` surface | — |
| 🟢 | #399 | Quorum-aware PodDisruptionBudget per EtcdCluster | — |
| 🟢 | #400 | Scale-in removes the right member and transfers leadership first | — |
| 🟢 | #401 | Backend quota + auto-compaction spec fields, NOSPACE alarm surfacing | — |
| 🟢 | #402 | Reconcile-loop gates replace the blocking StatefulSet-ready wait | — |
| 🟢 | #403 | Quorum-gated one-pod-at-a-time version upgrades via OnDelete | — |
| | **TLS stack — in order** | | |
| 🟢 | #376 | Independent `spec.tls.{peer,client}` surfaces (breaking alpha API) | — |
| ⚪ | #377 | `TLSReady` condition + TLS lifecycle Events | #376 |
| ⚪ | #378 | Multi-member TLS quorum e2e + `PeerCANotShared` | #377 |
| | **EtcdMirror — in order** | | |
| 🟢 | #406 | `EtcdMirror` CRD: one-way cross-cluster replication API (types + CEL) | — |
| 🟢 | #407 | `pkg/mirroragent` replication engine (fenced checkpoint-in-target) | #406 |
| 🟢 | #408 | Periodic reconciliation pass wired into the engine's steady-state loop | #407 |
| 🟢 | #412 | `mirror-agent` binary: config/TLS-reload/statusz/metrics + kind e2e | #408 |
| 🟢 | #413 | EtcdMirror controller: Deployment rendering, statusz-driven conditions, guards, fenced finalizer | #412 |
| 🟢 | #414 | CRD/sample/editor+viewer-role kustomize wiring | #413 |
| 🟢 | #415 | Controller-side phase/condition gauges, shipped PrometheusRule + dashboard | #414 |
| 🟢 | #416 | Full-lifecycle kind e2e: fence overlap, compaction+prune, restart resume, cert rotation, cutover/reversal | #415 |
| | **Parked as drafts pending #363** | | |
| ⚪ | #382 | Per-cluster domain metrics on the operator `/metrics` endpoint | — |
| ⚪ | #384 | EtcdCluster admission webhooks (consolidating with #328) | #363 |
| ⚪ | #386 | `EtcdBackup` CR → object storage (S3/GCS) | #363 |
| ⚪ | #387 | Automatic quorum-loss disaster recovery (bootstrap-latch guarded) | #363 |

🟢 ready · ⚪ draft
<!-- pr-stack:end -->