### PR TITLE
fix: remove the correct member on scale-in and transfer leadership first

### DIFF
--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -371,7 +371,8 @@ func (r *EtcdClusterReconciler) reconcileClusterState(ctx context.Context, s *re
 		logger = logger.WithValues("targetReplica", targetReplica, "expectedSize", s.cluster.Spec.Size)
 
 		eps = eps[:targetReplica]
-		if err := removeScaleInMember(logger, s.memberHealth, leaderStatus.Header.MemberId, eps); err != nil {
+		if err := removeScaleInMember(logger, s, leaderStatus.Header.MemberId, eps,
+			etcdutils.MoveLeader, etcdutils.RemoveMember); err != nil {
 			return ctrl.Result{}, err
 		}
 

--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -370,11 +370,8 @@ func (r *EtcdClusterReconciler) reconcileClusterState(ctx context.Context, s *re
 		targetReplica--
 		logger = logger.WithValues("targetReplica", targetReplica, "expectedSize", s.cluster.Spec.Size)
 
-		memberID := s.memberHealth[memberCnt-1].Status.Header.MemberId
-
-		logger.Info("[Scale in] removing one member", "memberID", memberID)
 		eps = eps[:targetReplica]
-		if err := etcdutils.RemoveMember(eps, memberID); err != nil {
+		if err := removeScaleInMember(logger, s.memberHealth, leaderStatus.Header.MemberId, eps); err != nil {
 			return ctrl.Result{}, err
 		}
 

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"maps"
 	"net"
+	"net/url"
 	"slices"
 	"strconv"
 	"strings"
@@ -481,6 +482,103 @@ func applyEtcdClusterState(ctx context.Context, ec *ecv1alpha1.EtcdCluster, repl
 func clientEndpointForOrdinalIndex(sts *appsv1.StatefulSet, index int) string {
 	return fmt.Sprintf("http://%s-%d.%s.%s.svc.cluster.local:2379",
 		sts.Name, index, sts.Name, sts.Namespace)
+}
+
+// ordinalFromEndpoint parses the STS ordinal from a member client endpoint,
+// e.g. http://name-3.name.ns.svc.cluster.local:2379 -> 3.
+func ordinalFromEndpoint(ep string) (int, error) {
+	u, err := url.Parse(ep)
+	if err != nil {
+		return 0, err
+	}
+	podName, _, _ := strings.Cut(u.Hostname(), ".")
+	// Ordinal is the segment after the last '-'; cluster names may contain dashes.
+	idx := strings.LastIndex(podName, "-")
+	if idx < 0 {
+		return 0, fmt.Errorf("no ordinal in endpoint %q", ep)
+	}
+	ordinal, err := strconv.Atoi(podName[idx+1:])
+	if err != nil {
+		return 0, fmt.Errorf("invalid ordinal in endpoint %q: %w", ep, err)
+	}
+	return ordinal, nil
+}
+
+// scaleInTarget returns the member with the highest STS ordinal. memberHealth
+// is sorted lexically by endpoint, so the last element is wrong once ordinals
+// reach 10.
+func scaleInTarget(healthInfos []etcdutils.EpHealth) (etcdutils.EpHealth, error) {
+	if len(healthInfos) == 0 {
+		return etcdutils.EpHealth{}, errors.New("no members eligible for scale-in")
+	}
+	maxIdx, maxOrdinal := 0, -1
+	for i := range healthInfos {
+		ordinal, err := ordinalFromEndpoint(healthInfos[i].Ep)
+		if err != nil {
+			return etcdutils.EpHealth{}, err
+		}
+		if ordinal > maxOrdinal {
+			maxOrdinal = ordinal
+			maxIdx = i
+		}
+	}
+	target := healthInfos[maxIdx]
+	if target.Status == nil || target.Status.Header == nil {
+		return etcdutils.EpHealth{}, fmt.Errorf("scale-in target %s has no status", target.Ep)
+	}
+	return target, nil
+}
+
+// transfereeForScaleIn returns the lowest-ordinal healthy voting member other
+// than removeID; ok=false when none exists.
+func transfereeForScaleIn(healthInfos []etcdutils.EpHealth, removeID uint64) (uint64, bool) {
+	var transferee uint64
+	bestOrdinal := -1
+	for i := range healthInfos {
+		h := healthInfos[i]
+		if !h.Health || h.Status == nil || h.Status.Header == nil ||
+			h.Status.IsLearner || h.Status.Header.MemberId == removeID {
+			continue
+		}
+		ordinal, err := ordinalFromEndpoint(h.Ep)
+		if err != nil {
+			continue
+		}
+		if bestOrdinal == -1 || ordinal < bestOrdinal {
+			bestOrdinal = ordinal
+			transferee = h.Status.Header.MemberId
+		}
+	}
+	return transferee, bestOrdinal >= 0
+}
+
+// Test seams.
+var (
+	moveLeaderFn   = etcdutils.MoveLeader
+	removeMemberFn = etcdutils.RemoveMember
+)
+
+// removeScaleInMember transfers leadership away from the removal target when
+// it is the leader (best-effort), then removes it from the etcd cluster.
+func removeScaleInMember(logger logr.Logger, healthInfos []etcdutils.EpHealth, leaderID uint64, eps []string) error {
+	target, err := scaleInTarget(healthInfos)
+	if err != nil {
+		return err
+	}
+	memberID := target.Status.Header.MemberId
+	if memberID == leaderID {
+		if transferee, ok := transfereeForScaleIn(healthInfos, memberID); ok {
+			logger.Info("[Scale in] transferring leadership off removal target",
+				"leaderID", memberID, "transfereeID", transferee)
+			// MoveLeader must be served by the leader itself.
+			if err := moveLeaderFn([]string{target.Ep}, transferee); err != nil {
+				// Best-effort: removing a leader is legal; the transfer only avoids an election stall.
+				logger.Error(err, "leadership transfer failed, proceeding with removal")
+			}
+		}
+	}
+	logger.Info("[Scale in] removing one member", "memberID", memberID)
+	return removeMemberFn(eps, memberID)
 }
 
 func getStatefulSet(ctx context.Context, c client.Client, name, namespace string) (*appsv1.StatefulSet, error) {

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"maps"
 	"net"
-	"net/url"
 	"slices"
 	"strconv"
 	"strings"
@@ -32,6 +31,7 @@ import (
 	"go.etcd.io/etcd-operator/internal/etcdutils"
 	"go.etcd.io/etcd-operator/pkg/certificate"
 	certInterface "go.etcd.io/etcd-operator/pkg/certificate/interfaces"
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
@@ -484,101 +484,67 @@ func clientEndpointForOrdinalIndex(sts *appsv1.StatefulSet, index int) string {
 		sts.Name, index, sts.Name, sts.Namespace)
 }
 
-// ordinalFromEndpoint parses the STS ordinal from a member client endpoint,
-// e.g. http://name-3.name.ns.svc.cluster.local:2379 -> 3.
-func ordinalFromEndpoint(ep string) (int, error) {
-	u, err := url.Parse(ep)
-	if err != nil {
-		return 0, err
+// scaleInTargetID returns the ID of the highest-ordinal member — the pod the
+// StatefulSet scale-in deletes. Members run with --name=$(POD_NAME), so match
+// by name against the authoritative member list; the target need not be
+// reachable. memberHealth can't be used here: it is sorted lexically by
+// endpoint, so its last element is wrong once ordinals reach 10.
+func scaleInTargetID(sts *appsv1.StatefulSet, members []*etcdserverpb.Member) (uint64, error) {
+	if len(members) == 0 {
+		return 0, errors.New("no members eligible for scale-in")
 	}
-	podName, _, _ := strings.Cut(u.Hostname(), ".")
-	// Ordinal is the segment after the last '-'; cluster names may contain dashes.
-	idx := strings.LastIndex(podName, "-")
-	if idx < 0 {
-		return 0, fmt.Errorf("no ordinal in endpoint %q", ep)
-	}
-	ordinal, err := strconv.Atoi(podName[idx+1:])
-	if err != nil {
-		return 0, fmt.Errorf("invalid ordinal in endpoint %q: %w", ep, err)
-	}
-	return ordinal, nil
-}
-
-// scaleInTarget returns the member with the highest STS ordinal. memberHealth
-// is sorted lexically by endpoint, so the last element is wrong once ordinals
-// reach 10.
-func scaleInTarget(healthInfos []etcdutils.EpHealth) (etcdutils.EpHealth, error) {
-	if len(healthInfos) == 0 {
-		return etcdutils.EpHealth{}, errors.New("no members eligible for scale-in")
-	}
-	maxIdx, maxOrdinal := 0, -1
-	for i := range healthInfos {
-		ordinal, err := ordinalFromEndpoint(healthInfos[i].Ep)
-		if err != nil {
-			return etcdutils.EpHealth{}, err
-		}
-		if ordinal > maxOrdinal {
-			maxOrdinal = ordinal
-			maxIdx = i
+	name := fmt.Sprintf("%s-%d", sts.Name, len(members)-1)
+	for _, m := range members {
+		if m.Name == name {
+			return m.ID, nil
 		}
 	}
-	target := healthInfos[maxIdx]
-	if target.Status == nil || target.Status.Header == nil {
-		return etcdutils.EpHealth{}, fmt.Errorf("scale-in target %s has no status", target.Ep)
-	}
-	return target, nil
+	return 0, fmt.Errorf("scale-in target %s not found in member list", name)
 }
 
 // transfereeForScaleIn returns the lowest-ordinal healthy voting member other
 // than removeID; ok=false when none exists.
-func transfereeForScaleIn(healthInfos []etcdutils.EpHealth, removeID uint64) (uint64, bool) {
-	var transferee uint64
-	bestOrdinal := -1
+func transfereeForScaleIn(sts *appsv1.StatefulSet, healthInfos []etcdutils.EpHealth, removeID uint64) (uint64, bool) {
+	byEp := make(map[string]etcdutils.EpHealth, len(healthInfos))
+	for _, h := range healthInfos {
+		byEp[h.Ep] = h
+	}
 	for i := range healthInfos {
-		h := healthInfos[i]
-		if !h.Health || h.Status == nil || h.Status.Header == nil ||
+		h, ok := byEp[clientEndpointForOrdinalIndex(sts, i)]
+		if !ok || !h.Health || h.Status == nil || h.Status.Header == nil ||
 			h.Status.IsLearner || h.Status.Header.MemberId == removeID {
 			continue
 		}
-		ordinal, err := ordinalFromEndpoint(h.Ep)
-		if err != nil {
-			continue
-		}
-		if bestOrdinal == -1 || ordinal < bestOrdinal {
-			bestOrdinal = ordinal
-			transferee = h.Status.Header.MemberId
-		}
+		return h.Status.Header.MemberId, true
 	}
-	return transferee, bestOrdinal >= 0
+	return 0, false
 }
-
-// Test seams.
-var (
-	moveLeaderFn   = etcdutils.MoveLeader
-	removeMemberFn = etcdutils.RemoveMember
-)
 
 // removeScaleInMember transfers leadership away from the removal target when
 // it is the leader (best-effort), then removes it from the etcd cluster.
-func removeScaleInMember(logger logr.Logger, healthInfos []etcdutils.EpHealth, leaderID uint64, eps []string) error {
-	target, err := scaleInTarget(healthInfos)
+// moveLeader/removeMember are parameters so tests can stub the etcd calls;
+// production passes etcdutils.MoveLeader and etcdutils.RemoveMember.
+func removeScaleInMember(logger logr.Logger, s *reconcileState, leaderID uint64, eps []string,
+	moveLeader, removeMember func([]string, uint64) error) error {
+	members := s.memberListResp.Members
+	memberID, err := scaleInTargetID(s.sts, members)
 	if err != nil {
 		return err
 	}
-	memberID := target.Status.Header.MemberId
 	if memberID == leaderID {
-		if transferee, ok := transfereeForScaleIn(healthInfos, memberID); ok {
+		if transferee, ok := transfereeForScaleIn(s.sts, s.memberHealth, memberID); ok {
 			logger.Info("[Scale in] transferring leadership off removal target",
 				"leaderID", memberID, "transfereeID", transferee)
 			// MoveLeader must be served by the leader itself.
-			if err := moveLeaderFn([]string{target.Ep}, transferee); err != nil {
+			leaderEp := clientEndpointForOrdinalIndex(s.sts, len(members)-1)
+			if err := moveLeader([]string{leaderEp}, transferee); err != nil {
 				// Best-effort: removing a leader is legal; the transfer only avoids an election stall.
 				logger.Error(err, "leadership transfer failed, proceeding with removal")
 			}
 		}
 	}
 	logger.Info("[Scale in] removing one member", "memberID", memberID)
-	return removeMemberFn(eps, memberID)
+	return removeMember(eps, memberID)
 }
 
 func getStatefulSet(ctx context.Context, c client.Client, name, namespace string) (*appsv1.StatefulSet, error) {

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sort"
 	"testing"
 	"time"
 
@@ -1089,4 +1090,274 @@ func TestCreateCMCertificateConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOrdinalFromEndpoint(t *testing.T) {
+	tests := []struct {
+		name      string
+		ep        string
+		expected  int
+		expectErr bool
+	}{
+		{
+			name:     "ordinal 0",
+			ep:       "http://test-sts-0.test-sts.default.svc.cluster.local:2379",
+			expected: 0,
+		},
+		{
+			name:     "ordinal 9",
+			ep:       "http://test-sts-9.test-sts.default.svc.cluster.local:2379",
+			expected: 9,
+		},
+		{
+			name:     "ordinal 10",
+			ep:       "http://test-sts-10.test-sts.default.svc.cluster.local:2379",
+			expected: 10,
+		},
+		{
+			name:     "multi-dash cluster name",
+			ep:       "http://my-etcd-12.my-etcd.ns.svc.cluster.local:2379",
+			expected: 12,
+		},
+		{
+			name:     "https scheme",
+			ep:       "https://test-sts-3.test-sts.default.svc.cluster.local:2379",
+			expected: 3,
+		},
+		{
+			name:      "no dash in pod name",
+			ep:        "http://podname.ns.svc.cluster.local:2379",
+			expectErr: true,
+		},
+		{
+			name:      "non-numeric suffix",
+			ep:        "http://test-sts-abc.test-sts.default.svc.cluster.local:2379",
+			expectErr: true,
+		},
+		{
+			name:      "empty string",
+			ep:        "",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ordinal, err := ordinalFromEndpoint(tt.ep)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, ordinal)
+			}
+		})
+	}
+}
+
+// scaleInEpHealth builds an EpHealth for the given ordinal using the real
+// endpoint format produced by clientEndpointForOrdinalIndex.
+func scaleInEpHealth(ordinal int, memberID uint64, healthy, learner bool) etcdutils.EpHealth {
+	return etcdutils.EpHealth{
+		Ep:     fmt.Sprintf("http://test-etcd-%d.test-etcd.default.svc.cluster.local:2379", ordinal),
+		Health: healthy,
+		Status: &clientv3.StatusResponse{
+			Header:    &etcdserverpb.ResponseHeader{MemberId: memberID},
+			IsLearner: learner,
+		},
+	}
+}
+
+// sortLexically reproduces etcdutils.ClusterHealth's healthReport sort order.
+func sortLexically(infos []etcdutils.EpHealth) {
+	sort.Slice(infos, func(i, j int) bool { return infos[i].Ep < infos[j].Ep })
+}
+
+func TestScaleInTarget(t *testing.T) {
+	t.Run("11 members: lexical order misleads, ordinal wins", func(t *testing.T) {
+		var infos []etcdutils.EpHealth
+		for i := 0; i <= 10; i++ {
+			infos = append(infos, scaleInEpHealth(i, uint64(100+i), true, false))
+		}
+		sortLexically(infos)
+
+		// The lexically-last entry is ordinal 9 — the old memberHealth[memberCnt-1]
+		// selection would remove the wrong member.
+		lastOrdinal, err := ordinalFromEndpoint(infos[len(infos)-1].Ep)
+		require.NoError(t, err)
+		assert.Equal(t, 9, lastOrdinal)
+
+		target, err := scaleInTarget(infos)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(110), target.Status.Header.MemberId)
+		assert.Equal(t, "http://test-etcd-10.test-etcd.default.svc.cluster.local:2379", target.Ep)
+	})
+
+	t.Run("3 members happy path", func(t *testing.T) {
+		infos := []etcdutils.EpHealth{
+			scaleInEpHealth(0, 100, true, false),
+			scaleInEpHealth(1, 101, true, false),
+			scaleInEpHealth(2, 102, true, false),
+		}
+		target, err := scaleInTarget(infos)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(102), target.Status.Header.MemberId)
+	})
+
+	t.Run("empty slice", func(t *testing.T) {
+		_, err := scaleInTarget(nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("nil status on max-ordinal entry", func(t *testing.T) {
+		infos := []etcdutils.EpHealth{
+			scaleInEpHealth(0, 100, true, false),
+			{Ep: "http://test-etcd-1.test-etcd.default.svc.cluster.local:2379", Health: true},
+		}
+		_, err := scaleInTarget(infos)
+		assert.Error(t, err)
+	})
+}
+
+func TestTransfereeForScaleIn(t *testing.T) {
+	t.Run("returns lowest ordinal voting member", func(t *testing.T) {
+		infos := []etcdutils.EpHealth{
+			scaleInEpHealth(0, 100, true, false),
+			scaleInEpHealth(1, 101, true, false),
+			scaleInEpHealth(2, 102, true, false),
+		}
+		transferee, ok := transfereeForScaleIn(infos, 102)
+		assert.True(t, ok)
+		assert.Equal(t, uint64(100), transferee)
+	})
+
+	t.Run("skips learner at ordinal 0", func(t *testing.T) {
+		infos := []etcdutils.EpHealth{
+			scaleInEpHealth(0, 100, true, true),
+			scaleInEpHealth(1, 101, true, false),
+			scaleInEpHealth(2, 102, true, false),
+		}
+		transferee, ok := transfereeForScaleIn(infos, 102)
+		assert.True(t, ok)
+		assert.Equal(t, uint64(101), transferee)
+	})
+
+	t.Run("only remaining member is a learner", func(t *testing.T) {
+		infos := []etcdutils.EpHealth{
+			scaleInEpHealth(0, 100, true, true),
+			scaleInEpHealth(1, 101, true, false),
+		}
+		_, ok := transfereeForScaleIn(infos, 101)
+		assert.False(t, ok)
+	})
+
+	t.Run("skips unhealthy members", func(t *testing.T) {
+		infos := []etcdutils.EpHealth{
+			scaleInEpHealth(0, 100, false, false),
+			scaleInEpHealth(1, 101, true, false),
+			scaleInEpHealth(2, 102, true, false),
+		}
+		transferee, ok := transfereeForScaleIn(infos, 102)
+		assert.True(t, ok)
+		assert.Equal(t, uint64(101), transferee)
+	})
+
+	t.Run("never returns the removal target", func(t *testing.T) {
+		infos := []etcdutils.EpHealth{
+			scaleInEpHealth(0, 100, true, false),
+		}
+		_, ok := transfereeForScaleIn(infos, 100)
+		assert.False(t, ok)
+	})
+}
+
+func TestRemoveScaleInMember(t *testing.T) {
+	logger := logr.Discard()
+
+	type call struct {
+		fn  string
+		eps []string
+		id  uint64
+	}
+
+	var calls []call
+	var moveErr error
+
+	origMove, origRemove := moveLeaderFn, removeMemberFn
+	t.Cleanup(func() { moveLeaderFn, removeMemberFn = origMove, origRemove })
+	moveLeaderFn = func(eps []string, transfereeID uint64) error {
+		calls = append(calls, call{fn: "move", eps: eps, id: transfereeID})
+		return moveErr
+	}
+	removeMemberFn = func(eps []string, memberID uint64) error {
+		calls = append(calls, call{fn: "remove", eps: eps, id: memberID})
+		return nil
+	}
+
+	threeMembers := []etcdutils.EpHealth{
+		scaleInEpHealth(0, 100, true, false),
+		scaleInEpHealth(1, 101, true, false),
+		scaleInEpHealth(2, 102, true, false),
+	}
+	eps := []string{"ep0", "ep1"}
+
+	t.Run("target is leader: transfer before removal", func(t *testing.T) {
+		calls, moveErr = nil, nil
+		err := removeScaleInMember(logger, threeMembers, 102, eps)
+		require.NoError(t, err)
+		require.Len(t, calls, 2)
+		assert.Equal(t, "move", calls[0].fn)
+		assert.Equal(t, []string{threeMembers[2].Ep}, calls[0].eps)
+		assert.Equal(t, uint64(100), calls[0].id)
+		assert.Equal(t, "remove", calls[1].fn)
+		assert.Equal(t, eps, calls[1].eps)
+		assert.Equal(t, uint64(102), calls[1].id)
+	})
+
+	t.Run("target not leader: no transfer", func(t *testing.T) {
+		calls, moveErr = nil, nil
+		err := removeScaleInMember(logger, threeMembers, 100, eps)
+		require.NoError(t, err)
+		require.Len(t, calls, 1)
+		assert.Equal(t, "remove", calls[0].fn)
+		assert.Equal(t, uint64(102), calls[0].id)
+	})
+
+	t.Run("transfer failure does not block removal", func(t *testing.T) {
+		calls, moveErr = nil, errors.New("transfer failed")
+		err := removeScaleInMember(logger, threeMembers, 102, eps)
+		require.NoError(t, err)
+		require.Len(t, calls, 2)
+		assert.Equal(t, "move", calls[0].fn)
+		assert.Equal(t, "remove", calls[1].fn)
+	})
+
+	t.Run("leader target with no eligible transferee", func(t *testing.T) {
+		calls, moveErr = nil, nil
+		infos := []etcdutils.EpHealth{
+			scaleInEpHealth(0, 100, true, true), // learner survivor
+			scaleInEpHealth(1, 101, true, false),
+		}
+		err := removeScaleInMember(logger, infos, 101, eps)
+		require.NoError(t, err)
+		require.Len(t, calls, 1)
+		assert.Equal(t, "remove", calls[0].fn)
+		assert.Equal(t, uint64(101), calls[0].id)
+	})
+
+	t.Run("11 members lexical order, leader at ordinal 10", func(t *testing.T) {
+		calls, moveErr = nil, nil
+		var infos []etcdutils.EpHealth
+		for i := 0; i <= 10; i++ {
+			infos = append(infos, scaleInEpHealth(i, uint64(100+i), true, false))
+		}
+		sortLexically(infos)
+		err := removeScaleInMember(logger, infos, 110, eps)
+		require.NoError(t, err)
+		require.Len(t, calls, 2)
+		assert.Equal(t, "move", calls[0].fn)
+		assert.Equal(t, []string{"http://test-etcd-10.test-etcd.default.svc.cluster.local:2379"}, calls[0].eps)
+		assert.Equal(t, uint64(100), calls[0].id)
+		assert.Equal(t, "remove", calls[1].fn)
+		assert.Equal(t, uint64(110), calls[1].id) // ordinal 10, not the lexically-last ordinal 9
+	})
 }

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -1092,65 +1092,10 @@ func TestCreateCMCertificateConfig(t *testing.T) {
 	}
 }
 
-func TestOrdinalFromEndpoint(t *testing.T) {
-	tests := []struct {
-		name      string
-		ep        string
-		expected  int
-		expectErr bool
-	}{
-		{
-			name:     "ordinal 0",
-			ep:       "http://test-sts-0.test-sts.default.svc.cluster.local:2379",
-			expected: 0,
-		},
-		{
-			name:     "ordinal 9",
-			ep:       "http://test-sts-9.test-sts.default.svc.cluster.local:2379",
-			expected: 9,
-		},
-		{
-			name:     "ordinal 10",
-			ep:       "http://test-sts-10.test-sts.default.svc.cluster.local:2379",
-			expected: 10,
-		},
-		{
-			name:     "multi-dash cluster name",
-			ep:       "http://my-etcd-12.my-etcd.ns.svc.cluster.local:2379",
-			expected: 12,
-		},
-		{
-			name:     "https scheme",
-			ep:       "https://test-sts-3.test-sts.default.svc.cluster.local:2379",
-			expected: 3,
-		},
-		{
-			name:      "no dash in pod name",
-			ep:        "http://podname.ns.svc.cluster.local:2379",
-			expectErr: true,
-		},
-		{
-			name:      "non-numeric suffix",
-			ep:        "http://test-sts-abc.test-sts.default.svc.cluster.local:2379",
-			expectErr: true,
-		},
-		{
-			name:      "empty string",
-			ep:        "",
-			expectErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ordinal, err := ordinalFromEndpoint(tt.ep)
-			if tt.expectErr {
-				assert.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tt.expected, ordinal)
-			}
-		})
+// scaleInSts returns a StatefulSet whose client endpoints match scaleInEpHealth.
+func scaleInSts() *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-etcd", Namespace: "default"},
 	}
 }
 
@@ -1167,65 +1112,66 @@ func scaleInEpHealth(ordinal int, memberID uint64, healthy, learner bool) etcdut
 	}
 }
 
+func scaleInMember(ordinal int, id uint64) *etcdserverpb.Member {
+	return &etcdserverpb.Member{Name: fmt.Sprintf("test-etcd-%d", ordinal), ID: id}
+}
+
 // sortLexically reproduces etcdutils.ClusterHealth's healthReport sort order.
 func sortLexically(infos []etcdutils.EpHealth) {
 	sort.Slice(infos, func(i, j int) bool { return infos[i].Ep < infos[j].Ep })
 }
 
-func TestScaleInTarget(t *testing.T) {
-	t.Run("11 members: lexical order misleads, ordinal wins", func(t *testing.T) {
-		var infos []etcdutils.EpHealth
-		for i := 0; i <= 10; i++ {
-			infos = append(infos, scaleInEpHealth(i, uint64(100+i), true, false))
-		}
-		sortLexically(infos)
-
-		// The lexically-last entry is ordinal 9 — the old memberHealth[memberCnt-1]
-		// selection would remove the wrong member.
-		lastOrdinal, err := ordinalFromEndpoint(infos[len(infos)-1].Ep)
-		require.NoError(t, err)
-		assert.Equal(t, 9, lastOrdinal)
-
-		target, err := scaleInTarget(infos)
-		require.NoError(t, err)
-		assert.Equal(t, uint64(110), target.Status.Header.MemberId)
-		assert.Equal(t, "http://test-etcd-10.test-etcd.default.svc.cluster.local:2379", target.Ep)
-	})
+func TestScaleInTargetID(t *testing.T) {
+	sts := scaleInSts()
 
 	t.Run("3 members happy path", func(t *testing.T) {
-		infos := []etcdutils.EpHealth{
-			scaleInEpHealth(0, 100, true, false),
-			scaleInEpHealth(1, 101, true, false),
-			scaleInEpHealth(2, 102, true, false),
+		members := []*etcdserverpb.Member{
+			scaleInMember(1, 101),
+			scaleInMember(0, 100),
+			scaleInMember(2, 102),
 		}
-		target, err := scaleInTarget(infos)
+		id, err := scaleInTargetID(sts, members)
 		require.NoError(t, err)
-		assert.Equal(t, uint64(102), target.Status.Header.MemberId)
+		assert.Equal(t, uint64(102), id)
 	})
 
-	t.Run("empty slice", func(t *testing.T) {
-		_, err := scaleInTarget(nil)
+	t.Run("11 members: highest ordinal wins regardless of order", func(t *testing.T) {
+		var members []*etcdserverpb.Member
+		// Reverse order — member list order carries no ordinal meaning.
+		for i := 10; i >= 0; i-- {
+			members = append(members, scaleInMember(i, uint64(100+i)))
+		}
+		id, err := scaleInTargetID(sts, members)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(110), id)
+	})
+
+	t.Run("empty member list", func(t *testing.T) {
+		_, err := scaleInTargetID(sts, nil)
 		assert.Error(t, err)
 	})
 
-	t.Run("nil status on max-ordinal entry", func(t *testing.T) {
-		infos := []etcdutils.EpHealth{
-			scaleInEpHealth(0, 100, true, false),
-			{Ep: "http://test-etcd-1.test-etcd.default.svc.cluster.local:2379", Health: true},
+	t.Run("target name missing from member list", func(t *testing.T) {
+		// Unstarted members report an empty name.
+		members := []*etcdserverpb.Member{
+			scaleInMember(0, 100),
+			{ID: 101},
 		}
-		_, err := scaleInTarget(infos)
+		_, err := scaleInTargetID(sts, members)
 		assert.Error(t, err)
 	})
 }
 
 func TestTransfereeForScaleIn(t *testing.T) {
+	sts := scaleInSts()
+
 	t.Run("returns lowest ordinal voting member", func(t *testing.T) {
 		infos := []etcdutils.EpHealth{
 			scaleInEpHealth(0, 100, true, false),
 			scaleInEpHealth(1, 101, true, false),
 			scaleInEpHealth(2, 102, true, false),
 		}
-		transferee, ok := transfereeForScaleIn(infos, 102)
+		transferee, ok := transfereeForScaleIn(sts, infos, 102)
 		assert.True(t, ok)
 		assert.Equal(t, uint64(100), transferee)
 	})
@@ -1236,7 +1182,7 @@ func TestTransfereeForScaleIn(t *testing.T) {
 			scaleInEpHealth(1, 101, true, false),
 			scaleInEpHealth(2, 102, true, false),
 		}
-		transferee, ok := transfereeForScaleIn(infos, 102)
+		transferee, ok := transfereeForScaleIn(sts, infos, 102)
 		assert.True(t, ok)
 		assert.Equal(t, uint64(101), transferee)
 	})
@@ -1246,7 +1192,7 @@ func TestTransfereeForScaleIn(t *testing.T) {
 			scaleInEpHealth(0, 100, true, true),
 			scaleInEpHealth(1, 101, true, false),
 		}
-		_, ok := transfereeForScaleIn(infos, 101)
+		_, ok := transfereeForScaleIn(sts, infos, 101)
 		assert.False(t, ok)
 	})
 
@@ -1256,7 +1202,7 @@ func TestTransfereeForScaleIn(t *testing.T) {
 			scaleInEpHealth(1, 101, true, false),
 			scaleInEpHealth(2, 102, true, false),
 		}
-		transferee, ok := transfereeForScaleIn(infos, 102)
+		transferee, ok := transfereeForScaleIn(sts, infos, 102)
 		assert.True(t, ok)
 		assert.Equal(t, uint64(101), transferee)
 	})
@@ -1265,48 +1211,56 @@ func TestTransfereeForScaleIn(t *testing.T) {
 		infos := []etcdutils.EpHealth{
 			scaleInEpHealth(0, 100, true, false),
 		}
-		_, ok := transfereeForScaleIn(infos, 100)
+		_, ok := transfereeForScaleIn(sts, infos, 100)
 		assert.False(t, ok)
 	})
 }
 
 func TestRemoveScaleInMember(t *testing.T) {
 	logger := logr.Discard()
+	eps := []string{"ep0", "ep1"}
 
 	type call struct {
 		fn  string
 		eps []string
 		id  uint64
 	}
-
-	var calls []call
-	var moveErr error
-
-	origMove, origRemove := moveLeaderFn, removeMemberFn
-	t.Cleanup(func() { moveLeaderFn, removeMemberFn = origMove, origRemove })
-	moveLeaderFn = func(eps []string, transfereeID uint64) error {
-		calls = append(calls, call{fn: "move", eps: eps, id: transfereeID})
-		return moveErr
+	// Per-test stubs capture into a local slice — no shared state between sub-tests.
+	stubs := func(calls *[]call, moveErr error) (moveLeader, removeMember func([]string, uint64) error) {
+		return func(eps []string, id uint64) error {
+				*calls = append(*calls, call{fn: "move", eps: eps, id: id})
+				return moveErr
+			}, func(eps []string, id uint64) error {
+				*calls = append(*calls, call{fn: "remove", eps: eps, id: id})
+				return nil
+			}
 	}
-	removeMemberFn = func(eps []string, memberID uint64) error {
-		calls = append(calls, call{fn: "remove", eps: eps, id: memberID})
-		return nil
+	newState := func(memberHealth []etcdutils.EpHealth, members ...*etcdserverpb.Member) *reconcileState {
+		return &reconcileState{
+			sts:            scaleInSts(),
+			memberListResp: &clientv3.MemberListResponse{Members: members},
+			memberHealth:   memberHealth,
+		}
 	}
 
-	threeMembers := []etcdutils.EpHealth{
+	threeHealthy := []etcdutils.EpHealth{
 		scaleInEpHealth(0, 100, true, false),
 		scaleInEpHealth(1, 101, true, false),
 		scaleInEpHealth(2, 102, true, false),
 	}
-	eps := []string{"ep0", "ep1"}
+	threeMembers := []*etcdserverpb.Member{
+		scaleInMember(0, 100), scaleInMember(1, 101), scaleInMember(2, 102),
+	}
 
 	t.Run("target is leader: transfer before removal", func(t *testing.T) {
-		calls, moveErr = nil, nil
-		err := removeScaleInMember(logger, threeMembers, 102, eps)
+		var calls []call
+		moveLeader, removeMember := stubs(&calls, nil)
+		err := removeScaleInMember(logger, newState(threeHealthy, threeMembers...), 102, eps,
+			moveLeader, removeMember)
 		require.NoError(t, err)
 		require.Len(t, calls, 2)
 		assert.Equal(t, "move", calls[0].fn)
-		assert.Equal(t, []string{threeMembers[2].Ep}, calls[0].eps)
+		assert.Equal(t, []string{threeHealthy[2].Ep}, calls[0].eps)
 		assert.Equal(t, uint64(100), calls[0].id)
 		assert.Equal(t, "remove", calls[1].fn)
 		assert.Equal(t, eps, calls[1].eps)
@@ -1314,8 +1268,10 @@ func TestRemoveScaleInMember(t *testing.T) {
 	})
 
 	t.Run("target not leader: no transfer", func(t *testing.T) {
-		calls, moveErr = nil, nil
-		err := removeScaleInMember(logger, threeMembers, 100, eps)
+		var calls []call
+		moveLeader, removeMember := stubs(&calls, nil)
+		err := removeScaleInMember(logger, newState(threeHealthy, threeMembers...), 100, eps,
+			moveLeader, removeMember)
 		require.NoError(t, err)
 		require.Len(t, calls, 1)
 		assert.Equal(t, "remove", calls[0].fn)
@@ -1323,8 +1279,10 @@ func TestRemoveScaleInMember(t *testing.T) {
 	})
 
 	t.Run("transfer failure does not block removal", func(t *testing.T) {
-		calls, moveErr = nil, errors.New("transfer failed")
-		err := removeScaleInMember(logger, threeMembers, 102, eps)
+		var calls []call
+		moveLeader, removeMember := stubs(&calls, errors.New("transfer failed"))
+		err := removeScaleInMember(logger, newState(threeHealthy, threeMembers...), 102, eps,
+			moveLeader, removeMember)
 		require.NoError(t, err)
 		require.Len(t, calls, 2)
 		assert.Equal(t, "move", calls[0].fn)
@@ -1332,32 +1290,58 @@ func TestRemoveScaleInMember(t *testing.T) {
 	})
 
 	t.Run("leader target with no eligible transferee", func(t *testing.T) {
-		calls, moveErr = nil, nil
+		var calls []call
+		moveLeader, removeMember := stubs(&calls, nil)
 		infos := []etcdutils.EpHealth{
 			scaleInEpHealth(0, 100, true, true), // learner survivor
 			scaleInEpHealth(1, 101, true, false),
 		}
-		err := removeScaleInMember(logger, infos, 101, eps)
+		s := newState(infos, scaleInMember(0, 100), scaleInMember(1, 101))
+		err := removeScaleInMember(logger, s, 101, eps, moveLeader, removeMember)
 		require.NoError(t, err)
 		require.Len(t, calls, 1)
 		assert.Equal(t, "remove", calls[0].fn)
 		assert.Equal(t, uint64(101), calls[0].id)
 	})
 
-	t.Run("11 members lexical order, leader at ordinal 10", func(t *testing.T) {
-		calls, moveErr = nil, nil
+	t.Run("unreachable target still removed via member list", func(t *testing.T) {
+		var calls []call
+		moveLeader, removeMember := stubs(&calls, nil)
+		infos := []etcdutils.EpHealth{
+			scaleInEpHealth(0, 100, true, false),
+			scaleInEpHealth(1, 101, true, false),
+			{Ep: "http://test-etcd-2.test-etcd.default.svc.cluster.local:2379"}, // no status
+		}
+		err := removeScaleInMember(logger, newState(infos, threeMembers...), 100, eps,
+			moveLeader, removeMember)
+		require.NoError(t, err)
+		require.Len(t, calls, 1)
+		assert.Equal(t, "remove", calls[0].fn)
+		assert.Equal(t, uint64(102), calls[0].id)
+	})
+
+	t.Run("11 members: lexical health order, leader at ordinal 10", func(t *testing.T) {
+		var calls []call
+		moveLeader, removeMember := stubs(&calls, nil)
 		var infos []etcdutils.EpHealth
+		var members []*etcdserverpb.Member
 		for i := 0; i <= 10; i++ {
 			infos = append(infos, scaleInEpHealth(i, uint64(100+i), true, false))
+			members = append(members, scaleInMember(i, uint64(100+i)))
 		}
 		sortLexically(infos)
-		err := removeScaleInMember(logger, infos, 110, eps)
+		// The lexically-last health entry is ordinal 9 — the old
+		// memberHealth[memberCnt-1] selection would remove the wrong member.
+		assert.Equal(t, scaleInEpHealth(9, 109, true, false).Ep, infos[len(infos)-1].Ep)
+
+		err := removeScaleInMember(logger, newState(infos, members...), 110, eps,
+			moveLeader, removeMember)
 		require.NoError(t, err)
 		require.Len(t, calls, 2)
 		assert.Equal(t, "move", calls[0].fn)
 		assert.Equal(t, []string{"http://test-etcd-10.test-etcd.default.svc.cluster.local:2379"}, calls[0].eps)
 		assert.Equal(t, uint64(100), calls[0].id)
 		assert.Equal(t, "remove", calls[1].fn)
-		assert.Equal(t, uint64(110), calls[1].id) // ordinal 10, not the lexically-last ordinal 9
+		assert.Equal(t, uint64(110), calls[1].id)
 	})
 }

--- a/internal/etcdutils/etcdutils.go
+++ b/internal/etcdutils/etcdutils.go
@@ -283,3 +283,32 @@ func RemoveMember(eps []string, memberID uint64) error {
 	_, err = c.MemberRemove(ctx, memberID)
 	return err
 }
+
+// MoveLeader transfers leadership to transfereeID. eps must contain the
+// current leader's client endpoint; etcd only serves MoveLeader on the leader.
+func MoveLeader(eps []string, transfereeID uint64) error {
+	cfg := clientv3.Config{
+		Endpoints:            eps,
+		DialTimeout:          2 * time.Second,
+		DialKeepAliveTime:    2 * time.Second,
+		DialKeepAliveTimeout: 6 * time.Second,
+	}
+
+	c, err := clientv3.New(cfg)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer func() {
+		err := c.Close()
+		if err != nil {
+			cancel()
+			return
+		}
+		cancel()
+	}()
+
+	_, err = c.MoveLeader(ctx, transfereeID)
+	return err
+}

--- a/internal/etcdutils/etcdutils_test.go
+++ b/internal/etcdutils/etcdutils_test.go
@@ -336,3 +336,20 @@ func TestHealthReportSwap(t *testing.T) {
 	assert.Equal(t, "http://localhost:2380", healthReports[0].Ep)
 	assert.Equal(t, "http://localhost:2379", healthReports[1].Ep)
 }
+
+func TestMoveLeader(t *testing.T) {
+	e := setupEtcdServer(t)
+	defer e.Close()
+
+	t.Run("ReturnsErrorForInvalidEndpoint", func(t *testing.T) {
+		eps := []string{"http://invalid:2379"}
+		err := MoveLeader(eps, 12345)
+		assert.Error(t, err)
+	})
+
+	t.Run("ReturnsErrorForBogusTransferee", func(t *testing.T) {
+		eps := []string{"http://localhost:2379"}
+		err := MoveLeader(eps, 12345)
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
## What

Two scale-in defects in `reconcileClusterState`, fixed together because they share the removal path:

1. **Wrong member removed once ordinals reach 10.** Scale-in removed `memberHealth[len-1]`, but `ClusterHealth` sorts health entries lexically by endpoint — so with 11 members the "last" entry is `...-9`, not `...-10`. The StatefulSet always deletes the highest-ordinal pod, so etcd membership desyncs from the actual pod set. The removal target is now matched **by name** against the authoritative `memberListResp.Members` (members run with `--name=$(POD_NAME)`, so the target is `<sts>-<len-1>`), via a new `scaleInTargetID`. This also means removal no longer requires the doomed pod to answer health probes — an unreachable top-ordinal member can still be removed.

2. **Removing the leader stalls the cluster on an election.** When the removal target is the current leader, the operator now transfers leadership first (`etcdutils.MoveLeader`, issued against the leader's own endpoint since MoveLeader must be served by the leader) to the lowest-ordinal healthy voting member. The transfer is **best-effort**: removing a leader is legal in etcd, so a failed transfer is logged and removal proceeds — it only exists to avoid the election stall.

## Files

- `internal/etcdutils/etcdutils.go` — add `MoveLeader(eps, transfereeID)`, mirroring the existing client boilerplate.
- `internal/controller/utils.go` — `scaleInTargetID` (name match against the member list), `transfereeForScaleIn` (walks ordinals ascending via `clientEndpointForOrdinalIndex` equality; skips learners, unhealthy members, and the target), `removeScaleInMember` (transfer-then-remove; takes the two etcd calls as parameters so tests stub them with local closures — no package-level seams).
- `internal/controller/etcdcluster_controller.go` — scale-in branch calls `removeScaleInMember`, passing `etcdutils.MoveLeader`/`etcdutils.RemoveMember`; leader ID comes from the `FindLeaderStatus` result already in hand.

## Review

An adversarial review pass produced 4 findings; both blocking/important ones resolved (second commit): the removal target was initially re-derived by reverse-parsing ordinals out of health-probe endpoint URLs instead of using the member list the reconciler already holds (blocking — replaced with the name match, `ordinalFromEndpoint` deleted), and mutable package-level function seams for testing (important — replaced with function parameters). Two follow-up review passes approved with minor-only notes.

## Testing

- `TestScaleInTargetID`: happy path, 11 members with the highest ordinal winning regardless of list order, empty member list, target name missing.
- `TestTransfereeForScaleIn`: lowest-ordinal voter wins; learners, unhealthy members, and the removal target are skipped; no-candidate case.
- `TestRemoveScaleInMember`: transfer-before-removal when the target leads, no transfer otherwise, transfer failure not blocking removal, no eligible transferee, **unreachable target still removed via the member list**, and an 11-member case with lexical health ordering and the leader at ordinal 10 (fails on the previous code).
- `TestMoveLeader` (`internal/etcdutils`): error on invalid endpoint and on a bogus transferee against a live embedded server.
- Full `make test` and `make verify` pass.

## Descoped follow-ups

(1) No spec/CRD knob to opt out of leader transfer (best-effort transfer needs no configuration); hence no `make generate`/`manifests`/`api-docs` churn. (2) No refactor of the duplicated clientv3 boilerplate in `etcdutils` (`AddMember`/`PromoteLearner`/`RemoveMember`/`MoveLeader`) — `dupl` is lint-excluded for `internal/*`. (3) Latent bugs left untouched, each deserving its own PR: `updateStatus`/`updateConditions` index-pair `memberListResp.Members[i]` with lexically-sorted `memberHealth[i]` (`etcdcluster_controller.go:434`), nil-`Status` deref risk in `FindLeaderStatus`/`FindLearnerStatus`, and `healthCheck`'s endpoint truncation during an interrupted scale. (4) No e2e/kind coverage for real multi-node leader transfer (unit seams cover the ordering) and no gofail failpoint additions. (5) `FindLeaderStatus` signature unchanged — leader ID derived from `leaderStatus.Header.MemberId` instead of threading a new return value through two call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### PR series — operability fixes, TLS & EtcdMirror
<!-- pr-stack:begin -->
Small single-purpose PRs from live kind-cluster testing of the operator. Each stands alone unless an *After* is listed. → = this PR.

| | PR | Lands | After |
|---|----|-------|-------|
| | **Reviewable now — small, any order** | | |
| 🟢 | #374 | Requeue instead of swallowing the client-cert provisioning error | — |
| 🟢 | #391 | Grant `events.k8s.io` RBAC so operator Events are actually recorded | — |
| 🟢 | #392 | Correlate `members[]`/`leaderID` from one health snapshot (consistent leader) | — |
| 🟢 | #393 | Propagate user-supplied `altNames.ipAddresses` into certificates | — |
| 🟢 | #394 | Accept day-suffix `validityDuration` (`365d`, `100d12h`) as documented | — |
| 🟢 | #395 | Surface early reconcile errors as a `Degraded` condition (was empty status) | — |
| 🟢 | #379 | Configurable reconcile worker pool (`--max-concurrent-reconciles`) | — |
| 🟢 | #369 | kind-based stress/scale e2e harness (1/3/7 members, churn, quorum watcher) | — |
| 🟢 | #398 | `podTemplate.spec` scheduling fields: topologySpread, resources, priorityClass, schedulerName | — |
| 🟢 | #397 | First-class Helm chart covering the full `config/` surface | — |
| 🟢 | #399 | Quorum-aware PodDisruptionBudget per EtcdCluster | — |
| 🟢→ | #400 | Scale-in removes the right member and transfers leadership first | — |
| 🟢 | #401 | Backend quota + auto-compaction spec fields, NOSPACE alarm surfacing | — |
| 🟢 | #402 | Reconcile-loop gates replace the blocking StatefulSet-ready wait | — |
| 🟢 | #403 | Quorum-gated one-pod-at-a-time version upgrades via OnDelete | — |
| | **TLS stack — in order** | | |
| 🟢 | #376 | Independent `spec.tls.{peer,client}` surfaces (breaking alpha API) | — |
| ⚪ | #377 | `TLSReady` condition + TLS lifecycle Events | #376 |
| ⚪ | #378 | Multi-member TLS quorum e2e + `PeerCANotShared` | #377 |
| | **EtcdMirror — in order** | | |
| 🟢 | #406 | `EtcdMirror` CRD: one-way cross-cluster replication API (types + CEL) | — |
| 🟢 | #407 | `pkg/mirroragent` replication engine (fenced checkpoint-in-target) | #406 |
| 🟢 | #408 | Periodic reconciliation pass wired into the engine's steady-state loop | #407 |
| 🟢 | #412 | `mirror-agent` binary: config/TLS-reload/statusz/metrics + kind e2e | #408 |
| 🟢 | #413 | EtcdMirror controller: Deployment rendering, statusz-driven conditions, guards, fenced finalizer | #412 |
| 🟢 | #414 | CRD/sample/editor+viewer-role kustomize wiring | #413 |
| 🟢 | #415 | Controller-side phase/condition gauges, shipped PrometheusRule + dashboard | #414 |
| 🟢 | #416 | Full-lifecycle kind e2e: fence overlap, compaction+prune, restart resume, cert rotation, cutover/reversal | #415 |
| | **Parked as drafts pending #363** | | |
| ⚪ | #382 | Per-cluster domain metrics on the operator `/metrics` endpoint | — |
| ⚪ | #384 | EtcdCluster admission webhooks (consolidating with #328) | #363 |
| ⚪ | #386 | `EtcdBackup` CR → object storage (S3/GCS) | #363 |
| ⚪ | #387 | Automatic quorum-loss disaster recovery (bootstrap-latch guarded) | #363 |

🟢 ready · ⚪ draft
<!-- pr-stack:end -->