### PR TITLE
feat: quorum-aware PodDisruptionBudget per EtcdCluster

### DIFF
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -23,7 +23,7 @@ package v1alpha1
 import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
 	netx "net"
 )
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -87,3 +87,15 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/docs/api-references/docs.md
+++ b/docs/api-references/docs.md
@@ -153,6 +153,24 @@ _Appears in:_
 | `labels` _object (keys:string, values:string)_ |  |  |  |
 
 
+#### PodSpec
+
+
+
+
+
+
+
+_Appears in:_
+- [PodTemplate](#podtemplate)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#affinity-v1-core)_ |  |  |  |
+| `nodeSelector` _object (keys:string, values:string)_ |  |  |  |
+| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#toleration-v1-core) array_ |  |  |  |
+
+
 #### PodTemplate
 
 
@@ -167,6 +185,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `metadata` _[PodMetadata](#podmetadata)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[PodSpec](#podspec)_ |  |  |  |
 
 
 #### ProviderAutoConfig

--- a/docs/pod-disruption-budget.md
+++ b/docs/pod-disruption-budget.md
@@ -1,0 +1,33 @@
+# PodDisruptionBudget
+
+The operator always creates a PodDisruptionBudget for every `EtcdCluster`,
+named after the cluster and selecting all its etcd pods. `minAvailable` is
+sized so that voluntary evictions (node drains, cluster-autoscaler
+scale-down, managed node-pool upgrades) can never break etcd quorum, and is
+re-tightened ahead of scale operations. There is no spec field to disable or
+override it; manual edits are reverted on the next reconcile, and a
+same-named PDB not created by the operator is left untouched (the operator
+then manages none).
+
+## Sizing
+
+`minAvailable = pods - (voters - quorum)`, computed from the live member
+list (learners and not-yet-removed pods count as pods but not voters):
+
+| Cluster size | Quorum | minAvailable | Evictions allowed |
+| --- | --- | --- | --- |
+| 1 | 1 | 1 | 0 |
+| 2 | 2 | 2 | 0 |
+| 3 | 2 | 2 | 1 |
+| 5 | 3 | 3 | 2 |
+| 7 | 4 | 4 | 3 |
+
+## Sizes 1 and 2 block drains by design
+
+A 1- or 2-member cluster cannot lose any member without losing quorum, so
+its PDB permanently disallows all voluntary evictions. `kubectl drain` and
+autoscaler scale-down will wedge on these pods with a generic
+"cannot evict pod as it would violate the pod's disruption budget" error.
+To move such a pod, either scale the cluster to 3 first, or delete the pod
+directly (`kubectl delete pod` bypasses the eviction API; expect downtime
+while the StatefulSet recreates it).

--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -128,8 +128,9 @@ func (r *EtcdClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	res, err = r.reconcileClusterState(ctx, state)
 	if err == nil && res.IsZero() && pdbErr != nil {
-		// Nothing else requeues; surface the PDB failure for backoff.
-		return res, pdbErr
+		// Nothing else requeues; surface the PDB failure for backoff. Assign
+		// to err so the deferred status/metrics closure observes it too.
+		err = pdbErr
 	}
 	return res, err
 }

--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -25,6 +25,7 @@ import (
 	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,6 +67,7 @@ type reconcileState struct {
 // +kubebuilder:rbac:groups=operator.etcd.io,resources=etcdclusters/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=operator.etcd.io,resources=etcdclusters/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch;get;list;update
@@ -105,8 +107,17 @@ func (r *EtcdClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return res, err
 	}
 
-	if err = r.performHealthChecks(ctx, state); err != nil {
-		return ctrl.Result{}, err
+	// Reconcile the PDB even when the health check errors: healthCheck still
+	// returns the member list for unhealthy clusters, which is exactly when
+	// disruption protection matters most.
+	healthErr := r.performHealthChecks(ctx, state)
+	if pdbErr := reconcilePodDisruptionBudget(
+		ctx, log.FromContext(ctx), r.Client, state.cluster, state.memberListResp, r.Scheme,
+	); pdbErr != nil {
+		return ctrl.Result{}, pdbErr
+	}
+	if healthErr != nil {
+		return ctrl.Result{}, healthErr
 	}
 
 	return r.reconcileClusterState(ctx, state)
@@ -586,7 +597,8 @@ func (r *EtcdClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&ecv1alpha1.EtcdCluster{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.Service{}).
-		Owns(&corev1.ConfigMap{})
+		Owns(&corev1.ConfigMap{}).
+		Owns(&policyv1.PodDisruptionBudget{})
 
 	// Conditionally watch cert-manager Certificate resources if CRDs are installed
 	// This allows the controller to react to Certificate status changes when using cert-manager provider

--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -112,8 +112,12 @@ func (r *EtcdClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// disruption protection matters most. A PDB write failure is logged but
 	// never blocks health handling or cluster reconciliation.
 	healthErr := r.performHealthChecks(ctx, state)
+	var stsReplicas int32
+	if state.sts != nil && state.sts.Spec.Replicas != nil {
+		stsReplicas = *state.sts.Spec.Replicas
+	}
 	pdbErr := reconcilePodDisruptionBudget(
-		ctx, log.FromContext(ctx), r.Client, state.cluster, state.memberListResp, r.Scheme,
+		ctx, log.FromContext(ctx), r.Client, state.cluster, state.memberListResp, stsReplicas, r.Scheme,
 	)
 	if pdbErr != nil {
 		log.FromContext(ctx).Error(pdbErr, "Failed to reconcile PodDisruptionBudget")

--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -109,18 +109,25 @@ func (r *EtcdClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	// Reconcile the PDB even when the health check errors: healthCheck still
 	// returns the member list for unhealthy clusters, which is exactly when
-	// disruption protection matters most.
+	// disruption protection matters most. A PDB write failure is logged but
+	// never blocks health handling or cluster reconciliation.
 	healthErr := r.performHealthChecks(ctx, state)
-	if pdbErr := reconcilePodDisruptionBudget(
+	pdbErr := reconcilePodDisruptionBudget(
 		ctx, log.FromContext(ctx), r.Client, state.cluster, state.memberListResp, r.Scheme,
-	); pdbErr != nil {
-		return ctrl.Result{}, pdbErr
+	)
+	if pdbErr != nil {
+		log.FromContext(ctx).Error(pdbErr, "Failed to reconcile PodDisruptionBudget")
 	}
 	if healthErr != nil {
 		return ctrl.Result{}, healthErr
 	}
 
-	return r.reconcileClusterState(ctx, state)
+	res, err = r.reconcileClusterState(ctx, state)
+	if err == nil && res.IsZero() && pdbErr != nil {
+		// Nothing else requeues; surface the PDB failure for backoff.
+		return res, pdbErr
+	}
+	return res, err
 }
 
 // fetchAndValidateState retrieves the EtcdCluster and its StatefulSet and ensures

--- a/internal/controller/poddisruptionbudget.go
+++ b/internal/controller/poddisruptionbudget.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	ecv1alpha1 "go.etcd.io/etcd-operator/api/v1alpha1"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+func pdbNameForEtcdCluster(ec *ecv1alpha1.EtcdCluster) string {
+	return ec.Name
+}
+
+func votingMemberCount(resp *clientv3.MemberListResponse) int {
+	if resp == nil {
+		return 0
+	}
+	count := 0
+	for _, m := range resp.Members {
+		if !m.IsLearner {
+			count++
+		}
+	}
+	return count
+}
+
+func minAvailableForVotingCount(voting int) int32 {
+	return int32(voting/2 + 1)
+}
+
+// reconcilePodDisruptionBudget keeps a PDB sized to the quorum of the observed
+// voting members. With no observed members it leaves any existing PDB alone:
+// a stale-but-protective PDB during an outage beats deleting it, and
+// minAvailable 0 protects nothing.
+func reconcilePodDisruptionBudget(
+	ctx context.Context,
+	logger logr.Logger,
+	c client.Client,
+	ec *ecv1alpha1.EtcdCluster,
+	memberListResp *clientv3.MemberListResponse,
+	scheme *runtime.Scheme,
+) error {
+	voting := votingMemberCount(memberListResp)
+	if voting == 0 {
+		return nil
+	}
+
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pdbNameForEtcdCluster(ec),
+			Namespace: ec.Namespace,
+		},
+	}
+
+	result, err := controllerutil.CreateOrPatch(ctx, c, pdb, func() error {
+		minAvailable := intstr.FromInt32(minAvailableForVotingCount(voting))
+		pdb.Spec.MinAvailable = &minAvailable
+		// Same labels as the StatefulSet pods, so learners are covered too:
+		// evicting a learner is still allowed while minAvailable voters remain.
+		pdb.Spec.Selector = &metav1.LabelSelector{MatchLabels: etcdPodLabels(ec)}
+		return controllerutil.SetControllerReference(ec, pdb, scheme)
+	})
+	if err != nil {
+		return err
+	}
+
+	if result == controllerutil.OperationResultCreated || result == controllerutil.OperationResultUpdated {
+		logger.Info("PodDisruptionBudget reconciled",
+			"name", pdb.Name, "namespace", pdb.Namespace, "result", result,
+			"minAvailable", minAvailableForVotingCount(voting))
+	}
+	return nil
+}

--- a/internal/controller/poddisruptionbudget.go
+++ b/internal/controller/poddisruptionbudget.go
@@ -18,9 +18,11 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -48,14 +50,44 @@ func votingMemberCount(resp *clientv3.MemberListResponse) int {
 	return count
 }
 
-func minAvailableForVotingCount(voting int) int32 {
-	return int32(voting/2 + 1)
+// evictableVoterCount is how many voters can be lost while keeping quorum.
+func evictableVoterCount(voting int) int {
+	if voting <= 0 {
+		return 0
+	}
+	quorum := voting/2 + 1
+	return voting - quorum
 }
 
-// reconcilePodDisruptionBudget keeps a PDB sized to the quorum of the observed
-// voting members. With no observed members it leaves any existing PDB alone:
-// a stale-but-protective PDB during an outage beats deleting it, and
-// minAvailable 0 protects nothing.
+// pdbMinAvailable sizes minAvailable for a selector matching every cluster
+// pod. A label selector cannot tell voters from learners (or from the pod of
+// a just-removed member), so the budget must assume every permitted eviction
+// lands on a voter: minAvailable = total members - evictable voters.
+//
+// The loop reconciles the PDB before mutating membership, so pending scale
+// steps are priced in ahead of time:
+//   - scale-in: RemoveMember runs before the StatefulSet shrinks, leaving the
+//     removed member's pod matching the selector; size for the post-removal
+//     voter set and keep the stricter value.
+//   - scale-out: a learner (and its pod) is added before the PDB is next
+//     updated; reserve the extra pod now.
+func pdbMinAvailable(total, voting, desiredSize int) int32 {
+	minAvailable := total - evictableVoterCount(voting)
+	switch {
+	case total > desiredSize:
+		if postRemoval := total - evictableVoterCount(voting-1); postRemoval > minAvailable {
+			minAvailable = postRemoval
+		}
+	case total < desiredSize:
+		minAvailable++
+	}
+	return int32(minAvailable)
+}
+
+// reconcilePodDisruptionBudget keeps a PDB sized so voluntary evictions can
+// never break quorum (see pdbMinAvailable). With no observed members it
+// leaves any existing PDB alone: a stale-but-protective PDB during an outage
+// beats deleting it, and minAvailable 0 protects nothing.
 func reconcilePodDisruptionBudget(
 	ctx context.Context,
 	logger logr.Logger,
@@ -68,6 +100,7 @@ func reconcilePodDisruptionBudget(
 	if voting == 0 {
 		return nil
 	}
+	total := len(memberListResp.Members)
 
 	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
@@ -76,11 +109,26 @@ func reconcilePodDisruptionBudget(
 		},
 	}
 
+	// Never adopt a PDB this operator did not create: patching it would
+	// clobber a user-managed spec, and SetControllerReference fails forever
+	// when another controller owns it. Skipping keeps the permanent name
+	// collision out of the requeue path.
+	existing := &policyv1.PodDisruptionBudget{}
+	switch err := c.Get(ctx, client.ObjectKeyFromObject(pdb), existing); {
+	case err == nil:
+		if !metav1.IsControlledBy(existing, ec) {
+			logger.Info("Skipping PodDisruptionBudget: existing object is not controlled by this EtcdCluster",
+				"name", pdb.Name, "namespace", pdb.Namespace)
+			return nil
+		}
+	case !apierrors.IsNotFound(err):
+		return fmt.Errorf("failed to get PodDisruptionBudget %s/%s: %w", pdb.Namespace, pdb.Name, err)
+	}
+
+	minAvailable := intstr.FromInt32(pdbMinAvailable(total, voting, ec.Spec.Size))
 	result, err := controllerutil.CreateOrPatch(ctx, c, pdb, func() error {
-		minAvailable := intstr.FromInt32(minAvailableForVotingCount(voting))
 		pdb.Spec.MinAvailable = &minAvailable
-		// Same labels as the StatefulSet pods, so learners are covered too:
-		// evicting a learner is still allowed while minAvailable voters remain.
+		pdb.Spec.MaxUnavailable = nil // apiserver rejects specs with both fields set
 		pdb.Spec.Selector = &metav1.LabelSelector{MatchLabels: etcdPodLabels(ec)}
 		return controllerutil.SetControllerReference(ec, pdb, scheme)
 	})
@@ -91,7 +139,7 @@ func reconcilePodDisruptionBudget(
 	if result == controllerutil.OperationResultCreated || result == controllerutil.OperationResultUpdated {
 		logger.Info("PodDisruptionBudget reconciled",
 			"name", pdb.Name, "namespace", pdb.Namespace, "result", result,
-			"minAvailable", minAvailableForVotingCount(voting))
+			"minAvailable", minAvailable.IntValue())
 	}
 	return nil
 }

--- a/internal/controller/poddisruptionbudget.go
+++ b/internal/controller/poddisruptionbudget.go
@@ -62,7 +62,7 @@ func evictableVoterCount(voting int) int {
 // pdbMinAvailable sizes minAvailable for a selector matching every cluster
 // pod. A label selector cannot tell voters from learners (or from the pod of
 // a just-removed member), so the budget must assume every permitted eviction
-// lands on a voter: minAvailable = total members - evictable voters.
+// lands on a voter: minAvailable = total pods - evictable voters.
 //
 // The loop reconciles the PDB before mutating membership, so pending scale
 // steps are priced in ahead of time:
@@ -88,12 +88,19 @@ func pdbMinAvailable(total, voting, desiredSize int) int32 {
 // never break quorum (see pdbMinAvailable). With no observed members it
 // leaves any existing PDB alone: a stale-but-protective PDB during an outage
 // beats deleting it, and minAvailable 0 protects nothing.
+//
+// stsReplicas floors the pod total: after RemoveMember but before the
+// StatefulSet shrinks (a crash can freeze that state), the removed member's
+// pod still matches the selector while it is gone from the member list, and
+// sizing off members alone would re-widen the eviction budget over a smaller
+// voter set.
 func reconcilePodDisruptionBudget(
 	ctx context.Context,
 	logger logr.Logger,
 	c client.Client,
 	ec *ecv1alpha1.EtcdCluster,
 	memberListResp *clientv3.MemberListResponse,
+	stsReplicas int32,
 	scheme *runtime.Scheme,
 ) error {
 	voting := votingMemberCount(memberListResp)
@@ -101,6 +108,9 @@ func reconcilePodDisruptionBudget(
 		return nil
 	}
 	total := len(memberListResp.Members)
+	if int(stsReplicas) > total {
+		total = int(stsReplicas)
+	}
 
 	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/poddisruptionbudget_test.go
+++ b/internal/controller/poddisruptionbudget_test.go
@@ -1,0 +1,151 @@
+package controller
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	ecv1alpha1 "go.etcd.io/etcd-operator/api/v1alpha1"
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+func memberList(voters, learners int) *clientv3.MemberListResponse {
+	members := make([]*etcdserverpb.Member, 0, voters+learners)
+	for i := 0; i < voters; i++ {
+		members = append(members, &etcdserverpb.Member{ID: uint64(i + 1), Name: fmt.Sprintf("voter-%d", i)})
+	}
+	for i := 0; i < learners; i++ {
+		members = append(members, &etcdserverpb.Member{
+			ID: uint64(voters + i + 1), Name: fmt.Sprintf("learner-%d", i), IsLearner: true,
+		})
+	}
+	return &clientv3.MemberListResponse{Members: members}
+}
+
+func TestMinAvailableForVotingCount(t *testing.T) {
+	tests := []struct {
+		voting   int
+		expected int32
+	}{
+		{1, 1},
+		{2, 2},
+		{3, 2},
+		{4, 3},
+		{5, 3},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.expected, minAvailableForVotingCount(tt.voting), "voting=%d", tt.voting)
+	}
+}
+
+func TestVotingMemberCount(t *testing.T) {
+	assert.Equal(t, 0, votingMemberCount(nil))
+	assert.Equal(t, 0, votingMemberCount(&clientv3.MemberListResponse{}))
+	assert.Equal(t, 3, votingMemberCount(memberList(3, 2)))
+}
+
+func TestReconcilePodDisruptionBudget(t *testing.T) {
+	ctx := t.Context()
+	logger := log.FromContext(ctx)
+
+	newEtcdCluster := func(t *testing.T, name string) *ecv1alpha1.EtcdCluster {
+		t.Helper()
+		ec := &ecv1alpha1.EtcdCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec:       ecv1alpha1.EtcdClusterSpec{Size: 3, Version: "3.5.17"},
+		}
+		require.NoError(t, k8sClient.Create(ctx, ec))
+		return ec
+	}
+
+	getPDB := func(t *testing.T, name string) *policyv1.PodDisruptionBudget {
+		t.Helper()
+		pdb := &policyv1.PodDisruptionBudget{}
+		require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: "default"}, pdb))
+		return pdb
+	}
+
+	t.Run("creates PDB with single voting member", func(t *testing.T) {
+		ec := newEtcdCluster(t, "pdb-single-voter")
+
+		err := reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(1, 0), scheme.Scheme)
+		require.NoError(t, err)
+
+		pdb := getPDB(t, ec.Name)
+		expected := intstr.FromInt32(1)
+		assert.Equal(t, &expected, pdb.Spec.MinAvailable)
+		assert.Equal(t, map[string]string{
+			"app":        ec.Name,
+			"controller": ec.Name,
+		}, pdb.Spec.Selector.MatchLabels)
+		require.Len(t, pdb.OwnerReferences, 1)
+		assert.Equal(t, "EtcdCluster", pdb.OwnerReferences[0].Kind)
+		assert.Equal(t, ec.Name, pdb.OwnerReferences[0].Name)
+		require.NotNil(t, pdb.OwnerReferences[0].Controller)
+		assert.True(t, *pdb.OwnerReferences[0].Controller)
+	})
+
+	t.Run("three voting members", func(t *testing.T) {
+		ec := newEtcdCluster(t, "pdb-three-voters")
+
+		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(3, 0), scheme.Scheme))
+		assert.Equal(t, intstr.FromInt32(2), *getPDB(t, ec.Name).Spec.MinAvailable)
+	})
+
+	t.Run("five voting members", func(t *testing.T) {
+		ec := newEtcdCluster(t, "pdb-five-voters")
+
+		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(5, 0), scheme.Scheme))
+		assert.Equal(t, intstr.FromInt32(3), *getPDB(t, ec.Name).Spec.MinAvailable)
+	})
+
+	t.Run("learners excluded", func(t *testing.T) {
+		ec := newEtcdCluster(t, "pdb-with-learner")
+
+		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(3, 1), scheme.Scheme))
+		assert.Equal(t, intstr.FromInt32(2), *getPDB(t, ec.Name).Spec.MinAvailable)
+	})
+
+	t.Run("updates PDB on membership change (scale)", func(t *testing.T) {
+		ec := newEtcdCluster(t, "pdb-scale")
+
+		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(1, 0), scheme.Scheme))
+		uid := getPDB(t, ec.Name).UID
+
+		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(3, 0), scheme.Scheme))
+		pdb := getPDB(t, ec.Name)
+		assert.Equal(t, uid, pdb.UID)
+		assert.Equal(t, intstr.FromInt32(2), *pdb.Spec.MinAvailable)
+
+		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(5, 0), scheme.Scheme))
+		pdb = getPDB(t, ec.Name)
+		assert.Equal(t, uid, pdb.UID)
+		assert.Equal(t, intstr.FromInt32(3), *pdb.Spec.MinAvailable)
+	})
+
+	t.Run("no members observed", func(t *testing.T) {
+		ec := newEtcdCluster(t, "pdb-no-members")
+
+		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, nil, scheme.Scheme))
+		err := k8sClient.Get(ctx, client.ObjectKey{Name: ec.Name, Namespace: "default"},
+			&policyv1.PodDisruptionBudget{})
+		assert.True(t, client.IgnoreNotFound(err) == nil && err != nil, "expected NotFound, got %v", err)
+
+		// A pre-existing PDB must survive a loop that observes no members.
+		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(3, 0), scheme.Scheme))
+		before := getPDB(t, ec.Name)
+		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, nil, scheme.Scheme))
+		after := getPDB(t, ec.Name)
+		assert.Equal(t, before.UID, after.UID)
+		assert.Equal(t, intstr.FromInt32(2), *after.Spec.MinAvailable)
+	})
+}

--- a/internal/controller/poddisruptionbudget_test.go
+++ b/internal/controller/poddisruptionbudget_test.go
@@ -31,19 +31,33 @@ func memberList(voters, learners int) *clientv3.MemberListResponse {
 	return &clientv3.MemberListResponse{Members: members}
 }
 
-func TestMinAvailableForVotingCount(t *testing.T) {
+func TestPDBMinAvailable(t *testing.T) {
 	tests := []struct {
-		voting   int
-		expected int32
+		name        string
+		total       int
+		voting      int
+		desiredSize int
+		expected    int32
 	}{
-		{1, 1},
-		{2, 2},
-		{3, 2},
-		{4, 3},
-		{5, 3},
+		{"steady 1", 1, 1, 1, 1},
+		{"steady 2", 2, 2, 2, 2},
+		{"steady 3", 3, 3, 3, 2},
+		{"steady 5", 5, 5, 5, 3},
+		{"learner counts as evictable-only pod", 4, 3, 4, 3},
+		{"single voter plus learner", 2, 1, 2, 2},
+		{"scale-out pending 1->3", 1, 1, 3, 2},
+		{"scale-out pending 3->5", 3, 3, 5, 3},
+		{"scale-out pending with learner", 4, 3, 5, 4},
+		{"scale-in pending 3->2", 3, 3, 2, 3},
+		{"scale-in pending 5->4", 5, 5, 4, 4},
+		{"scale-in pending 5->2", 5, 5, 2, 4},
+		{"scale-in pending 4->3", 4, 4, 3, 3},
+		{"scale-in pending 2->1", 2, 2, 1, 2},
 	}
 	for _, tt := range tests {
-		assert.Equal(t, tt.expected, minAvailableForVotingCount(tt.voting), "voting=%d", tt.voting)
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, pdbMinAvailable(tt.total, tt.voting, tt.desiredSize))
+		})
 	}
 }
 
@@ -57,11 +71,11 @@ func TestReconcilePodDisruptionBudget(t *testing.T) {
 	ctx := t.Context()
 	logger := log.FromContext(ctx)
 
-	newEtcdCluster := func(t *testing.T, name string) *ecv1alpha1.EtcdCluster {
+	newEtcdCluster := func(t *testing.T, name string, size int) *ecv1alpha1.EtcdCluster {
 		t.Helper()
 		ec := &ecv1alpha1.EtcdCluster{
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
-			Spec:       ecv1alpha1.EtcdClusterSpec{Size: 3, Version: "3.5.17"},
+			Spec:       ecv1alpha1.EtcdClusterSpec{Size: size, Version: "3.5.17"},
 		}
 		require.NoError(t, k8sClient.Create(ctx, ec))
 		return ec
@@ -75,7 +89,7 @@ func TestReconcilePodDisruptionBudget(t *testing.T) {
 	}
 
 	t.Run("creates PDB with single voting member", func(t *testing.T) {
-		ec := newEtcdCluster(t, "pdb-single-voter")
+		ec := newEtcdCluster(t, "pdb-single-voter", 1)
 
 		err := reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(1, 0), scheme.Scheme)
 		require.NoError(t, err)
@@ -83,6 +97,7 @@ func TestReconcilePodDisruptionBudget(t *testing.T) {
 		pdb := getPDB(t, ec.Name)
 		expected := intstr.FromInt32(1)
 		assert.Equal(t, &expected, pdb.Spec.MinAvailable)
+		assert.Nil(t, pdb.Spec.MaxUnavailable)
 		assert.Equal(t, map[string]string{
 			"app":        ec.Name,
 			"controller": ec.Name,
@@ -95,36 +110,54 @@ func TestReconcilePodDisruptionBudget(t *testing.T) {
 	})
 
 	t.Run("three voting members", func(t *testing.T) {
-		ec := newEtcdCluster(t, "pdb-three-voters")
+		ec := newEtcdCluster(t, "pdb-three-voters", 3)
 
 		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(3, 0), scheme.Scheme))
 		assert.Equal(t, intstr.FromInt32(2), *getPDB(t, ec.Name).Spec.MinAvailable)
 	})
 
 	t.Run("five voting members", func(t *testing.T) {
-		ec := newEtcdCluster(t, "pdb-five-voters")
+		ec := newEtcdCluster(t, "pdb-five-voters", 5)
 
 		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(5, 0), scheme.Scheme))
 		assert.Equal(t, intstr.FromInt32(3), *getPDB(t, ec.Name).Spec.MinAvailable)
 	})
 
-	t.Run("learners excluded", func(t *testing.T) {
-		ec := newEtcdCluster(t, "pdb-with-learner")
+	t.Run("learner pod raises minAvailable", func(t *testing.T) {
+		// The selector cannot tell voters from learners, so the learner pod
+		// must not widen the eviction budget for voters.
+		ec := newEtcdCluster(t, "pdb-with-learner", 4)
 
 		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(3, 1), scheme.Scheme))
+		assert.Equal(t, intstr.FromInt32(3), *getPDB(t, ec.Name).Spec.MinAvailable)
+	})
+
+	t.Run("scale-in pending sizes for post-removal membership", func(t *testing.T) {
+		ec := newEtcdCluster(t, "pdb-scale-in", 2)
+
+		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(3, 0), scheme.Scheme))
+		assert.Equal(t, intstr.FromInt32(3), *getPDB(t, ec.Name).Spec.MinAvailable)
+	})
+
+	t.Run("scale-out pending reserves the incoming learner pod", func(t *testing.T) {
+		ec := newEtcdCluster(t, "pdb-scale-out", 3)
+
+		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(1, 0), scheme.Scheme))
 		assert.Equal(t, intstr.FromInt32(2), *getPDB(t, ec.Name).Spec.MinAvailable)
 	})
 
 	t.Run("updates PDB on membership change (scale)", func(t *testing.T) {
-		ec := newEtcdCluster(t, "pdb-scale")
+		ec := newEtcdCluster(t, "pdb-scale", 5)
 
 		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(1, 0), scheme.Scheme))
-		uid := getPDB(t, ec.Name).UID
+		pdb := getPDB(t, ec.Name)
+		uid := pdb.UID
+		assert.Equal(t, intstr.FromInt32(2), *pdb.Spec.MinAvailable)
 
 		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(3, 0), scheme.Scheme))
-		pdb := getPDB(t, ec.Name)
+		pdb = getPDB(t, ec.Name)
 		assert.Equal(t, uid, pdb.UID)
-		assert.Equal(t, intstr.FromInt32(2), *pdb.Spec.MinAvailable)
+		assert.Equal(t, intstr.FromInt32(3), *pdb.Spec.MinAvailable)
 
 		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(5, 0), scheme.Scheme))
 		pdb = getPDB(t, ec.Name)
@@ -133,7 +166,7 @@ func TestReconcilePodDisruptionBudget(t *testing.T) {
 	})
 
 	t.Run("no members observed", func(t *testing.T) {
-		ec := newEtcdCluster(t, "pdb-no-members")
+		ec := newEtcdCluster(t, "pdb-no-members", 3)
 
 		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, nil, scheme.Scheme))
 		err := k8sClient.Get(ctx, client.ObjectKey{Name: ec.Name, Namespace: "default"},
@@ -147,5 +180,28 @@ func TestReconcilePodDisruptionBudget(t *testing.T) {
 		after := getPDB(t, ec.Name)
 		assert.Equal(t, before.UID, after.UID)
 		assert.Equal(t, intstr.FromInt32(2), *after.Spec.MinAvailable)
+	})
+
+	t.Run("pre-existing user PDB is not adopted", func(t *testing.T) {
+		ec := newEtcdCluster(t, "pdb-foreign", 3)
+
+		maxUnavailable := intstr.FromInt32(1)
+		userPDB := &policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{Name: ec.Name, Namespace: "default"},
+			Spec: policyv1.PodDisruptionBudgetSpec{
+				MaxUnavailable: &maxUnavailable,
+				Selector:       &metav1.LabelSelector{MatchLabels: map[string]string{"user": "owned"}},
+			},
+		}
+		require.NoError(t, k8sClient.Create(ctx, userPDB))
+
+		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(3, 0), scheme.Scheme))
+
+		pdb := getPDB(t, ec.Name)
+		assert.Empty(t, pdb.OwnerReferences)
+		assert.Nil(t, pdb.Spec.MinAvailable)
+		require.NotNil(t, pdb.Spec.MaxUnavailable)
+		assert.Equal(t, maxUnavailable, *pdb.Spec.MaxUnavailable)
+		assert.Equal(t, map[string]string{"user": "owned"}, pdb.Spec.Selector.MatchLabels)
 	})
 }

--- a/internal/controller/poddisruptionbudget_test.go
+++ b/internal/controller/poddisruptionbudget_test.go
@@ -53,6 +53,8 @@ func TestPDBMinAvailable(t *testing.T) {
 		{"scale-in pending 5->2", 5, 5, 2, 4},
 		{"scale-in pending 4->3", 4, 4, 3, 3},
 		{"scale-in pending 2->1", 2, 2, 1, 2},
+		{"interrupted scale-in 3->2 (orphan pod)", 3, 2, 2, 3},
+		{"interrupted scale-in 5->4 (orphan pod)", 5, 4, 4, 4},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -91,7 +93,7 @@ func TestReconcilePodDisruptionBudget(t *testing.T) {
 	t.Run("creates PDB with single voting member", func(t *testing.T) {
 		ec := newEtcdCluster(t, "pdb-single-voter", 1)
 
-		err := reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(1, 0), scheme.Scheme)
+		err := reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(1, 0), 1, scheme.Scheme)
 		require.NoError(t, err)
 
 		pdb := getPDB(t, ec.Name)
@@ -112,14 +114,14 @@ func TestReconcilePodDisruptionBudget(t *testing.T) {
 	t.Run("three voting members", func(t *testing.T) {
 		ec := newEtcdCluster(t, "pdb-three-voters", 3)
 
-		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(3, 0), scheme.Scheme))
+		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(3, 0), 3, scheme.Scheme))
 		assert.Equal(t, intstr.FromInt32(2), *getPDB(t, ec.Name).Spec.MinAvailable)
 	})
 
 	t.Run("five voting members", func(t *testing.T) {
 		ec := newEtcdCluster(t, "pdb-five-voters", 5)
 
-		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(5, 0), scheme.Scheme))
+		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(5, 0), 5, scheme.Scheme))
 		assert.Equal(t, intstr.FromInt32(3), *getPDB(t, ec.Name).Spec.MinAvailable)
 	})
 
@@ -128,38 +130,47 @@ func TestReconcilePodDisruptionBudget(t *testing.T) {
 		// must not widen the eviction budget for voters.
 		ec := newEtcdCluster(t, "pdb-with-learner", 4)
 
-		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(3, 1), scheme.Scheme))
+		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(3, 1), 4, scheme.Scheme))
 		assert.Equal(t, intstr.FromInt32(3), *getPDB(t, ec.Name).Spec.MinAvailable)
 	})
 
 	t.Run("scale-in pending sizes for post-removal membership", func(t *testing.T) {
 		ec := newEtcdCluster(t, "pdb-scale-in", 2)
 
-		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(3, 0), scheme.Scheme))
+		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(3, 0), 3, scheme.Scheme))
+		assert.Equal(t, intstr.FromInt32(3), *getPDB(t, ec.Name).Spec.MinAvailable)
+	})
+
+	t.Run("interrupted scale-in keeps the orphan pod priced in", func(t *testing.T) {
+		// After RemoveMember but before the StatefulSet shrinks, only 2
+		// members remain while 3 pods still match the selector.
+		ec := newEtcdCluster(t, "pdb-interrupted-scale-in", 2)
+
+		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(2, 0), 3, scheme.Scheme))
 		assert.Equal(t, intstr.FromInt32(3), *getPDB(t, ec.Name).Spec.MinAvailable)
 	})
 
 	t.Run("scale-out pending reserves the incoming learner pod", func(t *testing.T) {
 		ec := newEtcdCluster(t, "pdb-scale-out", 3)
 
-		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(1, 0), scheme.Scheme))
+		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(1, 0), 1, scheme.Scheme))
 		assert.Equal(t, intstr.FromInt32(2), *getPDB(t, ec.Name).Spec.MinAvailable)
 	})
 
 	t.Run("updates PDB on membership change (scale)", func(t *testing.T) {
 		ec := newEtcdCluster(t, "pdb-scale", 5)
 
-		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(1, 0), scheme.Scheme))
+		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(1, 0), 1, scheme.Scheme))
 		pdb := getPDB(t, ec.Name)
 		uid := pdb.UID
 		assert.Equal(t, intstr.FromInt32(2), *pdb.Spec.MinAvailable)
 
-		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(3, 0), scheme.Scheme))
+		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(3, 0), 3, scheme.Scheme))
 		pdb = getPDB(t, ec.Name)
 		assert.Equal(t, uid, pdb.UID)
 		assert.Equal(t, intstr.FromInt32(3), *pdb.Spec.MinAvailable)
 
-		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(5, 0), scheme.Scheme))
+		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(5, 0), 5, scheme.Scheme))
 		pdb = getPDB(t, ec.Name)
 		assert.Equal(t, uid, pdb.UID)
 		assert.Equal(t, intstr.FromInt32(3), *pdb.Spec.MinAvailable)
@@ -168,15 +179,15 @@ func TestReconcilePodDisruptionBudget(t *testing.T) {
 	t.Run("no members observed", func(t *testing.T) {
 		ec := newEtcdCluster(t, "pdb-no-members", 3)
 
-		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, nil, scheme.Scheme))
+		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, nil, 3, scheme.Scheme))
 		err := k8sClient.Get(ctx, client.ObjectKey{Name: ec.Name, Namespace: "default"},
 			&policyv1.PodDisruptionBudget{})
 		assert.True(t, client.IgnoreNotFound(err) == nil && err != nil, "expected NotFound, got %v", err)
 
 		// A pre-existing PDB must survive a loop that observes no members.
-		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(3, 0), scheme.Scheme))
+		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(3, 0), 3, scheme.Scheme))
 		before := getPDB(t, ec.Name)
-		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, nil, scheme.Scheme))
+		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, nil, 3, scheme.Scheme))
 		after := getPDB(t, ec.Name)
 		assert.Equal(t, before.UID, after.UID)
 		assert.Equal(t, intstr.FromInt32(2), *after.Spec.MinAvailable)
@@ -195,7 +206,7 @@ func TestReconcilePodDisruptionBudget(t *testing.T) {
 		}
 		require.NoError(t, k8sClient.Create(ctx, userPDB))
 
-		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(3, 0), scheme.Scheme))
+		require.NoError(t, reconcilePodDisruptionBudget(ctx, logger, k8sClient, ec, memberList(3, 0), 3, scheme.Scheme))
 
 		pdb := getPDB(t, ec.Name)
 		assert.Empty(t, pdb.OwnerReferences)

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -127,6 +127,15 @@ func createArgs(name string, etcdOptions []string) []string {
 	return defaultArgs
 }
 
+// etcdPodLabels labels the StatefulSet pods; the headless Service and
+// PodDisruptionBudget select on the same set.
+func etcdPodLabels(ec *ecv1alpha1.EtcdCluster) map[string]string {
+	return map[string]string{
+		"app":        ec.Name,
+		"controller": ec.Name,
+	}
+}
+
 func createOrPatchStatefulSet(ctx context.Context, logger logr.Logger, ec *ecv1alpha1.EtcdCluster, c client.Client, replicas int32, scheme *runtime.Scheme) error {
 	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -135,10 +144,7 @@ func createOrPatchStatefulSet(ctx context.Context, logger logr.Logger, ec *ecv1a
 		},
 	}
 
-	labels := map[string]string{
-		"app":        ec.Name,
-		"controller": ec.Name,
-	}
+	labels := etcdPodLabels(ec)
 
 	podSpec := corev1.PodSpec{
 		Containers: []corev1.Container{
@@ -377,10 +383,7 @@ func createHeadlessServiceIfNotExist(ctx context.Context, logger logr.Logger, c 
 		if k8serrors.IsNotFound(err) {
 			logger.Info("Headless service does not exist. Creating headless service")
 
-			labels := map[string]string{
-				"app":        ec.Name,
-				"controller": ec.Name,
-			}
+			labels := etcdPodLabels(ec)
 			// Create the headless service
 			headlessSvc := &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## What

The operator now maintains a **quorum-aware `PodDisruptionBudget`** for every `EtcdCluster` — named after the cluster, owned by it (ownerRef, so GC'd on delete), selecting the StatefulSet pods via the same `app`/`controller` labels as the headless Service.

Without a PDB, a node drain or any voluntary eviction can take down enough members at once to break quorum. Kubernetes-native etcd operators are expected to guard against this out of the box; today a `kubectl drain` across two nodes of a 3-member cluster is a quorum loss.

## Sizing (`minAvailable`)

A label selector cannot tell voters from learners (or from the pod of a just-removed member), so the budget assumes every permitted eviction lands on a voter:

```
minAvailable = total members − (voters − quorum(voters))
```

Pending scale steps are priced in *before* membership mutations run, closing the transition windows:

| state | example | minAvailable |
|---|---|---|
| steady 3 voters | 3/3 | 2 |
| steady 5 voters | 5/5 | 3 |
| learner present (promotion pending) | 3 voters + 1 learner | 3 |
| scale-in pending (removed member's pod lingers) | 3 → 2 | 3 |
| scale-out pending (learner pod incoming) | 3 → 5 | 3 |

## Reconciliation behavior

- The PDB is reconciled **even when health checks fail** — `healthCheck` still returns the member list for unhealthy clusters, which is exactly when disruption protection matters most. A PDB write failure is logged and surfaced for backoff only when nothing else requeues; it never masks health-check errors or blocks cluster-state reconciliation.
- With **no observed members**, any existing PDB is left untouched rather than weakened: a stale-but-protective PDB during an outage beats deleting it, and `minAvailable: 0` protects nothing.
- A pre-existing PDB with the same name that the operator did **not** create is skipped, never adopted — patching it would clobber a user-managed spec, and `SetControllerReference` would wedge the requeue path forever.
- `SetupWithManager` adds `Owns(&policyv1.PodDisruptionBudget{})`, so drift (manual edits/deletes) is repaired on the next event.

## Files

- **NEW** `internal/controller/poddisruptionbudget.go` — sizing math + `reconcilePodDisruptionBudget` (`CreateOrPatch`).
- `internal/controller/etcdcluster_controller.go` — wire into `Reconcile`, `Owns` watch, `policy` RBAC marker.
- `internal/controller/utils.go` — extract shared `etcdPodLabels` (StatefulSet / headless Service / PDB select on one set).
- `config/rbac/role.yaml`, `docs/api-references/docs.md`, `api/v1alpha1/zz_generated.deepcopy.go` — regenerated via `make generate manifests api-docs` (includes output that was stale on main).
- **NEW** `internal/controller/poddisruptionbudget_test.go` — envtest + table tests.

## Review

An adversarial review pass produced 5 findings, all blocking/important ones resolved (second commit): learner pods widening the eviction budget, the scale-in window where a removed member's lingering pod permits a quorum-breaking eviction, the symmetric scale-out window, adoption of a foreign same-name PDB (wedging on `SetControllerReference`), and PDB write errors masking health-check errors.

## Testing

- Table tests over the sizing math (`TestPDBMinAvailable`, `TestVotingMemberCount`): steady 1/2/3/5, learner mixes, pending scale-in/out including multi-step (5→2).
- envtest (`TestReconcilePodDisruptionBudget`): create, resize on membership change, learner handling, pending-scale sizing, no-members no-op, foreign-PDB non-adoption — all against a real apiserver, consistent with the repo's controller-helper testing pattern.
- Full `make test` and `make verify` pass.

## Descoped follow-ups

Trimmed to keep this PR #382/#384-sized: (1) no user-facing API field (e.g. `spec.podDisruptionBudget` template/override a la ECK) — operator-managed PDB only, so zero CRD/deepcopy/api-docs churn; (2) no PDB during bootstrap before the first etcd member is observed (minAvailable 0 protects nothing; PDB appears on the first loop that sees a member); (3) no deletion/GC logic — ownerRef garbage collection covers cluster deletion, and the reconciler deliberately never deletes a PDB on transient member-list failures; (4) no maxUnavailable mode, no unhealthyPodEvictionPolicy; (5) no e2e/kind test (test/e2e) — envtest-only coverage, consistent with the repo's controller-helper testing pattern; (6) no status surfacing of the PDB in EtcdClusterStatus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### PR series — operability fixes, TLS & EtcdMirror
<!-- pr-stack:begin -->
Small single-purpose PRs from live kind-cluster testing of the operator. Each stands alone unless an *After* is listed. → = this PR.

| | PR | Lands | After |
|---|----|-------|-------|
| | **Reviewable now — small, any order** | | |
| 🟢 | #374 | Requeue instead of swallowing the client-cert provisioning error | — |
| 🟢 | #391 | Grant `events.k8s.io` RBAC so operator Events are actually recorded | — |
| 🟢 | #392 | Correlate `members[]`/`leaderID` from one health snapshot (consistent leader) | — |
| 🟢 | #393 | Propagate user-supplied `altNames.ipAddresses` into certificates | — |
| 🟢 | #394 | Accept day-suffix `validityDuration` (`365d`, `100d12h`) as documented | — |
| 🟢 | #395 | Surface early reconcile errors as a `Degraded` condition (was empty status) | — |
| 🟢 | #379 | Configurable reconcile worker pool (`--max-concurrent-reconciles`) | — |
| 🟢 | #369 | kind-based stress/scale e2e harness (1/3/7 members, churn, quorum watcher) | — |
| 🟢 | #398 | `podTemplate.spec` scheduling fields: topologySpread, resources, priorityClass, schedulerName | — |
| 🟢 | #397 | First-class Helm chart covering the full `config/` surface | — |
| 🟢→ | #399 | Quorum-aware PodDisruptionBudget per EtcdCluster | — |
| 🟢 | #400 | Scale-in removes the right member and transfers leadership first | — |
| 🟢 | #401 | Backend quota + auto-compaction spec fields, NOSPACE alarm surfacing | — |
| 🟢 | #402 | Reconcile-loop gates replace the blocking StatefulSet-ready wait | — |
| 🟢 | #403 | Quorum-gated one-pod-at-a-time version upgrades via OnDelete | — |
| | **TLS stack — in order** | | |
| 🟢 | #376 | Independent `spec.tls.{peer,client}` surfaces (breaking alpha API) | — |
| ⚪ | #377 | `TLSReady` condition + TLS lifecycle Events | #376 |
| ⚪ | #378 | Multi-member TLS quorum e2e + `PeerCANotShared` | #377 |
| | **EtcdMirror — in order** | | |
| 🟢 | #406 | `EtcdMirror` CRD: one-way cross-cluster replication API (types + CEL) | — |
| 🟢 | #407 | `pkg/mirroragent` replication engine (fenced checkpoint-in-target) | #406 |
| 🟢 | #408 | Periodic reconciliation pass wired into the engine's steady-state loop | #407 |
| 🟢 | #412 | `mirror-agent` binary: config/TLS-reload/statusz/metrics + kind e2e | #408 |
| 🟢 | #413 | EtcdMirror controller: Deployment rendering, statusz-driven conditions, guards, fenced finalizer | #412 |
| 🟢 | #414 | CRD/sample/editor+viewer-role kustomize wiring | #413 |
| 🟢 | #415 | Controller-side phase/condition gauges, shipped PrometheusRule + dashboard | #414 |
| 🟢 | #416 | Full-lifecycle kind e2e: fence overlap, compaction+prune, restart resume, cert rotation, cutover/reversal | #415 |
| | **Parked as drafts pending #363** | | |
| ⚪ | #382 | Per-cluster domain metrics on the operator `/metrics` endpoint | — |
| ⚪ | #384 | EtcdCluster admission webhooks (consolidating with #328) | #363 |
| ⚪ | #386 | `EtcdBackup` CR → object storage (S3/GCS) | #363 |
| ⚪ | #387 | Automatic quorum-loss disaster recovery (bootstrap-latch guarded) | #363 |

🟢 ready · ⚪ draft
<!-- pr-stack:end -->