### PR TITLE
fix: replace the blocking StatefulSet-ready wait with reconcile-loop gates

### DIFF
--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -106,6 +106,13 @@ func (r *EtcdClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	if err = r.performHealthChecks(ctx, state); err != nil {
+		// While the StatefulSet is still converging (e.g. image pull after bootstrap)
+		// an unreachable member is expected; requeue instead of counting an error.
+		if !isStatefulSetSettled(state.sts) {
+			log.FromContext(ctx).Info("Health check failed while StatefulSet is converging, requeuing",
+				"reason", err.Error())
+			return ctrl.Result{RequeueAfter: requeueDuration}, nil
+		}
 		return ctrl.Result{}, err
 	}
 
@@ -312,9 +319,19 @@ func (r *EtcdClusterReconciler) reconcileClusterState(ctx context.Context, s *re
 	// Membership mutations below must only run against a settled StatefulSet. This gate sits
 	// after mismatch recovery on purpose: an interrupted scale-in leaves an orphaned pod whose
 	// etcd has exited, so the StatefulSet can never settle until recovery shrinks it.
-	if !isStatefulSetSettled(s.sts) {
+	// Spec-driven scale-in is exempt: reaching here means every member passed health checks,
+	// so removal is quorum-safe, and the member removed first is the last ordinal — often the
+	// very pod whose unreadiness prevents settling. Gating it would wedge a shrink away from
+	// a broken pod.
+	scaleIn := targetReplica > int32(s.cluster.Spec.Size)
+	if !scaleIn && !isStatefulSetSettled(s.sts) {
 		logger.Info("StatefulSet replicas not ready yet, requeuing",
 			"readyReplicas", s.sts.Status.ReadyReplicas, "replicas", targetReplica)
+		// Health checks passed but pods lag: normal briefly after a scale-out, anomalous
+		// if persistent (e.g. NotReady kubelet with etcd still serving).
+		r.warnEvent(s.cluster, "StatefulSetNotSettled", "Requeue",
+			"waiting for %d/%d ready replicas before mutating etcd membership",
+			s.sts.Status.ReadyReplicas, targetReplica)
 		return ctrl.Result{RequeueAfter: requeueDuration}, nil
 	}
 
@@ -417,6 +434,13 @@ func (r *EtcdClusterReconciler) reconcileClusterState(ctx context.Context, s *re
 
 	logger.Info("EtcdCluster reconciled successfully")
 	return ctrl.Result{}, nil
+}
+
+// warnEvent emits a Warning event on the cluster; no-op when no Recorder is wired (unit tests).
+func (r *EtcdClusterReconciler) warnEvent(obj runtime.Object, reason, action, note string, args ...interface{}) {
+	if r.Recorder != nil {
+		r.Recorder.Eventf(obj, nil, corev1.EventTypeWarning, reason, action, note, args...)
+	}
 }
 
 // updateStatus updates the EtcdCluster status based on observed state.

--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -277,6 +277,14 @@ func (r *EtcdClusterReconciler) reconcileClusterState(ctx context.Context, s *re
 	if s.memberListResp != nil {
 		memberCnt = len(s.memberListResp.Members)
 	}
+
+	// Don't act on a spec the StatefulSet controller hasn't observed yet (stale cache after our own write).
+	if !statefulSetSpecObserved(s.sts) {
+		logger.Info("StatefulSet spec not observed by its controller yet, requeuing",
+			"generation", s.sts.Generation, "observedGeneration", s.sts.Status.ObservedGeneration)
+		return ctrl.Result{RequeueAfter: requeueDuration}, nil
+	}
+
 	targetReplica := *s.sts.Spec.Replicas
 	var err error
 
@@ -298,6 +306,15 @@ func (r *EtcdClusterReconciler) reconcileClusterState(ctx context.Context, s *re
 				return ctrl.Result{}, err
 			}
 		}
+		return ctrl.Result{RequeueAfter: requeueDuration}, nil
+	}
+
+	// Membership mutations below must only run against a settled StatefulSet. This gate sits
+	// after mismatch recovery on purpose: an interrupted scale-in leaves an orphaned pod whose
+	// etcd has exited, so the StatefulSet can never settle until recovery shrinks it.
+	if !isStatefulSetSettled(s.sts) {
+		logger.Info("StatefulSet replicas not ready yet, requeuing",
+			"readyReplicas", s.sts.Status.ReadyReplicas, "replicas", targetReplica)
 		return ctrl.Result{RequeueAfter: requeueDuration}, nil
 	}
 

--- a/internal/controller/etcdcluster_controller_test.go
+++ b/internal/controller/etcdcluster_controller_test.go
@@ -27,11 +27,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	ecv1alpha1 "go.etcd.io/etcd-operator/api/v1alpha1"
+	"go.etcd.io/etcd-operator/internal/etcdutils"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
@@ -635,7 +637,8 @@ func TestReconcileClusterStateGates(t *testing.T) {
 		ec := newCluster(5)
 		sts := newSTS(1, 1, 3, 2)
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec, sts).Build()
-		r := &EtcdClusterReconciler{Client: fakeClient, Scheme: scheme}
+		recorder := events.NewFakeRecorder(10)
+		r := &EtcdClusterReconciler{Client: fakeClient, Scheme: scheme, Recorder: recorder}
 
 		stored := &appsv1.StatefulSet{}
 		require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: ec.Name, Namespace: ec.Namespace}, stored))
@@ -649,6 +652,42 @@ func TestReconcileClusterStateGates(t *testing.T) {
 		after := &appsv1.StatefulSet{}
 		require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: ec.Name, Namespace: ec.Namespace}, after))
 		assert.Equal(t, oldRV, after.ResourceVersion)
+
+		select {
+		case ev := <-recorder.Events:
+			assert.Contains(t, ev, "StatefulSetNotSettled")
+		default:
+			t.Fatal("expected a StatefulSetNotSettled warning event")
+		}
+	})
+
+	t.Run("spec-driven scale-in is exempt from the settled gate", func(t *testing.T) {
+		ctx := t.Context()
+		ec := newCluster(1)
+		sts := newSTS(1, 1, 3, 2) // e.g. last pod NotReady while its etcd still answers
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec, sts).Build()
+		r := &EtcdClusterReconciler{Client: fakeClient, Scheme: scheme}
+
+		stored := &appsv1.StatefulSet{}
+		require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: ec.Name, Namespace: ec.Namespace}, stored))
+
+		// Leaderless health data: reconcile must pass the gate and fail on the leader
+		// lookup, proving the gate did not requeue the scale-in.
+		health := make([]etcdutils.EpHealth, 3)
+		for i := range health {
+			health[i] = etcdutils.EpHealth{
+				Health: true,
+				Status: &clientv3.StatusResponse{
+					Header: &etcdserverpb.ResponseHeader{MemberId: uint64(i + 1)},
+					Leader: 99,
+				},
+			}
+		}
+
+		state := &reconcileState{cluster: ec, sts: stored, memberListResp: memberListRespWithCount(3), memberHealth: health}
+		_, err := r.reconcileClusterState(ctx, state)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "couldn't find leader")
 	})
 
 	t.Run("interrupted scale-in recovery is not gated", func(t *testing.T) {

--- a/internal/controller/etcdcluster_controller_test.go
+++ b/internal/controller/etcdcluster_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,6 +32,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	ecv1alpha1 "go.etcd.io/etcd-operator/api/v1alpha1"
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 // TestFetchAndValidateState describes the scenarios for the fetchAndValidateState
@@ -570,4 +573,158 @@ func TestBootstrapStatefulSet(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, storedCM.Data, fetchedCM.Data)
 	})
+}
+
+func memberListRespWithCount(n int) *clientv3.MemberListResponse {
+	members := make([]*etcdserverpb.Member, n)
+	for i := range members {
+		members[i] = &etcdserverpb.Member{ID: uint64(i + 1), Name: fmt.Sprintf("etcd-%d", i)}
+	}
+	return &clientv3.MemberListResponse{Members: members}
+}
+
+// TestReconcileClusterStateGates verifies the observed-generation/settled gates
+// in reconcileClusterState. The tests run without a live etcd cluster: passing
+// without one proves the gates fire before any membership call.
+func TestReconcileClusterStateGates(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme)
+	_ = ecv1alpha1.AddToScheme(scheme)
+
+	newCluster := func(size int) *ecv1alpha1.EtcdCluster {
+		return &ecv1alpha1.EtcdCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "etcd", Namespace: "default", UID: "1"},
+			Spec:       ecv1alpha1.EtcdClusterSpec{Size: size, Version: "3.5.17"},
+		}
+	}
+	newSTS := func(generation, observedGen int64, replicas, readyReplicas int32) *appsv1.StatefulSet {
+		return &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: "etcd", Namespace: "default", Generation: generation},
+			Spec:       appsv1.StatefulSetSpec{Replicas: pointerToInt32(replicas)},
+			Status: appsv1.StatefulSetStatus{
+				ObservedGeneration: observedGen,
+				ReadyReplicas:      readyReplicas,
+			},
+		}
+	}
+
+	t.Run("stale generation requeues without writes", func(t *testing.T) {
+		ctx := t.Context()
+		ec := newCluster(5)
+		sts := newSTS(2, 1, 3, 3)
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec, sts).Build()
+		r := &EtcdClusterReconciler{Client: fakeClient, Scheme: scheme}
+
+		stored := &appsv1.StatefulSet{}
+		require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: ec.Name, Namespace: ec.Namespace}, stored))
+		oldRV := stored.ResourceVersion
+
+		state := &reconcileState{cluster: ec, sts: stored, memberListResp: memberListRespWithCount(3)}
+		res, err := r.reconcileClusterState(ctx, state)
+		assert.NoError(t, err)
+		assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, res)
+
+		after := &appsv1.StatefulSet{}
+		require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: ec.Name, Namespace: ec.Namespace}, after))
+		assert.Equal(t, oldRV, after.ResourceVersion)
+	})
+
+	t.Run("unsettled replicas requeue before scale-out", func(t *testing.T) {
+		ctx := t.Context()
+		ec := newCluster(5)
+		sts := newSTS(1, 1, 3, 2)
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec, sts).Build()
+		r := &EtcdClusterReconciler{Client: fakeClient, Scheme: scheme}
+
+		stored := &appsv1.StatefulSet{}
+		require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: ec.Name, Namespace: ec.Namespace}, stored))
+		oldRV := stored.ResourceVersion
+
+		state := &reconcileState{cluster: ec, sts: stored, memberListResp: memberListRespWithCount(3)}
+		res, err := r.reconcileClusterState(ctx, state)
+		assert.NoError(t, err)
+		assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, res)
+
+		after := &appsv1.StatefulSet{}
+		require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: ec.Name, Namespace: ec.Namespace}, after))
+		assert.Equal(t, oldRV, after.ResourceVersion)
+	})
+
+	t.Run("interrupted scale-in recovery is not gated", func(t *testing.T) {
+		ctx := t.Context()
+		ec := newCluster(2)
+		// Member already removed but StatefulSet not yet shrunk: the orphaned pod can
+		// never become ready, so recovery must run before the settled gate.
+		sts := newSTS(1, 1, 3, 2)
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec, sts).Build()
+		r := &EtcdClusterReconciler{Client: fakeClient, Scheme: scheme}
+
+		stored := &appsv1.StatefulSet{}
+		require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: ec.Name, Namespace: ec.Namespace}, stored))
+
+		state := &reconcileState{cluster: ec, sts: stored, memberListResp: memberListRespWithCount(2)}
+		res, err := r.reconcileClusterState(ctx, state)
+		assert.NoError(t, err)
+		assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, res)
+
+		after := &appsv1.StatefulSet{}
+		require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: ec.Name, Namespace: ec.Namespace}, after))
+		assert.Equal(t, int32(2), *after.Spec.Replicas)
+	})
+}
+
+// TestReconcileClusterStateStaleGenerationEnvtest exercises the stale-generation
+// gate against real API-server generation semantics: envtest runs no
+// kube-controller-manager, so Status.ObservedGeneration stays 0 while
+// Generation is 1 after creation.
+func TestReconcileClusterStateStaleGenerationEnvtest(t *testing.T) {
+	ctx := t.Context()
+
+	ec := &ecv1alpha1.EtcdCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "gate-envtest", Namespace: "default"},
+		Spec:       ecv1alpha1.EtcdClusterSpec{Size: 1, Version: "3.5.17"},
+	}
+	require.NoError(t, k8sClient.Create(ctx, ec))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, ec) })
+
+	labels := map[string]string{"app": ec.Name}
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ec.Name,
+			Namespace: ec.Namespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: ecv1alpha1.GroupVersion.String(),
+				Kind:       "EtcdCluster",
+				Name:       ec.Name,
+				UID:        ec.UID,
+				Controller: pointerToBool(true),
+			}},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas:    pointerToInt32(1),
+			ServiceName: ec.Name,
+			Selector:    &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "etcd", Image: "gcr.io/etcd-development/etcd:3.5.17"}},
+				},
+			},
+		},
+	}
+	require.NoError(t, k8sClient.Create(ctx, sts))
+	t.Cleanup(func() { _ = k8sClient.Delete(ctx, sts) })
+
+	fetched := &appsv1.StatefulSet{}
+	require.NoError(t, k8sClient.Get(ctx, client.ObjectKey{Name: ec.Name, Namespace: ec.Namespace}, fetched))
+	require.Equal(t, int64(1), fetched.Generation)
+	require.Equal(t, int64(0), fetched.Status.ObservedGeneration)
+
+	r := &EtcdClusterReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+	state := &reconcileState{cluster: ec, sts: fetched, memberListResp: memberListRespWithCount(1)}
+
+	res, err := r.reconcileClusterState(ctx, state)
+	assert.NoError(t, err)
+	assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, res)
 }

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -8,7 +8,6 @@ import (
 	"maps"
 	"net"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -22,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -60,20 +58,9 @@ func reconcileStatefulSet(ctx context.Context, logger logr.Logger, ec *ecv1alpha
 		return nil, err
 	}
 
-	// Create Update StatefulSet
-	err = createOrPatchStatefulSet(ctx, logger, ec, c, replicas, scheme)
-	if err != nil {
-		return nil, err
-	}
-
-	// Wait for statefulset to be ready
-	err = waitForStatefulSetReady(ctx, logger, c, ec.Name, ec.Namespace)
-	if err != nil {
-		return nil, err
-	}
-
-	// Return latest Stateful set. (This is to ensure that we return the latest statefulset for next operation to act on)
-	return getStatefulSet(ctx, c, ec.Name, ec.Namespace)
+	// Create/update StatefulSet. The write response is returned (fresher than a
+	// post-write cache read, which can still hold the pre-write object).
+	return createOrPatchStatefulSet(ctx, logger, ec, c, replicas, scheme)
 }
 
 func defaultArgs(name string) []string {
@@ -127,7 +114,7 @@ func createArgs(name string, etcdOptions []string) []string {
 	return defaultArgs
 }
 
-func createOrPatchStatefulSet(ctx context.Context, logger logr.Logger, ec *ecv1alpha1.EtcdCluster, c client.Client, replicas int32, scheme *runtime.Scheme) error {
+func createOrPatchStatefulSet(ctx context.Context, logger logr.Logger, ec *ecv1alpha1.EtcdCluster, c client.Client, replicas int32, scheme *runtime.Scheme) (*appsv1.StatefulSet, error) {
 	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ec.Name,
@@ -261,7 +248,7 @@ func createOrPatchStatefulSet(ctx context.Context, logger logr.Logger, ec *ecv1a
 		}}
 		// Create a new volume claim template
 		if ec.Spec.StorageSpec.VolumeSizeRequest.Cmp(resource.MustParse("1Mi")) < 0 {
-			return fmt.Errorf("VolumeSizeRequest must be at least 1Mi")
+			return nil, fmt.Errorf("VolumeSizeRequest must be at least 1Mi")
 		}
 
 		if ec.Spec.StorageSpec.VolumeSizeLimit.IsZero() {
@@ -295,7 +282,7 @@ func createOrPatchStatefulSet(ctx context.Context, logger logr.Logger, ec *ecv1a
 			}
 		case corev1.ReadWriteMany:
 			if ec.Spec.StorageSpec.PVCName == "" {
-				return fmt.Errorf("PVCName must be set when AccessModes is ReadWriteMany")
+				return nil, fmt.Errorf("PVCName must be set when AccessModes is ReadWriteMany")
 			}
 			stsSpec.Template.Spec.Volumes = append(stsSpec.Template.Spec.Volumes, corev1.Volume{
 				Name: volumeName,
@@ -306,7 +293,7 @@ func createOrPatchStatefulSet(ctx context.Context, logger logr.Logger, ec *ecv1a
 				},
 			})
 		default:
-			return fmt.Errorf("AccessMode %s is not supported", ec.Spec.StorageSpec.AccessModes)
+			return nil, fmt.Errorf("AccessMode %s is not supported", ec.Spec.StorageSpec.AccessModes)
 		}
 	}
 
@@ -327,46 +314,11 @@ func createOrPatchStatefulSet(ctx context.Context, logger logr.Logger, ec *ecv1a
 		return nil
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	logger.Info("Stateful set created/updated", "name", ec.Name, "namespace", ec.Namespace, "replicas", replicas)
-	return nil
-}
-
-func waitForStatefulSetReady(ctx context.Context, logger logr.Logger, r client.Client, name, namespace string) error {
-	logger.Info("Now checking the readiness of statefulset", "name", name, "namespace", namespace)
-
-	backoff := wait.Backoff{
-		Duration: 3 * time.Second,
-		Factor:   2.0,
-		Steps:    5,
-	}
-
-	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
-		// Fetch the StatefulSet
-		sts, err := getStatefulSet(ctx, r, name, namespace)
-		if err != nil {
-			return false, err
-		}
-
-		// Check if the StatefulSet is ready
-		if sts.Status.ReadyReplicas == *sts.Spec.Replicas {
-			// StatefulSet is ready
-			logger.Info("StatefulSet is ready", "name", name, "namespace", namespace)
-			return true, nil
-		}
-
-		// Log the current status
-		logger.Info("StatefulSet is not ready", "ReadyReplicas", strconv.Itoa(int(sts.Status.ReadyReplicas)), "DesiredReplicas", strconv.Itoa(int(*sts.Spec.Replicas)))
-		return false, nil
-	})
-
-	if err != nil {
-		return fmt.Errorf("StatefulSet %s/%s did not become ready: %w", namespace, name, err)
-	}
-
-	return nil
+	return sts, nil
 }
 
 func createHeadlessServiceIfNotExist(ctx context.Context, logger logr.Logger, c client.Client, ec *ecv1alpha1.EtcdCluster, scheme *runtime.Scheme) error {
@@ -490,6 +442,16 @@ func getStatefulSet(ctx context.Context, c client.Client, name, namespace string
 		return nil, err
 	}
 	return sts, nil
+}
+
+// statefulSetSpecObserved reports whether the StatefulSet controller has seen the latest spec write.
+func statefulSetSpecObserved(sts *appsv1.StatefulSet) bool {
+	return sts.Status.ObservedGeneration >= sts.Generation
+}
+
+// isStatefulSetSettled additionally requires every desired replica to be ready.
+func isStatefulSetSettled(sts *appsv1.StatefulSet) bool {
+	return statefulSetSpecObserved(sts) && sts.Spec.Replicas != nil && sts.Status.ReadyReplicas == *sts.Spec.Replicas
 }
 
 func clientEndpointsFromStatefulsets(sts *appsv1.StatefulSet) []string {

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -49,10 +49,14 @@ func TestReconcileStatefulSet(t *testing.T) {
 		},
 	}
 
-	_, _ = reconcileStatefulSet(t.Context(), logger, ec, fakeClient, 3, scheme)
+	returned, err := reconcileStatefulSet(t.Context(), logger, ec, fakeClient, 3, scheme)
+	require.NoError(t, err)
+	// Returned object is the CreateOrPatch response, no post-write Get.
+	require.NotNil(t, returned)
+	assert.Equal(t, int32(3), *returned.Spec.Replicas)
 
 	sts := &appsv1.StatefulSet{}
-	err := fakeClient.Get(t.Context(), client.ObjectKey{Name: "test-etcd", Namespace: "default"}, sts)
+	err = fakeClient.Get(t.Context(), client.ObjectKey{Name: "test-etcd", Namespace: "default"}, sts)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -62,81 +66,56 @@ func TestReconcileStatefulSet(t *testing.T) {
 	}
 }
 
-func TestWaitForStatefulSetReady(t *testing.T) {
-	// Create a scheme and register the necessary types
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = ecv1alpha1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
-
+func TestStatefulSetSpecObserved(t *testing.T) {
 	tests := []struct {
-		name           string
-		statefulSet    *appsv1.StatefulSet
-		expectedResult bool
-		expectedError  error
+		name        string
+		generation  int64
+		observedGen int64
+		expected    bool
 	}{
-		{
-			name: "StatefulSet is ready",
-			statefulSet: &appsv1.StatefulSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-sts",
-					Namespace: "default",
-				},
-				Spec: appsv1.StatefulSetSpec{
-					Replicas: pointerToInt32(3),
-				},
-				Status: appsv1.StatefulSetStatus{
-					ReadyReplicas: 3,
-				},
-			},
-			expectedResult: true,
-			expectedError:  nil,
-		},
-		{
-			name: "StatefulSet is not ready",
-			statefulSet: &appsv1.StatefulSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-sts",
-					Namespace: "default",
-				},
-				Spec: appsv1.StatefulSetSpec{
-					Replicas: pointerToInt32(3),
-				},
-				Status: appsv1.StatefulSetStatus{
-					ReadyReplicas: 2,
-				},
-			},
-			expectedResult: false,
-			expectedError:  errors.New("StatefulSet default/test-sts did not become ready: timed out waiting for the condition"),
-		},
-		{
-			name:           "StatefulSet does not exist",
-			statefulSet:    nil,
-			expectedResult: false,
-			expectedError:  errors.New("statefulsets.apps \"test-sts\" not found"),
-		},
+		{name: "observed behind generation", generation: 2, observedGen: 1, expected: false},
+		{name: "observed equals generation", generation: 2, observedGen: 2, expected: true},
+		{name: "observed ahead of generation", generation: 1, observedGen: 2, expected: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var clientBuilder *fake.ClientBuilder
-			if tt.statefulSet != nil {
-				clientBuilder = fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.statefulSet)
-			} else {
-				clientBuilder = fake.NewClientBuilder().WithScheme(scheme)
+			sts := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Generation: tt.generation},
+				Status:     appsv1.StatefulSetStatus{ObservedGeneration: tt.observedGen},
 			}
-			fakeClient := clientBuilder.Build()
+			assert.Equal(t, tt.expected, statefulSetSpecObserved(sts))
+		})
+	}
+}
 
-			ctx := t.Context()
-			logger := log.FromContext(ctx)
+func TestIsStatefulSetSettled(t *testing.T) {
+	tests := []struct {
+		name          string
+		generation    int64
+		observedGen   int64
+		replicas      *int32
+		readyReplicas int32
+		expected      bool
+	}{
+		{name: "spec not observed", generation: 2, observedGen: 1, replicas: pointerToInt32(3), readyReplicas: 3, expected: false},
+		{name: "observed and all ready", generation: 2, observedGen: 2, replicas: pointerToInt32(3), readyReplicas: 3, expected: true},
+		{name: "observed ahead and all ready", generation: 1, observedGen: 2, replicas: pointerToInt32(3), readyReplicas: 3, expected: true},
+		{name: "ready below replicas", generation: 1, observedGen: 1, replicas: pointerToInt32(3), readyReplicas: 2, expected: false},
+		{name: "nil replicas", generation: 1, observedGen: 1, replicas: nil, readyReplicas: 0, expected: false},
+	}
 
-			err := waitForStatefulSetReady(ctx, logger, fakeClient, "test-sts", "default")
-			if tt.expectedError != nil {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), tt.expectedError.Error())
-			} else {
-				assert.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sts := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Generation: tt.generation},
+				Spec:       appsv1.StatefulSetSpec{Replicas: tt.replicas},
+				Status: appsv1.StatefulSetStatus{
+					ObservedGeneration: tt.observedGen,
+					ReadyReplicas:      tt.readyReplicas,
+				},
 			}
+			assert.Equal(t, tt.expected, isStatefulSetSettled(sts))
 		})
 	}
 }
@@ -567,7 +546,7 @@ func TestCreateOrPatchStatefulSetWithPodAnnotations(t *testing.T) {
 				},
 			}
 
-			err := createOrPatchStatefulSet(ctx, logger, ec, fakeClient, 3, scheme)
+			_, err := createOrPatchStatefulSet(ctx, logger, ec, fakeClient, 3, scheme)
 			assert.NoError(t, err)
 
 			// Verify that the StatefulSet was created
@@ -685,7 +664,7 @@ func TestCreateOrPatchStatefulSetWithPodLabels(t *testing.T) {
 				},
 			}
 
-			err := createOrPatchStatefulSet(ctx, logger, ec, fakeClient, 3, scheme)
+			_, err := createOrPatchStatefulSet(ctx, logger, ec, fakeClient, 3, scheme)
 			assert.NoError(t, err)
 
 			// Verify that the StatefulSet was created with correct labels


### PR DESCRIPTION
## What

`reconcileStatefulSet` slept up to 45s inside the reconcile worker (`waitForStatefulSetReady`, exponential backoff polling `ReadyReplicas == Replicas`). That blocks the worker for the whole rollout, and with a single worker it head-of-line blocks every other EtcdCluster. This PR removes the blocking wait and re-plumbs the same predicate into the reconcile loop as requeue gates:

- `reconcileStatefulSet` now returns the `CreateOrPatch` response directly — fresher than the post-write cache read it replaces, which could still hold the pre-write object.
- **Observed-generation gate**: `reconcileClusterState` requeues before reading `Spec.Replicas` if the StatefulSet controller hasn't observed the latest spec write (own-write cache staleness), so the operator never acts on a spec the workload controller hasn't seen.
- **Settled gate**: membership mutations (learner promotion, scale-out member add) require `ObservedGeneration` caught up **and** `ReadyReplicas == Replicas` — the old wait's predicate, now non-blocking. The `Owns(StatefulSet)` watch plus the existing 10s requeue backstop drive convergence.

Gate placement is deliberate:

- The settled gate sits **after** the replica/member-count mismatch recovery, so an interrupted scale-in — whose orphaned pod has exited etcd and can never become ready — still unblocks.
- **Spec-driven scale-in is exempt** from the settled gate: reaching it means every member passed health checks (quorum-safe), and the member removed first is the last ordinal — often the very pod whose unreadiness prevents settling. Gating it would wedge a shrink away from a broken pod.
- While unsettled, `performHealthChecks` failures **requeue instead of erroring**: after bootstrap scales 0→1 the endpoint is unreachable until the pod starts, a window the old blocking wait absorbed — without this every new cluster inflates reconcile error metrics on the happy path. Once settled, health failures surface as errors exactly as before.
- A persistent settled-gate stall (etcd healthy but pod readiness lagging, e.g. dead kubelet) emits a `StatefulSetNotSettled` warning event, so it's visible on the CR instead of only in operator logs.

## Files

- `internal/controller/utils.go` — delete `waitForStatefulSetReady`; `createOrPatchStatefulSet` returns the written object; add `statefulSetSpecObserved` / `isStatefulSetSettled` predicates.
- `internal/controller/etcdcluster_controller.go` — the two gates in `reconcileClusterState`, the unsettled health-check requeue in `Reconcile`, and the `StatefulSetNotSettled` event.

## Review

An adversarial review pass produced 3 findings; all blocking/important ones resolved (second commit): the settled gate wedged spec-driven scale-in whenever a pod was NotReady but its etcd still answered — exactly the pod an admin shrinks away from (blocking — scale-in exempted, quorum-safety argued above); every new cluster erred through health checks during the bootstrap 0→1 window the old wait used to absorb (important — requeue while unsettled); and a persistent gate stall was invisible outside operator logs (resolved with the warning event).

## Testing

- `TestReconcileClusterStateGates`: stale generation requeues without writes, unsettled replicas requeue before scale-out, spec-driven scale-in is exempt from the settled gate, interrupted scale-in recovery is not gated.
- `TestReconcileClusterStateStaleGenerationEnvtest`: envtest-backed own-write staleness scenario through the real cache.
- `TestStatefulSetSpecObserved` / `TestIsStatefulSetSettled`: predicate table tests (nil replicas, generation skew, partial readiness).
- `internal/controller/utils_test.go` reworked for `createOrPatchStatefulSet` returning the object; `waitForStatefulSetReady` tests deleted with the function.
- Full `make test` and `make verify` pass.

## Descoped follow-ups

(1) In-memory expectations mechanism (ECK-style per-cluster expected-Generation map recorded after each write): descoped — the ObservedGeneration gate plus `reconcileClusterState`'s existing replica/memberCnt cross-check (`etcdcluster_controller.go:284`, which turns own-write cache staleness into an idempotent re-patch) already neutralize the race once the blocking wait is gone; an expectations store adds a stateful component and restart semantics for marginal gain. Revisit with the MaxConcurrentReconciles follow-up if soak shows residual double-acts. (2) `MaxConcurrentReconciles` bump: explicitly excluded from this PR; noted as follow-up (see #379). (3) `UpdatedReplicas`/`CurrentRevision==UpdateRevision` checks in the settled predicate: descoped — the old wait only checked `ReadyReplicas==Replicas`; adding rollout-revision checks would be a behavior change beyond re-plumbing. (4) Gating `bootstrapStatefulSet`'s 0→1 scale on the gate: unnecessary (idempotent re-patch, no pods yet) and it would add bootstrap latency visible to e2e. (5) New CRD status fields / conditions for "waiting on StatefulSet": descoped — no API change keeps the PR marker-free and generated-file-free. (6) Reworking `performHealthChecks` error noise during pod startup in general (e.g. treating connection-refused as requeue-not-error even when settled): descoped, separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### PR series — operability fixes, TLS & EtcdMirror
<!-- pr-stack:begin -->
Small single-purpose PRs from live kind-cluster testing of the operator. Each stands alone unless an *After* is listed. → = this PR.

| | PR | Lands | After |
|---|----|-------|-------|
| | **Reviewable now — small, any order** | | |
| 🟢 | #374 | Requeue instead of swallowing the client-cert provisioning error | — |
| 🟢 | #391 | Grant `events.k8s.io` RBAC so operator Events are actually recorded | — |
| 🟢 | #392 | Correlate `members[]`/`leaderID` from one health snapshot (consistent leader) | — |
| 🟢 | #393 | Propagate user-supplied `altNames.ipAddresses` into certificates | — |
| 🟢 | #394 | Accept day-suffix `validityDuration` (`365d`, `100d12h`) as documented | — |
| 🟢 | #395 | Surface early reconcile errors as a `Degraded` condition (was empty status) | — |
| 🟢 | #379 | Configurable reconcile worker pool (`--max-concurrent-reconciles`) | — |
| 🟢 | #369 | kind-based stress/scale e2e harness (1/3/7 members, churn, quorum watcher) | — |
| 🟢 | #398 | `podTemplate.spec` scheduling fields: topologySpread, resources, priorityClass, schedulerName | — |
| 🟢 | #397 | First-class Helm chart covering the full `config/` surface | — |
| 🟢 | #399 | Quorum-aware PodDisruptionBudget per EtcdCluster | — |
| 🟢 | #400 | Scale-in removes the right member and transfers leadership first | — |
| 🟢 | #401 | Backend quota + auto-compaction spec fields, NOSPACE alarm surfacing | — |
| 🟢→ | #402 | Reconcile-loop gates replace the blocking StatefulSet-ready wait | — |
| 🟢 | #403 | Quorum-gated one-pod-at-a-time version upgrades via OnDelete | — |
| | **TLS stack — in order** | | |
| 🟢 | #376 | Independent `spec.tls.{peer,client}` surfaces (breaking alpha API) | — |
| ⚪ | #377 | `TLSReady` condition + TLS lifecycle Events | #376 |
| ⚪ | #378 | Multi-member TLS quorum e2e + `PeerCANotShared` | #377 |
| | **EtcdMirror — in order** | | |
| 🟢 | #406 | `EtcdMirror` CRD: one-way cross-cluster replication API (types + CEL) | — |
| 🟢 | #407 | `pkg/mirroragent` replication engine (fenced checkpoint-in-target) | #406 |
| 🟢 | #408 | Periodic reconciliation pass wired into the engine's steady-state loop | #407 |
| 🟢 | #412 | `mirror-agent` binary: config/TLS-reload/statusz/metrics + kind e2e | #408 |
| 🟢 | #413 | EtcdMirror controller: Deployment rendering, statusz-driven conditions, guards, fenced finalizer | #412 |
| 🟢 | #414 | CRD/sample/editor+viewer-role kustomize wiring | #413 |
| 🟢 | #415 | Controller-side phase/condition gauges, shipped PrometheusRule + dashboard | #414 |
| 🟢 | #416 | Full-lifecycle kind e2e: fence overlap, compaction+prune, restart resume, cert rotation, cutover/reversal | #415 |
| | **Parked as drafts pending #363** | | |
| ⚪ | #382 | Per-cluster domain metrics on the operator `/metrics` endpoint | — |
| ⚪ | #384 | EtcdCluster admission webhooks (consolidating with #328) | #363 |
| ⚪ | #386 | `EtcdBackup` CR → object storage (S3/GCS) | #363 |
| ⚪ | #387 | Automatic quorum-loss disaster recovery (bootstrap-latch guarded) | #363 |

🟢 ready · ⚪ draft
<!-- pr-stack:end -->