### PR TITLE
feat: add a Helm chart covering the full config/ surface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,3 +280,26 @@ mv $(1) $(1)-$(3) ;\
 } ;\
 ln -sf $(1)-$(3) $(1)
 endef
+
+##@ Helm Chart
+
+HELM ?= helm
+HELM_CHART = charts/etcd-operator
+
+.PHONY: helm-crds
+helm-crds: ## Copy config/crd/bases into the chart's templates/crds, wrapped in a crds.enabled guard. Run after `make manifests`.
+	@mkdir -p $(HELM_CHART)/templates/crds
+	@rm -f $(HELM_CHART)/templates/crds/*.yaml
+	@for f in config/crd/bases/*.yaml; do \
+		out=$(HELM_CHART)/templates/crds/$$(basename $$f); \
+		echo "syncing $$f -> $$out"; \
+		{ \
+			echo '{{- if .Values.crds.enabled }}'; \
+			sed -e 's/{{/{{ "{{" }}/g' $$f; \
+			echo '{{- end }}'; \
+		} > $$out; \
+	done
+
+.PHONY: helm-lint
+helm-lint: ## Lint the Helm chart.
+	$(HELM) lint $(HELM_CHART)

--- a/charts/etcd-operator/.helmignore
+++ b/charts/etcd-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/etcd-operator/Chart.yaml
+++ b/charts/etcd-operator/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: etcd-operator
+description: Operator managing etcd clusters on Kubernetes
+type: application
+version: 0.1.0
+appVersion: "v0.2.0"
+kubeVersion: ">=1.30.0-0"
+sources:
+  - https://github.com/etcd-io/etcd-operator

--- a/charts/etcd-operator/README.md
+++ b/charts/etcd-operator/README.md
@@ -1,0 +1,95 @@
+# etcd-operator Helm chart
+
+Installs the etcd-operator: the EtcdCluster CRD, controller Deployment, RBAC,
+metrics Service, and optionally the admission webhooks (server and
+configurations). Covers the same surface as `kustomize build config/default`.
+
+```sh
+helm install etcd-operator ./charts/etcd-operator \
+  --namespace etcd-operator-system --create-namespace
+```
+
+## Values
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `nameOverride` / `fullnameOverride` | `""` | Usual name overrides. |
+| `crds.enabled` | `true` | Install the CRDs (`templates/crds/`, synced from `config/crd/bases` by `make helm-crds`). |
+| `controller.enabled` | `true` | Render the runtime: Deployment, ServiceAccount, RBAC, Services. |
+| `controller.replicas` | `1` | |
+| `controller.image.repository` | `gcr.io/etcd-development/etcd-operator` | |
+| `controller.image.tag` | `""` | Defaults to the chart `appVersion`. |
+| `controller.image.digest` | `""` | Pins `repository@digest`; wins over `tag`. |
+| `controller.image.pullPolicy` | `IfNotPresent` | |
+| `controller.imagePullSecrets` | `[]` | |
+| `controller.operatorImage` | `""` | `OPERATOR_IMAGE` env (image for operator-run utility containers). Defaults to the manager image ref, digest pin included. |
+| `controller.leaderElection` | `true` | `--leader-elect`. |
+| `controller.watchNamespace` | `""` | Scope the operator to one namespace: namespaced Role/RoleBinding there instead of ClusterRole/ClusterRoleBinding, plus `--watch-namespace` / `WATCH_NAMESPACE`. |
+| `controller.restrictClusterIssuer` | `false` | `RESTRICT_CLUSTER_ISSUER=true`: webhook rejects `issuerKind: ClusterIssuer`. |
+| `controller.resources` | see `values.yaml` | |
+| `controller.serviceAccount.annotations` | `{}` | |
+| `metrics.secure` | `true` | HTTPS metrics with authn/authz (installs the metrics-auth ClusterRoles). `false`: plain HTTP, no cluster-scoped metrics RBAC. |
+| `metrics.port` | `8443` | Bind address, metrics Service, and NetworkPolicy port. Convention: `8080` when `secure=false`. |
+| `metrics.serviceMonitor.enabled` | `false` | ServiceMonitor; scheme/auth follow `metrics.secure`. |
+| `metrics.serviceMonitor.additionalLabels` | `{}` | e.g. your Prometheus `release:` selector. |
+| `metrics.networkPolicy.enabled` | `false` | Allow metrics ingress only from namespaces labeled `metrics: enabled`. |
+| `webhook.enabled` | `false` | Webhook server side: webhook Service, serving-cert mount and port 9443 on the Deployment. Off: `ENABLE_WEBHOOKS=false`. |
+| `webhook.certManager.enabled` | `true` | SelfSigned Issuer + serving Certificate; CA-injection annotation on the WebhookConfigurations. |
+| `admissionWebhooks.enabled` | `false` | The cluster-scoped Validating/Mutating WebhookConfigurations. |
+| `admissionWebhooks.namespaceSelector` | `{}` | Constrain the fail-closed webhooks; empty = all namespaces. |
+
+Webhook toggles default off because the `appVersion` operator does not serve
+admission webhooks yet; enable them with an operator build that does
+(etcd-io/etcd-operator#384).
+
+## Split install (CRDs + webhook configurations vs runtime)
+
+Cluster-scoped installs (CRDs, WebhookConfigurations) often deploy through a
+privileged lane while the runtime deploys namespaced — e.g. two ArgoCD
+Applications rendering this chart twice. Both releases must produce the same
+resource names: set the same `fullnameOverride` and target namespace.
+
+Application 1 — cluster-scoped only (CRDs + the two WebhookConfigurations):
+
+```yaml
+fullnameOverride: etcd-operator
+controller:
+  enabled: false
+admissionWebhooks:
+  enabled: true
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: kv
+```
+
+Application 2 — runtime only, in namespace `kv`:
+
+```yaml
+fullnameOverride: etcd-operator
+crds:
+  enabled: false
+webhook:
+  enabled: true
+```
+
+## Namespace-scoped operator
+
+```yaml
+controller:
+  watchNamespace: kv
+  restrictClusterIssuer: true
+metrics:
+  secure: false
+  port: 8080
+```
+
+Renders a Role/RoleBinding in `kv` instead of the manager
+ClusterRole/ClusterRoleBinding and drops all other cluster-scoped RBAC.
+
+## CRD sync
+
+`templates/crds/` is generated — never edit it by hand:
+
+```sh
+make manifests helm-crds
+```

--- a/charts/etcd-operator/templates/_helpers.tpl
+++ b/charts/etcd-operator/templates/_helpers.tpl
@@ -1,0 +1,57 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "etcd-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name, truncated at 63 chars.
+*/}}
+{{- define "etcd-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "etcd-operator.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "etcd-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "etcd-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "etcd-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Manager image ref: digest pin wins over tag; tag defaults to appVersion.
+*/}}
+{{- define "etcd-operator.image" -}}
+{{- if .Values.controller.image.digest -}}
+{{ .Values.controller.image.repository }}@{{ .Values.controller.image.digest }}
+{{- else -}}
+{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag | default .Chart.AppVersion }}
+{{- end -}}
+{{- end }}
+
+{{- define "etcd-operator.serviceAccountName" -}}
+{{ include "etcd-operator.fullname" . }}
+{{- end }}

--- a/charts/etcd-operator/templates/admission-webhooks.yaml
+++ b/charts/etcd-operator/templates/admission-webhooks.yaml
@@ -1,0 +1,94 @@
+{{- if .Values.admissionWebhooks.enabled }}
+{{/*
+From config/webhook/manifests.yaml. The objectSelector is the per-object
+break-glass opt-out for the fail-closed webhooks: label an EtcdCluster
+etcd.operator.etcd.io/skip-webhooks=true to bypass admission for that object.
+*/}}
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ include "etcd-operator.fullname" . }}-mutating-webhook-configuration
+  labels:
+    {{- include "etcd-operator.labels" . | nindent 4 }}
+  {{- if .Values.webhook.certManager.enabled }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "etcd-operator.fullname" . }}-serving-cert
+  {{- end }}
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: {{ include "etcd-operator.fullname" . }}-webhook-service
+        namespace: {{ .Release.Namespace }}
+        path: /mutate-operator-etcd-io-v1alpha1-etcdcluster
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    name: metcdcluster-v1alpha1.kb.io
+    {{- with .Values.admissionWebhooks.namespaceSelector }}
+    namespaceSelector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    objectSelector:
+      matchExpressions:
+        - key: etcd.operator.etcd.io/skip-webhooks
+          operator: NotIn
+          values:
+            - "true"
+    rules:
+      - apiGroups:
+          - operator.etcd.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - etcdclusters
+    sideEffects: None
+    timeoutSeconds: 10
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ include "etcd-operator.fullname" . }}-validating-webhook-configuration
+  labels:
+    {{- include "etcd-operator.labels" . | nindent 4 }}
+  {{- if .Values.webhook.certManager.enabled }}
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "etcd-operator.fullname" . }}-serving-cert
+  {{- end }}
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: {{ include "etcd-operator.fullname" . }}-webhook-service
+        namespace: {{ .Release.Namespace }}
+        path: /validate-operator-etcd-io-v1alpha1-etcdcluster
+    failurePolicy: Fail
+    matchPolicy: Equivalent
+    name: vetcdcluster-v1alpha1.kb.io
+    {{- with .Values.admissionWebhooks.namespaceSelector }}
+    namespaceSelector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    objectSelector:
+      matchExpressions:
+        - key: etcd.operator.etcd.io/skip-webhooks
+          operator: NotIn
+          values:
+            - "true"
+    rules:
+      - apiGroups:
+          - operator.etcd.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - etcdclusters
+    sideEffects: None
+    timeoutSeconds: 10
+{{- end }}

--- a/charts/etcd-operator/templates/crds/operator.etcd.io_etcdclusters.yaml
+++ b/charts/etcd-operator/templates/crds/operator.etcd.io_etcdclusters.yaml
@@ -1,0 +1,1342 @@
+{{- if .Values.crds.enabled }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+  name: etcdclusters.operator.etcd.io
+spec:
+  group: operator.etcd.io
+  names:
+    kind: EtcdCluster
+    listKind: EtcdClusterList
+    plural: etcdclusters
+    singular: etcdcluster
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: EtcdCluster is the Schema for the etcdclusters API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: EtcdClusterSpec defines the desired state of EtcdCluster.
+            properties:
+              etcdOptions:
+                description: etcd configuration options are passed as command line
+                  arguments to the etcd container, refer to etcd documentation for
+                  configuration options applicable for the version of etcd being used.
+                items:
+                  type: string
+                type: array
+              imageRegistry:
+                description: |-
+                  ImageRegistry specifies the container registry that hosts the etcd images.
+                  If unset, it defaults to the value provided via the controller's
+                  --image-registry flag, which itself defaults to "gcr.io/etcd-development/etcd".
+                type: string
+              podTemplate:
+                description: PodTemplate is the pod template to use for the etcd cluster.
+                properties:
+                  metadata:
+                    description: Metadata is the metadata to add to the pod.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  spec:
+                    properties:
+                      affinity:
+                        description: Affinity is a group of affinity scheduling rules.
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: |-
+                                    An empty preferred scheduling term matches all objects with implicit weight 0
+                                    (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to an update), the system
+                                  may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: |-
+                                        A null or empty node selector term matches no objects. The requirements of
+                                        them are ANDed.
+                                        The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the anti-affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and subtracting
+                                  "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the anti-affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the anti-affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      tolerations:
+                        items:
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
+                                Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                              type: string
+                            tolerationSeconds:
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              size:
+                description: Size is the expected size of the etcd cluster.
+                minimum: 1
+                type: integer
+              storageSpec:
+                description: StorageSpec is the name of the StorageSpec to use for
+                  the etcd cluster. If not provided, then each POD just uses the temporary
+                  storage inside the container.
+                properties:
+                  accessModes:
+                    type: string
+                  pvcName:
+                    type: string
+                  storageClassName:
+                    type: string
+                  volumeSizeLimit:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  volumeSizeRequest:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                required:
+                - volumeSizeRequest
+                type: object
+              tls:
+                description: TLS is the TLS certificate configuration to use for the
+                  etcd cluster and etcd operator.
+                properties:
+                  provider:
+                    type: string
+                  providerCfg:
+                    properties:
+                      autoCfg:
+                        properties:
+                          altNames:
+                            description: |-
+                              AltNames contains the domain names and IP addresses that will be added
+                              to the x509 certificate SubAltNames fields. The values will be passed
+                              directly to the x509.Certificate object.
+                            properties:
+                              dnsNames:
+                                description: |-
+                                  DNSNames is the expected array of DNS subject alternative names.
+                                  if empty defaults to $(POD_NAME).$(ETCD_CLUSTER_NAME).$(POD_NAMESPACE).svc.cluster.local
+                                items:
+                                  type: string
+                                type: array
+                              ipAddresses:
+                                description: IPs is the expected array of IP address
+                                  subject alternative names.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          caBundleSecret:
+                            description: |-
+                              CABundleSecret is the expected secret name with CABundle present. It's used
+                              by each etcd POD to verify TLS communications with its peers or clients. If it isn't
+                              provided, the CA included in the secret generated by certificate provider will be
+                              used instead if present; otherwise, there is no way to verify TLS communications.
+                            type: string
+                          commonName:
+                            description: |-
+                              CommonName is the expected common name X509 certificate subject attribute.
+                              Should have a length of 64 characters or fewer to avoid generating invalid CSRs.
+                            type: string
+                          organizations:
+                            description: Organization is the expected array of Organization
+                              names to be used on the Certificate.
+                            items:
+                              type: string
+                            type: array
+                          validityDuration:
+                            description: |-
+                              ValidityDuration is the expected duration until which the certificate will be valid,
+                              expects in human-readable duration: 100d12h, if empty defaults to 90d for cert-manager
+                              and 365d for auto as per: https://github.com/etcd-io/etcd/blob/b87bc1c3a275d7d4904f4d201b963a2de2264f0d/client/pkg/transport/listener.go#L275
+                            type: string
+                        type: object
+                      certManagerCfg:
+                        properties:
+                          altNames:
+                            description: |-
+                              AltNames contains the domain names and IP addresses that will be added
+                              to the x509 certificate SubAltNames fields. The values will be passed
+                              directly to the x509.Certificate object.
+                            properties:
+                              dnsNames:
+                                description: |-
+                                  DNSNames is the expected array of DNS subject alternative names.
+                                  if empty defaults to $(POD_NAME).$(ETCD_CLUSTER_NAME).$(POD_NAMESPACE).svc.cluster.local
+                                items:
+                                  type: string
+                                type: array
+                              ipAddresses:
+                                description: IPs is the expected array of IP address
+                                  subject alternative names.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          caBundleSecret:
+                            description: |-
+                              CABundleSecret is the expected secret name with CABundle present. It's used
+                              by each etcd POD to verify TLS communications with its peers or clients. If it isn't
+                              provided, the CA included in the secret generated by certificate provider will be
+                              used instead if present; otherwise, there is no way to verify TLS communications.
+                            type: string
+                          commonName:
+                            description: |-
+                              CommonName is the expected common name X509 certificate subject attribute.
+                              Should have a length of 64 characters or fewer to avoid generating invalid CSRs.
+                            type: string
+                          issuerKind:
+                            description: IssuerKind is the expected kind of Issuer,
+                              either "ClusterIssuer" or "Issuer"
+                            type: string
+                          issuerName:
+                            description: IssuerName is the expected name of Issuer
+                              required to issue a certificate
+                            type: string
+                          organizations:
+                            description: Organization is the expected array of Organization
+                              names to be used on the Certificate.
+                            items:
+                              type: string
+                            type: array
+                          validityDuration:
+                            description: |-
+                              ValidityDuration is the expected duration until which the certificate will be valid,
+                              expects in human-readable duration: 100d12h, if empty defaults to 90d for cert-manager
+                              and 365d for auto as per: https://github.com/etcd-io/etcd/blob/b87bc1c3a275d7d4904f4d201b963a2de2264f0d/client/pkg/transport/listener.go#L275
+                            type: string
+                        required:
+                        - issuerKind
+                        - issuerName
+                        type: object
+                    type: object
+                type: object
+              version:
+                description: Version is the expected version of the etcd container
+                  image.
+                type: string
+            required:
+            - size
+            - version
+            type: object
+          status:
+            description: EtcdClusterStatus defines the observed state of EtcdCluster.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the EtcdCluster's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              currentReplicas:
+                description: |-
+                  CurrentReplicas is the number of etcd pods managed by the StatefulSet for this cluster.
+                  This reflects the .spec.replicas of the underlying StatefulSet.
+                format: int32
+                type: integer
+              currentVersion:
+                description: |-
+                  CurrentVersion is the observed etcd version of the cluster.
+                  This is typically derived from the version of the healthy leader or a consensus among healthy members.
+                type: string
+              leaderID:
+                description: LeaderID is the hex-encoded ID of the current etcd cluster
+                  leader, if one exists and is known.
+                type: string
+              memberCount:
+                description: |-
+                  MemberCount is the number of members currently registered in the etcd cluster,
+                  as reported by the etcd 'member list' API. This may differ from CurrentReplicas
+                  during scaling operations or if members are added/removed outside the operator's direct control.
+                format: int32
+                type: integer
+              members:
+                description: |-
+                  Members provides the status of each individual etcd member.
+                  Alternative listMapKey could be 'name' if 'id' is not always immediately available or stable during init.
+                  However, 'id' is more canonical once a member is part of the cluster.
+                items:
+                  description: MemberStatus defines the observed state of a single
+                    etcd member.
+                  properties:
+                    id:
+                      description: |-
+                        ID is the hex-encoded member ID as reported by etcd.
+                        This is the canonical identifier for an etcd member.
+                      type: string
+                    isHealthy:
+                      description: |-
+                        IsHealthy indicates if the member is considered healthy.
+                        A member is healthy if its etcd /health endpoint is reachable and reports OK,
+                        and its Status endpoint does not report any 'Errors'.
+                      type: boolean
+                    isLeader:
+                      description: IsLeader indicates if this member is currently
+                        the cluster leader.
+                      type: boolean
+                    isLearner:
+                      description: IsLearner indicates if the member is currently
+                        a learner in the etcd cluster.
+                      type: boolean
+                    name:
+                      description: |-
+                        Name of the etcd member, typically the pod name (e.g., "etcd-cluster-example-0").
+                        This can also be the name reported by etcd itself if set.
+                      type: string
+                    version:
+                      description: Version of etcd running on this member.
+                      type: string
+                  required:
+                  - id
+                  - isHealthy
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - id
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  for this EtcdCluster by the controller.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: |-
+                  ReadyReplicas is the number of etcd pods managed by the StatefulSet that are currently ready.
+                  This reflects the .status.readyReplicas of the underlying StatefulSet.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/etcd-operator/templates/deployment.yaml
+++ b/charts/etcd-operator/templates/deployment.yaml
@@ -1,0 +1,98 @@
+{{- if .Values.controller.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "etcd-operator.fullname" . }}
+  labels:
+    {{- include "etcd-operator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.controller.replicas }}
+  selector:
+    matchLabels:
+      {{- include "etcd-operator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        {{- include "etcd-operator.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.controller.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "etcd-operator.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+      terminationGracePeriodSeconds: 10
+      containers:
+        - name: manager
+          image: {{ include "etcd-operator.image" . }}
+          imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+          command:
+            - /manager
+          args:
+            {{- if .Values.controller.leaderElection }}
+            - --leader-elect
+            {{- end }}
+            - --health-probe-bind-address=:8081
+            - --metrics-bind-address=:{{ .Values.metrics.port }}
+            {{- if not .Values.metrics.secure }}
+            - --metrics-secure=false
+            {{- end }}
+            {{- with .Values.controller.watchNamespace }}
+            - --watch-namespace={{ . }}
+            {{- end }}
+          env:
+            - name: OPERATOR_IMAGE
+              value: {{ .Values.controller.operatorImage | default (include "etcd-operator.image" .) }}
+            {{- with .Values.controller.watchNamespace }}
+            - name: WATCH_NAMESPACE
+              value: {{ . | quote }}
+            {{- end }}
+            {{- if .Values.controller.restrictClusterIssuer }}
+            - name: RESTRICT_CLUSTER_ISSUER
+              value: "true"
+            {{- end }}
+            {{- if not .Values.webhook.enabled }}
+            - name: ENABLE_WEBHOOKS
+              value: "false"
+            {{- end }}
+          {{- if .Values.webhook.enabled }}
+          ports:
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
+          {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.controller.resources | nindent 12 }}
+          {{- if .Values.webhook.enabled }}
+          volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: webhook-certs
+              readOnly: true
+          {{- end }}
+      {{- if .Values.webhook.enabled }}
+      volumes:
+        - name: webhook-certs
+          secret:
+            secretName: {{ include "etcd-operator.fullname" . }}-webhook-server-cert
+      {{- end }}
+{{- end }}

--- a/charts/etcd-operator/templates/etcdcluster-user-rbac.yaml
+++ b/charts/etcd-operator/templates/etcdcluster-user-rbac.yaml
@@ -1,0 +1,54 @@
+{{- if and .Values.controller.enabled (not .Values.controller.watchNamespace) }}
+{{/*
+Convenience roles for end users, from config/rbac/etcdcluster_{editor,viewer}_role.yaml.
+Skipped in watchNamespace mode: the namespaced install makes no cluster-scoped writes
+beyond the CRDs.
+*/}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "etcd-operator.fullname" . }}-etcdcluster-editor-role
+  labels:
+    {{- include "etcd-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - operator.etcd.io
+  resources:
+  - etcdclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operator.etcd.io
+  resources:
+  - etcdclusters/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "etcd-operator.fullname" . }}-etcdcluster-viewer-role
+  labels:
+    {{- include "etcd-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - operator.etcd.io
+  resources:
+  - etcdclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - operator.etcd.io
+  resources:
+  - etcdclusters/status
+  verbs:
+  - get
+{{- end }}

--- a/charts/etcd-operator/templates/leader-election-rbac.yaml
+++ b/charts/etcd-operator/templates/leader-election-rbac.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.controller.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "etcd-operator.fullname" . }}-leader-election-role
+  labels:
+    {{- include "etcd-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "etcd-operator.fullname" . }}-leader-election-rolebinding
+  labels:
+    {{- include "etcd-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "etcd-operator.fullname" . }}-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "etcd-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/etcd-operator/templates/manager-rbac.yaml
+++ b/charts/etcd-operator/templates/manager-rbac.yaml
@@ -1,0 +1,231 @@
+{{- if .Values.controller.enabled }}
+{{- if .Values.controller.watchNamespace }}
+{{/*
+Namespace-scoped variant of config/rbac/role.yaml: kind Role in the watched
+namespace; the cluster-scoped cert-manager `clusterissuers` rule is dropped
+(pair with controller.restrictClusterIssuer so the webhook rejects
+issuerKind: ClusterIssuer at admission); adds the events.k8s.io rule for the
+events/v1 recorder.
+*/}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "etcd-operator.fullname" . }}-manager-role
+  namespace: {{ .Values.controller.watchNamespace }}
+  labels:
+    {{- include "etcd-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - issuers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - operator.etcd.io
+  resources:
+  - etcdclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operator.etcd.io
+  resources:
+  - etcdclusters/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - operator.etcd.io
+  resources:
+  - etcdclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "etcd-operator.fullname" . }}-manager-rolebinding
+  namespace: {{ .Values.controller.watchNamespace }}
+  labels:
+    {{- include "etcd-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "etcd-operator.fullname" . }}-manager-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "etcd-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- else }}
+{{/* Rules from config/rbac/role.yaml (controller-gen output) — keep verbatim. */}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "etcd-operator.fullname" . }}-manager-role
+  labels:
+    {{- include "etcd-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - clusterissuers
+  - issuers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - operator.etcd.io
+  resources:
+  - etcdclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operator.etcd.io
+  resources:
+  - etcdclusters/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - operator.etcd.io
+  resources:
+  - etcdclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "etcd-operator.fullname" . }}-manager-rolebinding
+  labels:
+    {{- include "etcd-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "etcd-operator.fullname" . }}-manager-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "etcd-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/charts/etcd-operator/templates/metrics-auth-rbac.yaml
+++ b/charts/etcd-operator/templates/metrics-auth-rbac.yaml
@@ -1,0 +1,48 @@
+{{- if and .Values.controller.enabled .Values.metrics.secure }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "etcd-operator.fullname" . }}-metrics-auth-role
+  labels:
+    {{- include "etcd-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "etcd-operator.fullname" . }}-metrics-auth-rolebinding
+  labels:
+    {{- include "etcd-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "etcd-operator.fullname" . }}-metrics-auth-role
+subjects:
+- kind: ServiceAccount
+  name: {{ include "etcd-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "etcd-operator.fullname" . }}-metrics-reader
+  labels:
+    {{- include "etcd-operator.labels" . | nindent 4 }}
+rules:
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get
+{{- end }}

--- a/charts/etcd-operator/templates/metrics-networkpolicy.yaml
+++ b/charts/etcd-operator/templates/metrics-networkpolicy.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.controller.enabled .Values.metrics.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "etcd-operator.fullname" . }}-allow-metrics-traffic
+  labels:
+    {{- include "etcd-operator.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "etcd-operator.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              metrics: enabled
+      ports:
+        - port: {{ .Values.metrics.port }}
+          protocol: TCP
+{{- end }}

--- a/charts/etcd-operator/templates/metrics-service.yaml
+++ b/charts/etcd-operator/templates/metrics-service.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.controller.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "etcd-operator.fullname" . }}-metrics-service
+  labels:
+    {{- include "etcd-operator.labels" . | nindent 4 }}
+spec:
+  ports:
+    - name: {{ ternary "https" "http" .Values.metrics.secure }}
+      port: {{ .Values.metrics.port }}
+      protocol: TCP
+      targetPort: {{ .Values.metrics.port }}
+  selector:
+    {{- include "etcd-operator.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/etcd-operator/templates/serviceaccount.yaml
+++ b/charts/etcd-operator/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.controller.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "etcd-operator.serviceAccountName" . }}
+  labels:
+    {{- include "etcd-operator.labels" . | nindent 4 }}
+  {{- with .Values.controller.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/etcd-operator/templates/servicemonitor.yaml
+++ b/charts/etcd-operator/templates/servicemonitor.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.controller.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "etcd-operator.fullname" . }}-metrics-monitor
+  labels:
+    {{- include "etcd-operator.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - path: /metrics
+      {{- if .Values.metrics.secure }}
+      port: https
+      scheme: https
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: true
+      {{- else }}
+      port: http
+      scheme: http
+      {{- end }}
+  selector:
+    matchLabels:
+      {{- include "etcd-operator.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/etcd-operator/templates/webhook-certificate.yaml
+++ b/charts/etcd-operator/templates/webhook-certificate.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.controller.enabled .Values.webhook.enabled .Values.webhook.certManager.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "etcd-operator.fullname" . }}-selfsigned-issuer
+  labels:
+    {{- include "etcd-operator.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "etcd-operator.fullname" . }}-serving-cert
+  labels:
+    {{- include "etcd-operator.labels" . | nindent 4 }}
+spec:
+  dnsNames:
+    - {{ include "etcd-operator.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc
+    - {{ include "etcd-operator.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: {{ include "etcd-operator.fullname" . }}-selfsigned-issuer
+  secretName: {{ include "etcd-operator.fullname" . }}-webhook-server-cert
+{{- end }}

--- a/charts/etcd-operator/templates/webhook-service.yaml
+++ b/charts/etcd-operator/templates/webhook-service.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.controller.enabled .Values.webhook.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "etcd-operator.fullname" . }}-webhook-service
+  labels:
+    {{- include "etcd-operator.labels" . | nindent 4 }}
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    {{- include "etcd-operator.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/etcd-operator/values.yaml
+++ b/charts/etcd-operator/values.yaml
@@ -1,0 +1,70 @@
+nameOverride: ""
+fullnameOverride: ""
+
+crds:
+  # Disable when CRDs are installed by a separate release (see README: split install).
+  enabled: true
+
+controller:
+  enabled: true
+  replicas: 1
+  image:
+    repository: gcr.io/etcd-development/etcd-operator
+    # Defaults to the chart appVersion.
+    tag: ""
+    # When set, the image is pinned by digest (repository@digest) and tag is ignored.
+    digest: ""
+    pullPolicy: IfNotPresent
+  imagePullSecrets: []
+  # OPERATOR_IMAGE env: image for operator-run utility containers (e.g. restore).
+  # Defaults to the manager image ref. kustomize `images:` cannot rewrite env
+  # values; here it follows the image automatically.
+  operatorImage: ""
+  leaderElection: true
+  # Scope the operator to one namespace: renders a namespaced Role/RoleBinding in
+  # that namespace instead of ClusterRole/ClusterRoleBinding and passes
+  # --watch-namespace / WATCH_NAMESPACE.
+  watchNamespace: ""
+  # RESTRICT_CLUSTER_ISSUER=true: the admission webhook rejects
+  # spec.tls.certManager.issuerKind: ClusterIssuer.
+  restrictClusterIssuer: false
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi
+  serviceAccount:
+    annotations: {}
+
+metrics:
+  # true: HTTPS with authn/authz (needs the cluster-scoped metrics-auth RBAC this
+  # chart then installs). false: plain HTTP, no cluster-scoped metrics RBAC.
+  secure: true
+  port: 8443
+  serviceMonitor:
+    enabled: false
+    additionalLabels: {}
+  networkPolicy:
+    # Restrict metrics ingress to namespaces labeled metrics=enabled.
+    enabled: false
+
+webhook:
+  # Admission webhook server: webhook Service plus serving-cert mount and port on
+  # the Deployment. Requires an operator build with the EtcdCluster webhooks.
+  enabled: false
+  certManager:
+    # SelfSigned Issuer + serving Certificate, and the CA-injection annotation on
+    # the WebhookConfigurations. Disable to manage the
+    # <fullname>-webhook-server-cert Secret yourself.
+    enabled: true
+
+admissionWebhooks:
+  # The cluster-scoped Validating/Mutating WebhookConfigurations. Separate from
+  # webhook.enabled so the split install can render them without the runtime
+  # (see README).
+  enabled: false
+  # Constrain the fail-closed webhooks to matching namespaces; empty selects all
+  # namespaces.
+  namespaceSelector: {}


### PR DESCRIPTION
## Summary

Adds a first-class Helm chart at `charts/etcd-operator` (chart `0.1.0`, appVersion `v0.2.0`). It reproduces the full `config/` surface with everything parameterized through values, so `helm install etcd-operator charts/etcd-operator` is equivalent to `kustomize build config/default | kubectl apply -f -` — and the pieces kustomize keeps behind commented-out `[WEBHOOK]`/`[CERTMANAGER]`/`[PROMETHEUS]`/`[NETWORK POLICY]` markers become plain toggles.

## Parity with `kustomize build config/default`

| kustomize resource | chart |
|---|---|
| Namespace `etcd-operator-system` | omitted — the release namespace is Helm's (`--create-namespace`) |
| CRD `etcdclusters.operator.etcd.io` | `templates/crds/` (generated, see below), gated by `crds.enabled` |
| ServiceAccount `…-controller-manager` | `serviceaccount.yaml` |
| ClusterRole/Binding `…-manager-role(binding)` | `manager-rbac.yaml` |
| Role/Binding `…-leader-election-*` | `leader-election-rbac.yaml` (always namespaced) |
| ClusterRoles `…-metrics-auth-*`, `…-metrics-reader` | `metrics-auth-rbac.yaml`, rendered only while `metrics.secure=true` (the only mode that uses TokenReview/SubjectAccessReview) |
| ClusterRoles `…-etcdcluster-{editor,viewer}-role` | `etcdcluster-user-rbac.yaml` |
| Service `…-metrics-service` | `metrics-service.yaml` |
| Deployment `…-controller-manager` | `deployment.yaml` |

Plus the optional surface: ServiceMonitor (`config/prometheus`), metrics NetworkPolicy (`config/network-policy`), webhook Service + self-signed Issuer/Certificate (`config/webhook`, `config/certmanager`), and the Validating/Mutating WebhookConfigurations with cert-manager CA injection (#384). Webhook toggles default off to match today's `config/default` and the v0.2.0 image.

## Values highlights

- **Digest pinning**: `controller.image.digest` renders `repository@digest` and wins over `tag` (which defaults to `appVersion`).
- **`OPERATOR_IMAGE`** env defaults to the manager image ref. kustomize `images:` cannot rewrite env values; the chart keeps the two in lockstep automatically (digest pin included).
- **`controller.watchNamespace`**: swaps the manager ClusterRole/ClusterRoleBinding for a namespaced Role/RoleBinding in the watched namespace (no `clusterissuers` rule — pair with `controller.restrictClusterIssuer`; includes the `events.k8s.io` rule from #391) and passes `--watch-namespace`/`WATCH_NAMESPACE`.
- **`metrics.secure=false`**: plain-HTTP metrics with zero cluster-scoped metrics RBAC; the Service, ServiceMonitor scheme/auth, and NetworkPolicy port all follow.
- **`admissionWebhooks.namespaceSelector`**: constrain the fail-closed webhooks to selected namespaces; empty keeps upstream's cluster-wide behavior.

## Split rendering (why three component gates)

`crds.enabled` / `controller.enabled` / `admissionWebhooks.enabled` let one chart serve GitOps setups that split cluster-scoped installs from the namespaced runtime (e.g. two ArgoCD Applications, one privileged): side (a) `controller.enabled=false, admissionWebhooks.enabled=true` renders **only** the CRDs + the two WebhookConfigurations; side (b) `crds.enabled=false, webhook.enabled=true` renders the full runtime with neither. Exact values in the chart README.

## CRD sync idiom

`templates/crds/` is generated, never hand-edited: `make helm-crds` copies `config/crd/bases/*.yaml` verbatim, wraps each in the `crds.enabled` guard, and escapes any `{{` for the template engine (none today; guarded anyway). `make manifests helm-crds` keeps the chart in lockstep after API changes. `make helm-lint` runs `helm lint`. No existing Makefile targets are touched.

## Verification

- `helm lint`: clean.
- `helm template` over four configurations: default, split side (a) (exactly 3 resources), split side (b) (no CRD/WebhookConfiguration leak), and namespace-scoped (`watchNamespace=kv, metrics.secure=false`: zero ClusterRoles emitted).
- Resource-by-resource parity against `kustomize build config/default` (table above); the Namespace is the single deliberate omission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### PR series — operability fixes, TLS & EtcdMirror
<!-- pr-stack:begin -->
Small single-purpose PRs from live kind-cluster testing of the operator. Each stands alone unless an *After* is listed. → = this PR.

| | PR | Lands | After |
|---|----|-------|-------|
| | **Reviewable now — small, any order** | | |
| 🟢 | #374 | Requeue instead of swallowing the client-cert provisioning error | — |
| 🟢 | #391 | Grant `events.k8s.io` RBAC so operator Events are actually recorded | — |
| 🟢 | #392 | Correlate `members[]`/`leaderID` from one health snapshot (consistent leader) | — |
| 🟢 | #393 | Propagate user-supplied `altNames.ipAddresses` into certificates | — |
| 🟢 | #394 | Accept day-suffix `validityDuration` (`365d`, `100d12h`) as documented | — |
| 🟢 | #395 | Surface early reconcile errors as a `Degraded` condition (was empty status) | — |
| 🟢 | #379 | Configurable reconcile worker pool (`--max-concurrent-reconciles`) | — |
| 🟢 | #369 | kind-based stress/scale e2e harness (1/3/7 members, churn, quorum watcher) | — |
| 🟢 | #398 | `podTemplate.spec` scheduling fields: topologySpread, resources, priorityClass, schedulerName | — |
| 🟢→ | #397 | First-class Helm chart covering the full `config/` surface | — |
| 🟢 | #399 | Quorum-aware PodDisruptionBudget per EtcdCluster | — |
| 🟢 | #400 | Scale-in removes the right member and transfers leadership first | — |
| 🟢 | #401 | Backend quota + auto-compaction spec fields, NOSPACE alarm surfacing | — |
| 🟢 | #402 | Reconcile-loop gates replace the blocking StatefulSet-ready wait | — |
| 🟢 | #403 | Quorum-gated one-pod-at-a-time version upgrades via OnDelete | — |
| | **TLS stack — in order** | | |
| 🟢 | #376 | Independent `spec.tls.{peer,client}` surfaces (breaking alpha API) | — |
| ⚪ | #377 | `TLSReady` condition + TLS lifecycle Events | #376 |
| ⚪ | #378 | Multi-member TLS quorum e2e + `PeerCANotShared` | #377 |
| | **EtcdMirror — in order** | | |
| 🟢 | #406 | `EtcdMirror` CRD: one-way cross-cluster replication API (types + CEL) | — |
| 🟢 | #407 | `pkg/mirroragent` replication engine (fenced checkpoint-in-target) | #406 |
| 🟢 | #408 | Periodic reconciliation pass wired into the engine's steady-state loop | #407 |
| 🟢 | #412 | `mirror-agent` binary: config/TLS-reload/statusz/metrics + kind e2e | #408 |
| 🟢 | #413 | EtcdMirror controller: Deployment rendering, statusz-driven conditions, guards, fenced finalizer | #412 |
| 🟢 | #414 | CRD/sample/editor+viewer-role kustomize wiring | #413 |
| 🟢 | #415 | Controller-side phase/condition gauges, shipped PrometheusRule + dashboard | #414 |
| 🟢 | #416 | Full-lifecycle kind e2e: fence overlap, compaction+prune, restart resume, cert rotation, cutover/reversal | #415 |
| | **Parked as drafts pending #363** | | |
| ⚪ | #382 | Per-cluster domain metrics on the operator `/metrics` endpoint | — |
| ⚪ | #384 | EtcdCluster admission webhooks (consolidating with #328) | #363 |
| ⚪ | #386 | `EtcdBackup` CR → object storage (S3/GCS) | #363 |
| ⚪ | #387 | Automatic quorum-loss disaster recovery (bootstrap-latch guarded) | #363 |

🟢 ready · ⚪ draft
<!-- pr-stack:end -->