### PR TITLE
feat: quorum-gated one-pod-at-a-time version upgrades via OnDelete

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -35,8 +35,6 @@ rules:
   verbs:
   - delete
   - get
-  - list
-  - watch
 - apiGroups:
   - apps
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -29,6 +29,15 @@ rules:
   - patch
   - update
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
   - apps
   resources:
   - statefulsets

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -13,3 +13,13 @@ However, if you are using custom etcd image tags that are not
 compatible with [Semantic Versioning](https://semver.org/),
 no validation will be performed and you have to manually ensure
 that the upgrade path is supported.
+
+## Upgrade mechanics
+
+The StatefulSet uses the `OnDelete` update strategy, so a version change
+re-renders the pod template without restarting anything. The operator then
+replaces one pod per reconcile, and only while all members are healthy, a
+leader exists, and every member's revision is within 90% of the leader's.
+The leader's pod is replaced last. Persistent storage (`spec.storageSpec`)
+is strongly recommended: a deleted pod without a PVC loses its data
+directory and cannot rejoin the cluster cleanly.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -23,3 +23,14 @@ leader exists, and every member's revision is within 90% of the leader's.
 The leader's pod is replaced last. Persistent storage (`spec.storageSpec`)
 is strongly recommended: a deleted pod without a PVC loses its data
 directory and cannot rejoin the cluster cleanly.
+
+## Failed upgrades and rollback
+
+If a replaced pod cannot run the new version (nonexistent tag, incompatible
+flags), fix the spec — reverting `spec.version` to the version the members
+still report is accepted, since upgrade-path validation runs against the
+observed cluster version. While the remaining members hold quorum the
+operator keeps syncing the template and replaces the broken pod
+automatically. If quorum is lost it stops deleting pods; recover manually by
+fixing the spec and deleting the affected pods
+(`kubectl delete pod <cluster>-<ordinal>`).

--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -69,6 +69,7 @@ type reconcileState struct {
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch;get;list;update
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;delete
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;patch;update;delete
 // +kubebuilder:rbac:groups="cert-manager.io",resources=certificates,verbs=get;list;watch;create;patch;update;delete
 // +kubebuilder:rbac:groups="cert-manager.io",resources=clusterissuers,verbs=get;list;watch
@@ -337,8 +338,7 @@ func (r *EtcdClusterReconciler) reconcileClusterState(ctx context.Context, s *re
 	}
 
 	if targetReplica == int32(s.cluster.Spec.Size) {
-		logger.Info("EtcdCluster is already up-to-date")
-		return ctrl.Result{}, nil
+		return r.reconcileVersionUpgrade(ctx, s)
 	}
 
 	eps := clientEndpointsFromStatefulsets(s.sts)

--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -47,7 +47,10 @@ const (
 // EtcdClusterReconciler reconciles a EtcdCluster object
 type EtcdClusterReconciler struct {
 	client.Client
-	Scheme        *runtime.Scheme
+	Scheme *runtime.Scheme
+	// PodReader reads pods straight from the API server. Reading pods through
+	// the cached client would lazily start a cluster-wide pod informer.
+	PodReader     client.Reader
 	Recorder      events.EventRecorder
 	ImageRegistry string
 }
@@ -69,7 +72,7 @@ type reconcileState struct {
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch;get;list;update
-// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;delete
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;delete
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;patch;update;delete
 // +kubebuilder:rbac:groups="cert-manager.io",resources=certificates,verbs=get;list;watch;create;patch;update;delete
 // +kubebuilder:rbac:groups="cert-manager.io",resources=clusterissuers,verbs=get;list;watch
@@ -580,6 +583,9 @@ func isCertManagerCRDPresent(mgr ctrl.Manager) bool {
 // SetupWithManager sets up the controller with the Manager.
 func (r *EtcdClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.Recorder = mgr.GetEventRecorder("etcdcluster-controller")
+	if r.PodReader == nil {
+		r.PodReader = mgr.GetAPIReader()
+	}
 	setupLog := ctrl.Log.WithName("setup")
 
 	builder := ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -110,6 +110,12 @@ func (r *EtcdClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	if err = r.performHealthChecks(ctx, state); err != nil {
+		// A pod replaced during an upgrade may never come back healthy;
+		// without this the failed health check would keep template and pod
+		// convergence unreachable forever.
+		if res, handled := r.recoverDegradedUpgrade(ctx, state); handled {
+			return res, nil
+		}
 		return ctrl.Result{}, err
 	}
 
@@ -184,6 +190,12 @@ func (r *EtcdClusterReconciler) fetchAndValidateState(ctx context.Context, req c
 			return &reconcileState{cluster: ec, sts: sts}, ctrl.Result{}, nil
 		}
 		currentVersion := stsImage[idx+1:]
+		// Prefer the observed cluster version: the template tag may name an
+		// image that never ran (e.g. a nonexistent patch release), which would
+		// make every rollback look like a downgrade and wedge the cluster.
+		if ec.Status.CurrentVersion != "" {
+			currentVersion = ec.Status.CurrentVersion
+		}
 		targetVersion := ec.Spec.Version
 
 		// Only handle cases when there is a version change.

--- a/internal/controller/etcdcluster_controller_test.go
+++ b/internal/controller/etcdcluster_controller_test.go
@@ -178,6 +178,51 @@ func TestFetchAndValidateState(t *testing.T) {
 			},
 		},
 		{
+			// The template may name a version that never ran (phantom patch
+			// tag); validation runs against the observed cluster version so
+			// reverting spec.version is not misread as a downgrade.
+			name: "Rollback to observed version allowed despite bad template tag",
+			ec: &ecv1alpha1.EtcdCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "etcd",
+					Namespace: "default",
+					UID:       "2",
+				},
+				Spec:   ecv1alpha1.EtcdClusterSpec{Size: 1, Version: "3.5.17"},
+				Status: ecv1alpha1.EtcdClusterStatus{CurrentVersion: "3.5.17"},
+			},
+			sts: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "etcd",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: ecv1alpha1.GroupVersion.String(),
+							Kind:       "EtcdCluster",
+							Name:       "etcd",
+							UID:        "2",
+							Controller: pointerToBool(true),
+						},
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Image: "gcr.io/etcd-development/etcd:3.6.99"},
+							},
+						},
+					},
+				},
+			},
+			req: ctrl.Request{NamespacedName: types.NamespacedName{Name: "etcd", Namespace: "default"}},
+			assert: func(t *testing.T, state *reconcileState, res ctrl.Result, err error, ec *ecv1alpha1.EtcdCluster, sts *appsv1.StatefulSet) {
+				require.NotNil(t, state)
+				assert.NoError(t, err)
+				assert.Equal(t, ctrl.Result{}, res)
+			},
+		},
+		{
 			name: "Cannot parse StatefulSet image tag",
 			ec: &ecv1alpha1.EtcdCluster{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/upgrade.go
+++ b/internal/controller/upgrade.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -43,6 +44,18 @@ func ordinalFromPeerEp(stsName, ep string) (int, bool) {
 	return ordinal, true
 }
 
+// isPodOutdated reports whether the pod predates the StatefulSet's current
+// template. The controller-revision-hash label catches any template drift
+// (args, labels, volumes, ...) and stays valid when admission webhooks
+// rewrite pod images; the image comparison is only a fallback for the window
+// before the StatefulSet controller publishes an update revision.
+func isPodOutdated(pod *corev1.Pod, sts *appsv1.StatefulSet, desiredImage string) bool {
+	if rev := sts.Status.UpdateRevision; rev != "" {
+		return pod.Labels[appsv1.ControllerRevisionHashLabelKey] != rev
+	}
+	return len(pod.Spec.Containers) == 0 || pod.Spec.Containers[0].Image != desiredImage
+}
+
 func isPodReady(pod *corev1.Pod) bool {
 	for _, cond := range pod.Status.Conditions {
 		if cond.Type == corev1.PodReady {
@@ -65,9 +78,12 @@ func (r *EtcdClusterReconciler) reconcileVersionUpgrade(ctx context.Context, s *
 		return ctrl.Result{}, nil
 	}
 
+	// Re-render on image drift or on any spec edit not yet observed, so
+	// non-image template changes (etcdOptions, podTemplate, TLS) roll out too.
 	desiredImage := desiredEtcdImage(s.cluster)
-	if s.sts.Spec.Template.Spec.Containers[0].Image != desiredImage {
-		logger.Info("Version change detected. Re-rendering StatefulSet template", "desiredImage", desiredImage)
+	if s.sts.Spec.Template.Spec.Containers[0].Image != desiredImage ||
+		s.cluster.Generation != s.cluster.Status.ObservedGeneration {
+		logger.Info("Spec change detected. Re-rendering StatefulSet template", "desiredImage", desiredImage)
 		var err error
 		s.sts, err = reconcileStatefulSet(ctx, logger, s.cluster, r.Client, *s.sts.Spec.Replicas, r.Scheme)
 		return ctrl.Result{RequeueAfter: requeueDuration}, err
@@ -100,7 +116,7 @@ func (r *EtcdClusterReconciler) reconcileVersionUpgrade(ctx context.Context, s *
 
 	var outdated []ordinalPod
 	for _, p := range pods {
-		if len(p.pod.Spec.Containers) == 0 || p.pod.Spec.Containers[0].Image != desiredImage {
+		if isPodOutdated(p.pod, s.sts, desiredImage) {
 			outdated = append(outdated, p)
 		}
 	}

--- a/internal/controller/upgrade.go
+++ b/internal/controller/upgrade.go
@@ -1,0 +1,157 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	ecv1alpha1 "go.etcd.io/etcd-operator/api/v1alpha1"
+	"go.etcd.io/etcd-operator/internal/etcdutils"
+)
+
+func desiredEtcdImage(ec *ecv1alpha1.EtcdCluster) string {
+	return fmt.Sprintf("%s:%s", ec.Spec.ImageRegistry, ec.Spec.Version)
+}
+
+// ordinalFromPeerEp extracts the pod ordinal from a health-report endpoint
+// ("http://{stsName}-{i}.{svc}...:2379"). memberHealth is sorted
+// lexicographically by endpoint, so slice index != ordinal once i >= 10.
+func ordinalFromPeerEp(stsName, ep string) (int, bool) {
+	host := ep
+	if idx := strings.Index(host, "://"); idx != -1 {
+		host = host[idx+len("://"):]
+	}
+	prefix := stsName + "-"
+	if !strings.HasPrefix(host, prefix) {
+		return 0, false
+	}
+	rest := host[len(prefix):]
+	if end := strings.IndexAny(rest, ".:"); end != -1 {
+		rest = rest[:end]
+	}
+	ordinal, err := strconv.Atoi(rest)
+	if err != nil || ordinal < 0 {
+		return 0, false
+	}
+	return ordinal, true
+}
+
+func isPodReady(pod *corev1.Pod) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady {
+			return cond.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// reconcileVersionUpgrade rolls the cluster to spec.version one pod per
+// reconcile. The StatefulSet uses the OnDelete update strategy, so
+// re-rendering the template never restarts pods by itself; each pod is only
+// deleted once every member is healthy, a leader exists, all member revisions
+// are within 90% of the leader's, and every pod is Ready. The leader's pod is
+// replaced last.
+func (r *EtcdClusterReconciler) reconcileVersionUpgrade(ctx context.Context, s *reconcileState) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	if len(s.sts.Spec.Template.Spec.Containers) == 0 {
+		return ctrl.Result{}, nil
+	}
+
+	desiredImage := desiredEtcdImage(s.cluster)
+	if s.sts.Spec.Template.Spec.Containers[0].Image != desiredImage {
+		logger.Info("Version change detected. Re-rendering StatefulSet template", "desiredImage", desiredImage)
+		var err error
+		s.sts, err = reconcileStatefulSet(ctx, logger, s.cluster, r.Client, *s.sts.Spec.Replicas, r.Scheme)
+		return ctrl.Result{RequeueAfter: requeueDuration}, err
+	}
+
+	type ordinalPod struct {
+		ordinal int
+		pod     *corev1.Pod
+	}
+
+	replicas := int(*s.sts.Spec.Replicas)
+	pods := make([]ordinalPod, 0, replicas)
+	for i := 0; i < replicas; i++ {
+		pod := &corev1.Pod{}
+		podName := fmt.Sprintf("%s-%d", s.cluster.Name, i)
+		if err := r.Get(ctx, client.ObjectKey{Name: podName, Namespace: s.cluster.Namespace}, pod); err != nil {
+			if errors.IsNotFound(err) {
+				// A replacement is in flight; wait for the StatefulSet controller.
+				logger.Info("Pod not found. Waiting for it to be recreated", "pod", podName)
+				return ctrl.Result{RequeueAfter: requeueDuration}, nil
+			}
+			return ctrl.Result{}, err
+		}
+		if pod.DeletionTimestamp != nil {
+			logger.Info("Pod is terminating. Waiting for its replacement", "pod", podName)
+			return ctrl.Result{RequeueAfter: requeueDuration}, nil
+		}
+		pods = append(pods, ordinalPod{ordinal: i, pod: pod})
+	}
+
+	var outdated []ordinalPod
+	for _, p := range pods {
+		if len(p.pod.Spec.Containers) == 0 || p.pod.Spec.Containers[0].Image != desiredImage {
+			outdated = append(outdated, p)
+		}
+	}
+	if len(outdated) == 0 {
+		logger.Info("EtcdCluster is already up-to-date")
+		return ctrl.Result{}, nil
+	}
+
+	for _, p := range pods {
+		if !isPodReady(p.pod) {
+			logger.Info("Pod is not ready. Deferring upgrade step", "pod", p.pod.Name)
+			return ctrl.Result{RequeueAfter: requeueDuration}, nil
+		}
+	}
+
+	_, leaderStatus := etcdutils.FindLeaderStatus(s.memberHealth, logger)
+	if leaderStatus == nil {
+		logger.Info("No leader found. Deferring upgrade step")
+		return ctrl.Result{RequeueAfter: requeueDuration}, nil
+	}
+	for i := range s.memberHealth {
+		if s.memberHealth[i].Status == nil {
+			continue
+		}
+		if !etcdutils.IsLearnerReady(leaderStatus, s.memberHealth[i].Status) {
+			logger.Info("Member is lagging behind the leader. Deferring upgrade step", "endpoint", s.memberHealth[i].Ep)
+			return ctrl.Result{RequeueAfter: requeueDuration}, nil
+		}
+	}
+
+	leaderOrdinal := -1
+	for i := range s.memberHealth {
+		status := s.memberHealth[i].Status
+		if status != nil && status.Header != nil && status.Header.MemberId == status.Leader {
+			if ordinal, ok := ordinalFromPeerEp(s.sts.Name, s.memberHealth[i].Ep); ok {
+				leaderOrdinal = ordinal
+			}
+			break
+		}
+	}
+
+	// Lowest-ordinal outdated pod first; the leader's pod goes last.
+	victim := outdated[0]
+	if victim.ordinal == leaderOrdinal && len(outdated) > 1 {
+		victim = outdated[1]
+	}
+
+	logger.Info("Deleting pod so the StatefulSet recreates it with the new image",
+		"pod", victim.pod.Name, "desiredImage", desiredImage, "leaderOrdinal", leaderOrdinal)
+	if err := r.Delete(ctx, victim.pod); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{RequeueAfter: requeueDuration}, nil
+}

--- a/internal/controller/upgrade.go
+++ b/internal/controller/upgrade.go
@@ -65,12 +65,12 @@ func isPodReady(pod *corev1.Pod) bool {
 	return false
 }
 
-// reconcileVersionUpgrade rolls the cluster to spec.version one pod per
-// reconcile. The StatefulSet uses the OnDelete update strategy, so
+// reconcileVersionUpgrade rolls the cluster to the current template one pod
+// per reconcile. The StatefulSet uses the OnDelete update strategy, so
 // re-rendering the template never restarts pods by itself; each pod is only
 // deleted once every member is healthy, a leader exists, all member revisions
-// are within 90% of the leader's, and every pod is Ready. The leader's pod is
-// replaced last.
+// are within 90% of the leader's, and every up-to-date pod is Ready. The
+// leader's pod is replaced last.
 func (r *EtcdClusterReconciler) reconcileVersionUpgrade(ctx context.Context, s *reconcileState) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
@@ -125,8 +125,15 @@ func (r *EtcdClusterReconciler) reconcileVersionUpgrade(ctx context.Context, s *
 		return ctrl.Result{}, nil
 	}
 
+	// Every up-to-date pod must be Ready before touching anything. A not-Ready
+	// pod that is itself outdated is exempt: requiring it Ready would block
+	// its own replacement (rollback from a version that never becomes Ready).
+	outdatedOrdinals := make(map[int]bool, len(outdated))
+	for _, p := range outdated {
+		outdatedOrdinals[p.ordinal] = true
+	}
 	for _, p := range pods {
-		if !isPodReady(p.pod) {
+		if !outdatedOrdinals[p.ordinal] && !isPodReady(p.pod) {
 			logger.Info("Pod is not ready. Deferring upgrade step", "pod", p.pod.Name)
 			return ctrl.Result{RequeueAfter: requeueDuration}, nil
 		}
@@ -158,10 +165,22 @@ func (r *EtcdClusterReconciler) reconcileVersionUpgrade(ctx context.Context, s *
 		}
 	}
 
-	// Lowest-ordinal outdated pod first; the leader's pod goes last.
-	victim := outdated[0]
-	if victim.ordinal == leaderOrdinal && len(outdated) > 1 {
-		victim = outdated[1]
+	// Not-Ready outdated pods go first (they hold no quorum weight), then
+	// lowest ordinal; the leader's pod goes last.
+	candidates := make([]ordinalPod, 0, len(outdated))
+	for _, p := range outdated {
+		if !isPodReady(p.pod) {
+			candidates = append(candidates, p)
+		}
+	}
+	for _, p := range outdated {
+		if isPodReady(p.pod) {
+			candidates = append(candidates, p)
+		}
+	}
+	victim := candidates[0]
+	if victim.ordinal == leaderOrdinal && len(candidates) > 1 {
+		victim = candidates[1]
 	}
 
 	logger.Info("Deleting pod so the StatefulSet recreates it with the new image",
@@ -170,4 +189,79 @@ func (r *EtcdClusterReconciler) reconcileVersionUpgrade(ctx context.Context, s *
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{RequeueAfter: requeueDuration}, nil
+}
+
+// recoverDegradedUpgrade runs when the member health check fails, which
+// otherwise blocks reconciliation before any template or pod convergence: a
+// pod replaced with a broken image (bad tag, incompatible flags) would wedge
+// the cluster at N-1 members forever. It re-syncs the StatefulSet template
+// from the spec so a version rollback or option fix can land, and, while the
+// remaining members still hold quorum, deletes one not-Ready outdated pod so
+// the StatefulSet recreates it from the fixed template. Returns handled=false
+// when the degradation is not something template convergence can repair.
+func (r *EtcdClusterReconciler) recoverDegradedUpgrade(ctx context.Context, s *reconcileState) (ctrl.Result, bool) {
+	logger := log.FromContext(ctx)
+
+	if s.sts == nil || s.sts.Spec.Replicas == nil || len(s.sts.Spec.Template.Spec.Containers) == 0 {
+		return ctrl.Result{}, false
+	}
+
+	// waitForStatefulSetReady can never succeed with a member down, so sync
+	// without it.
+	sts, err := syncStatefulSet(ctx, logger, s.cluster, r.Client, *s.sts.Spec.Replicas, r.Scheme)
+	if err != nil {
+		logger.Error(err, "Failed to re-sync StatefulSet template while degraded")
+		return ctrl.Result{}, false
+	}
+	s.sts = sts
+
+	healthy := 0
+	for i := range s.memberHealth {
+		if s.memberHealth[i].Health {
+			healthy++
+		}
+	}
+	replicas := int(*sts.Spec.Replicas)
+	if healthy < replicas/2+1 {
+		// Quorum is already lost; deleting anything can only make it worse.
+		return ctrl.Result{}, false
+	}
+
+	desiredImage := desiredEtcdImage(s.cluster)
+	var victim *corev1.Pod
+	for i := 0; i < replicas; i++ {
+		pod := &corev1.Pod{}
+		podName := fmt.Sprintf("%s-%d", s.cluster.Name, i)
+		if err := r.PodReader.Get(ctx, client.ObjectKey{Name: podName, Namespace: s.cluster.Namespace}, pod); err != nil {
+			if errors.IsNotFound(err) {
+				// A replacement is already in flight.
+				return ctrl.Result{RequeueAfter: requeueDuration}, true
+			}
+			return ctrl.Result{}, false
+		}
+		if pod.DeletionTimestamp != nil {
+			return ctrl.Result{RequeueAfter: requeueDuration}, true
+		}
+		if isPodReady(pod) {
+			continue
+		}
+		if !isPodOutdated(pod, sts, desiredImage) {
+			// Broken but already on the current template: recreating it would
+			// change nothing.
+			return ctrl.Result{}, false
+		}
+		if victim == nil {
+			victim = pod
+		}
+	}
+	if victim == nil {
+		return ctrl.Result{}, false
+	}
+
+	logger.Info("Replacing broken outdated pod while quorum holds", "pod", victim.Name)
+	if err := r.Delete(ctx, victim); err != nil {
+		logger.Error(err, "Failed to delete broken outdated pod", "pod", victim.Name)
+		return ctrl.Result{}, false
+	}
+	return ctrl.Result{RequeueAfter: requeueDuration}, true
 }

--- a/internal/controller/upgrade.go
+++ b/internal/controller/upgrade.go
@@ -83,7 +83,7 @@ func (r *EtcdClusterReconciler) reconcileVersionUpgrade(ctx context.Context, s *
 	for i := 0; i < replicas; i++ {
 		pod := &corev1.Pod{}
 		podName := fmt.Sprintf("%s-%d", s.cluster.Name, i)
-		if err := r.Get(ctx, client.ObjectKey{Name: podName, Namespace: s.cluster.Namespace}, pod); err != nil {
+		if err := r.PodReader.Get(ctx, client.ObjectKey{Name: podName, Namespace: s.cluster.Namespace}, pod); err != nil {
 			if errors.IsNotFound(err) {
 				// A replacement is in flight; wait for the StatefulSet controller.
 				logger.Info("Pod not found. Waiting for it to be recreated", "pod", podName)

--- a/internal/controller/upgrade_test.go
+++ b/internal/controller/upgrade_test.go
@@ -1,0 +1,149 @@
+package controller
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	ecv1alpha1 "go.etcd.io/etcd-operator/api/v1alpha1"
+	"go.etcd.io/etcd-operator/internal/etcdutils"
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+const (
+	upgradeTestRegistry = "gcr.io/etcd-development/etcd"
+	upgradeOldImage     = upgradeTestRegistry + ":3.5.17"
+	upgradeNewImage     = upgradeTestRegistry + ":3.6.0"
+)
+
+func upgradeTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, ecv1alpha1.AddToScheme(scheme))
+	return scheme
+}
+
+func upgradeTestCluster() *ecv1alpha1.EtcdCluster {
+	return &ecv1alpha1.EtcdCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-etcd",
+			Namespace: "default",
+			UID:       "1234",
+		},
+		Spec: ecv1alpha1.EtcdClusterSpec{
+			Size:          3,
+			Version:       "3.6.0",
+			ImageRegistry: upgradeTestRegistry,
+		},
+	}
+}
+
+func upgradeTestStatefulSet(ec *ecv1alpha1.EtcdCluster, image string, replicas int32) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ec.Name,
+			Namespace: ec.Namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "operator.etcd.io/v1alpha1",
+					Kind:       "EtcdCluster",
+					Name:       ec.Name,
+					UID:        ec.UID,
+					Controller: pointerToBool(true),
+				},
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas:    pointerToInt32(replicas),
+			ServiceName: ec.Name,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "etcd", Image: image}},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{ReadyReplicas: replicas},
+	}
+}
+
+func upgradeTestPod(ec *ecv1alpha1.EtcdCluster, ordinal int, image string, ready bool) *corev1.Pod {
+	readyStatus := corev1.ConditionFalse
+	if ready {
+		readyStatus = corev1.ConditionTrue
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%d", ec.Name, ordinal),
+			Namespace: ec.Namespace,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "etcd", Image: image}},
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: readyStatus}},
+		},
+	}
+}
+
+// upgradeTestHealth fabricates health info for members 0..size-1 with the
+// given revisions; leaderOrdinal's member ID is reported as leader by all.
+func upgradeTestHealth(ec *ecv1alpha1.EtcdCluster, revisions []int64, leaderOrdinal int) (*clientv3.MemberListResponse, []etcdutils.EpHealth) {
+	memberID := func(ordinal int) uint64 { return uint64(ordinal + 1) }
+
+	members := make([]*etcdserverpb.Member, 0, len(revisions))
+	health := make([]etcdutils.EpHealth, 0, len(revisions))
+	for i, rev := range revisions {
+		members = append(members, &etcdserverpb.Member{ID: memberID(i)})
+		health = append(health, etcdutils.EpHealth{
+			Ep:     fmt.Sprintf("http://%s-%d.%s.%s.svc.cluster.local:2379", ec.Name, i, ec.Name, ec.Namespace),
+			Health: true,
+			Status: &clientv3.StatusResponse{
+				Header: &etcdserverpb.ResponseHeader{
+					MemberId: memberID(i),
+					Revision: rev,
+				},
+				Leader: memberID(leaderOrdinal),
+			},
+		})
+	}
+	return &clientv3.MemberListResponse{Members: members}, health
+}
+
+// regression repro: pure version bump never re-renders the STS; fixed in the next commit.
+func TestVersionBumpIsSilentNoop(t *testing.T) {
+	scheme := upgradeTestScheme(t)
+	ec := upgradeTestCluster()
+	sts := upgradeTestStatefulSet(ec, upgradeOldImage, 3)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec, sts).Build()
+	r := &EtcdClusterReconciler{Client: fakeClient, Scheme: scheme}
+
+	memberList, health := upgradeTestHealth(ec, []int64{100, 100, 100}, 0)
+	state := &reconcileState{
+		cluster:        ec,
+		sts:            sts,
+		memberListResp: memberList,
+		memberHealth:   health,
+	}
+
+	res, err := r.reconcileClusterState(t.Context(), state)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, res)
+
+	got := &appsv1.StatefulSet{}
+	require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKey{Name: ec.Name, Namespace: ec.Namespace}, got))
+	assert.Equal(t, upgradeOldImage, got.Spec.Template.Spec.Containers[0].Image,
+		"version bump silently ignored: StatefulSet still runs the old image")
+}

--- a/internal/controller/upgrade_test.go
+++ b/internal/controller/upgrade_test.go
@@ -127,7 +127,7 @@ func upgradeTestReconciler(t *testing.T, objs ...client.Object) (*EtcdClusterRec
 	t.Helper()
 	scheme := upgradeTestScheme(t)
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
-	return &EtcdClusterReconciler{Client: fakeClient, Scheme: scheme}, fakeClient
+	return &EtcdClusterReconciler{Client: fakeClient, PodReader: fakeClient, Scheme: scheme}, fakeClient
 }
 
 func podNames(t *testing.T, c client.Client, namespace string) []string {

--- a/internal/controller/upgrade_test.go
+++ b/internal/controller/upgrade_test.go
@@ -349,6 +349,79 @@ func TestUpgradeRequeuesWhenPodMissing(t *testing.T) {
 	assert.True(t, k8serrors.IsNotFound(err))
 }
 
+func withRevisionHash(pod *corev1.Pod, revision string) *corev1.Pod {
+	if pod.Labels == nil {
+		pod.Labels = map[string]string{}
+	}
+	pod.Labels[appsv1.ControllerRevisionHashLabelKey] = revision
+	return pod
+}
+
+// A pod-mutating admission webhook may rewrite pod images (mirror registry,
+// tag-to-digest pinning); matching revision hashes must win over the image
+// string, or every reconcile would delete a healthy up-to-date pod.
+func TestUpgradeIgnoresWebhookMutatedPodImage(t *testing.T) {
+	ec := upgradeTestCluster()
+	sts := upgradeTestStatefulSet(ec, upgradeNewImage)
+	sts.Status.UpdateRevision = "rev-2"
+	mutatedImage := "mirror.local/etcd@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+	r, fakeClient := upgradeTestReconciler(t, ec, sts,
+		withRevisionHash(upgradeTestPod(ec, 0, mutatedImage, true), "rev-2"),
+		withRevisionHash(upgradeTestPod(ec, 1, mutatedImage, true), "rev-2"),
+		withRevisionHash(upgradeTestPod(ec, 2, mutatedImage, true), "rev-2"),
+	)
+
+	memberList, health := upgradeTestHealth(ec, []int64{100, 100, 100}, 0)
+	state := &reconcileState{cluster: ec, sts: sts, memberListResp: memberList, memberHealth: health}
+
+	res, err := r.reconcileVersionUpgrade(t.Context(), state)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, res)
+	assert.Len(t, podNames(t, fakeClient, ec.Namespace), 3, "no pod may be deleted when revision hashes match")
+}
+
+// Non-image template drift (etcdOptions, podTemplate, TLS volumes) changes the
+// update revision without changing the image; the stale pod must still roll.
+func TestUpgradeRollsPodOnNonImageTemplateChange(t *testing.T) {
+	ec := upgradeTestCluster()
+	sts := upgradeTestStatefulSet(ec, upgradeNewImage)
+	sts.Status.UpdateRevision = "rev-2"
+	r, fakeClient := upgradeTestReconciler(t, ec, sts,
+		withRevisionHash(upgradeTestPod(ec, 0, upgradeNewImage, true), "rev-1"),
+		withRevisionHash(upgradeTestPod(ec, 1, upgradeNewImage, true), "rev-2"),
+		withRevisionHash(upgradeTestPod(ec, 2, upgradeNewImage, true), "rev-2"),
+	)
+
+	memberList, health := upgradeTestHealth(ec, []int64{100, 100, 100}, 2)
+	state := &reconcileState{cluster: ec, sts: sts, memberListResp: memberList, memberHealth: health}
+
+	res, err := r.reconcileVersionUpgrade(t.Context(), state)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, res)
+	assert.ElementsMatch(t, []string{"test-etcd-1", "test-etcd-2"}, podNames(t, fakeClient, ec.Namespace))
+}
+
+// A spec edit that doesn't touch the image (observed via generation lag) must
+// re-render the template; OnDelete otherwise leaves it stale forever.
+func TestUpgradeRerendersOnUnobservedSpecChange(t *testing.T) {
+	ec := upgradeTestCluster()
+	ec.Generation = 2
+	ec.Status.ObservedGeneration = 1
+	sts := upgradeTestStatefulSet(ec, upgradeNewImage)
+	r, _ := upgradeTestReconciler(t, ec, sts,
+		upgradeTestPod(ec, 0, upgradeNewImage, true),
+		upgradeTestPod(ec, 1, upgradeNewImage, true),
+		upgradeTestPod(ec, 2, upgradeNewImage, true),
+	)
+
+	memberList, health := upgradeTestHealth(ec, []int64{100, 100, 100}, 0)
+	state := &reconcileState{cluster: ec, sts: sts, memberListResp: memberList, memberHealth: health}
+
+	res, err := r.reconcileVersionUpgrade(t.Context(), state)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, res, "unobserved spec change must re-render and requeue")
+}
+
 func TestOrdinalFromPeerEp(t *testing.T) {
 	tests := []struct {
 		ep       string

--- a/internal/controller/upgrade_test.go
+++ b/internal/controller/upgrade_test.go
@@ -422,6 +422,122 @@ func TestUpgradeRerendersOnUnobservedSpecChange(t *testing.T) {
 	assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, res, "unobserved spec change must re-render and requeue")
 }
 
+// Rollback deadlock (healthy-members case): the sole outdated pod is itself
+// not Ready; requiring it Ready would block its own replacement forever.
+func TestUpgradeReplacesNotReadyOutdatedPod(t *testing.T) {
+	ec := upgradeTestCluster()
+	sts := upgradeTestStatefulSet(ec, upgradeNewImage)
+	r, fakeClient := upgradeTestReconciler(t, ec, sts,
+		upgradeTestPod(ec, 0, upgradeOldImage, false),
+		upgradeTestPod(ec, 1, upgradeNewImage, true),
+		upgradeTestPod(ec, 2, upgradeNewImage, true),
+	)
+
+	memberList, health := upgradeTestHealth(ec, []int64{100, 100, 100}, 1)
+	state := &reconcileState{cluster: ec, sts: sts, memberListResp: memberList, memberHealth: health}
+
+	res, err := r.reconcileVersionUpgrade(t.Context(), state)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, res)
+	assert.ElementsMatch(t, []string{"test-etcd-1", "test-etcd-2"}, podNames(t, fakeClient, ec.Namespace))
+}
+
+func upgradeDegradedHealth(ec *ecv1alpha1.EtcdCluster, healthyOrdinals ...int) []etcdutils.EpHealth {
+	_, health := upgradeTestHealth(ec, []int64{100, 100, 100}, healthyOrdinals[0])
+	healthySet := map[int]bool{}
+	for _, o := range healthyOrdinals {
+		healthySet[o] = true
+	}
+	for i := range health {
+		if !healthySet[i] {
+			health[i].Health = false
+		}
+	}
+	return health
+}
+
+// Failed-upgrade wedge: the replacement pod crashloops, the health check
+// fails every reconcile, and the normal upgrade path is unreachable. Recovery
+// must re-sync the template and replace the broken pod while quorum holds.
+func TestRecoverDegradedUpgrade(t *testing.T) {
+	t.Run("replaces broken outdated pod while quorum holds", func(t *testing.T) {
+		ec := upgradeTestCluster()
+		// Spec already rolled back: template re-renders to the old image, and
+		// the crashlooping pod still carries the bad revision.
+		ec.Spec.Version = "3.5.17"
+		sts := upgradeTestStatefulSet(ec, upgradeOldImage)
+		sts.Status.UpdateRevision = "rev-1"
+		r, fakeClient := upgradeTestReconciler(t, ec, sts,
+			withRevisionHash(upgradeTestPod(ec, 0, upgradeNewImage, false), "rev-2"),
+			withRevisionHash(upgradeTestPod(ec, 1, upgradeOldImage, true), "rev-1"),
+			withRevisionHash(upgradeTestPod(ec, 2, upgradeOldImage, true), "rev-1"),
+		)
+
+		state := &reconcileState{cluster: ec, sts: sts, memberHealth: upgradeDegradedHealth(ec, 1, 2)}
+
+		res, handled := r.recoverDegradedUpgrade(t.Context(), state)
+		assert.True(t, handled)
+		assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, res)
+		assert.ElementsMatch(t, []string{"test-etcd-1", "test-etcd-2"}, podNames(t, fakeClient, ec.Namespace))
+	})
+
+	t.Run("re-syncs template from spec while degraded", func(t *testing.T) {
+		ec := upgradeTestCluster()
+		ec.Spec.Version = "3.5.17"
+		// Template still carries the bad image; only the sync can fix it.
+		sts := upgradeTestStatefulSet(ec, upgradeNewImage)
+		sts.Status.UpdateRevision = "rev-2"
+		r, fakeClient := upgradeTestReconciler(t, ec, sts,
+			withRevisionHash(upgradeTestPod(ec, 0, upgradeNewImage, false), "rev-2"),
+			withRevisionHash(upgradeTestPod(ec, 1, upgradeOldImage, true), "rev-1"),
+			withRevisionHash(upgradeTestPod(ec, 2, upgradeOldImage, true), "rev-1"),
+		)
+
+		state := &reconcileState{cluster: ec, sts: sts, memberHealth: upgradeDegradedHealth(ec, 1, 2)}
+
+		_, _ = r.recoverDegradedUpgrade(t.Context(), state)
+
+		got := &appsv1.StatefulSet{}
+		require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKey{Name: ec.Name, Namespace: ec.Namespace}, got))
+		assert.Equal(t, upgradeOldImage, got.Spec.Template.Spec.Containers[0].Image)
+	})
+
+	t.Run("refuses to delete when quorum is lost", func(t *testing.T) {
+		ec := upgradeTestCluster()
+		ec.Spec.Version = "3.5.17"
+		sts := upgradeTestStatefulSet(ec, upgradeOldImage)
+		sts.Status.UpdateRevision = "rev-1"
+		r, fakeClient := upgradeTestReconciler(t, ec, sts,
+			withRevisionHash(upgradeTestPod(ec, 0, upgradeNewImage, false), "rev-2"),
+			withRevisionHash(upgradeTestPod(ec, 1, upgradeNewImage, false), "rev-2"),
+			withRevisionHash(upgradeTestPod(ec, 2, upgradeOldImage, true), "rev-1"),
+		)
+
+		state := &reconcileState{cluster: ec, sts: sts, memberHealth: upgradeDegradedHealth(ec, 2)}
+
+		_, handled := r.recoverDegradedUpgrade(t.Context(), state)
+		assert.False(t, handled)
+		assert.Len(t, podNames(t, fakeClient, ec.Namespace), 3, "no pod may be deleted without quorum")
+	})
+
+	t.Run("refuses when broken pod is already on current template", func(t *testing.T) {
+		ec := upgradeTestCluster()
+		sts := upgradeTestStatefulSet(ec, upgradeNewImage)
+		sts.Status.UpdateRevision = "rev-2"
+		r, fakeClient := upgradeTestReconciler(t, ec, sts,
+			withRevisionHash(upgradeTestPod(ec, 0, upgradeNewImage, false), "rev-2"),
+			withRevisionHash(upgradeTestPod(ec, 1, upgradeNewImage, true), "rev-2"),
+			withRevisionHash(upgradeTestPod(ec, 2, upgradeNewImage, true), "rev-2"),
+		)
+
+		state := &reconcileState{cluster: ec, sts: sts, memberHealth: upgradeDegradedHealth(ec, 1, 2)}
+
+		_, handled := r.recoverDegradedUpgrade(t.Context(), state)
+		assert.False(t, handled, "recreating a pod from the same template cannot help")
+		assert.Len(t, podNames(t, fakeClient, ec.Namespace), 3)
+	})
+}
+
 func TestOrdinalFromPeerEp(t *testing.T) {
 	tests := []struct {
 		ep       string

--- a/internal/controller/upgrade_test.go
+++ b/internal/controller/upgrade_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -50,7 +51,8 @@ func upgradeTestCluster() *ecv1alpha1.EtcdCluster {
 	}
 }
 
-func upgradeTestStatefulSet(ec *ecv1alpha1.EtcdCluster, image string, replicas int32) *appsv1.StatefulSet {
+func upgradeTestStatefulSet(ec *ecv1alpha1.EtcdCluster, image string) *appsv1.StatefulSet {
+	replicas := int32(ec.Spec.Size)
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ec.Name,
@@ -97,8 +99,8 @@ func upgradeTestPod(ec *ecv1alpha1.EtcdCluster, ordinal int, image string, ready
 	}
 }
 
-// upgradeTestHealth fabricates health info for members 0..size-1 with the
-// given revisions; leaderOrdinal's member ID is reported as leader by all.
+// upgradeTestHealth fabricates health info for members 0..len(revisions)-1;
+// leaderOrdinal's member ID is reported as leader by all members.
 func upgradeTestHealth(ec *ecv1alpha1.EtcdCluster, revisions []int64, leaderOrdinal int) (*clientv3.MemberListResponse, []etcdutils.EpHealth) {
 	memberID := func(ordinal int) uint64 { return uint64(ordinal + 1) }
 
@@ -121,29 +123,248 @@ func upgradeTestHealth(ec *ecv1alpha1.EtcdCluster, revisions []int64, leaderOrdi
 	return &clientv3.MemberListResponse{Members: members}, health
 }
 
-// regression repro: pure version bump never re-renders the STS; fixed in the next commit.
-func TestVersionBumpIsSilentNoop(t *testing.T) {
+func upgradeTestReconciler(t *testing.T, objs ...client.Object) (*EtcdClusterReconciler, client.Client) {
+	t.Helper()
 	scheme := upgradeTestScheme(t)
-	ec := upgradeTestCluster()
-	sts := upgradeTestStatefulSet(ec, upgradeOldImage, 3)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	return &EtcdClusterReconciler{Client: fakeClient, Scheme: scheme}, fakeClient
+}
 
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec, sts).Build()
-	r := &EtcdClusterReconciler{Client: fakeClient, Scheme: scheme}
+func podNames(t *testing.T, c client.Client, namespace string) []string {
+	t.Helper()
+	podList := &corev1.PodList{}
+	require.NoError(t, c.List(t.Context(), podList, client.InNamespace(namespace)))
+	names := make([]string, 0, len(podList.Items))
+	for i := range podList.Items {
+		names = append(names, podList.Items[i].Name)
+	}
+	return names
+}
+
+// Flipped from the commit-1 regression repro (TestVersionBumpIsSilentNoop):
+// a pure version bump now re-renders the StatefulSet template (OnDelete, so
+// no pod restarts yet) and requeues.
+func TestVersionBumpRerendersStatefulSet(t *testing.T) {
+	ec := upgradeTestCluster()
+	sts := upgradeTestStatefulSet(ec, upgradeOldImage)
+	r, fakeClient := upgradeTestReconciler(t, ec, sts)
 
 	memberList, health := upgradeTestHealth(ec, []int64{100, 100, 100}, 0)
-	state := &reconcileState{
-		cluster:        ec,
-		sts:            sts,
-		memberListResp: memberList,
-		memberHealth:   health,
-	}
+	state := &reconcileState{cluster: ec, sts: sts, memberListResp: memberList, memberHealth: health}
 
 	res, err := r.reconcileClusterState(t.Context(), state)
 	require.NoError(t, err)
-	assert.Equal(t, ctrl.Result{}, res)
+	assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, res)
 
 	got := &appsv1.StatefulSet{}
 	require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKey{Name: ec.Name, Namespace: ec.Namespace}, got))
-	assert.Equal(t, upgradeOldImage, got.Spec.Template.Spec.Containers[0].Image,
-		"version bump silently ignored: StatefulSet still runs the old image")
+	assert.Equal(t, upgradeNewImage, got.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, appsv1.OnDeleteStatefulSetStrategyType, got.Spec.UpdateStrategy.Type)
+	assert.Empty(t, podNames(t, fakeClient, ec.Namespace), "no pod may be deleted or created by the re-render step")
+}
+
+func TestUpgradeDeletesOnePodPerReconcile(t *testing.T) {
+	ec := upgradeTestCluster()
+	sts := upgradeTestStatefulSet(ec, upgradeNewImage)
+	r, fakeClient := upgradeTestReconciler(t, ec, sts,
+		upgradeTestPod(ec, 0, upgradeOldImage, true),
+		upgradeTestPod(ec, 1, upgradeOldImage, true),
+		upgradeTestPod(ec, 2, upgradeOldImage, true),
+	)
+
+	memberList, health := upgradeTestHealth(ec, []int64{100, 100, 100}, 2)
+	state := &reconcileState{cluster: ec, sts: sts, memberListResp: memberList, memberHealth: health}
+
+	res, err := r.reconcileVersionUpgrade(t.Context(), state)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, res)
+	assert.ElementsMatch(t, []string{"test-etcd-1", "test-etcd-2"}, podNames(t, fakeClient, ec.Namespace))
+
+	// StatefulSet controller "recreated" pod-0 with the new image.
+	require.NoError(t, fakeClient.Create(t.Context(), upgradeTestPod(ec, 0, upgradeNewImage, true)))
+
+	res, err = r.reconcileVersionUpgrade(t.Context(), state)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, res)
+	assert.ElementsMatch(t, []string{"test-etcd-0", "test-etcd-2"}, podNames(t, fakeClient, ec.Namespace))
+}
+
+func TestUpgradeLeaderPodLast(t *testing.T) {
+	ec := upgradeTestCluster()
+	sts := upgradeTestStatefulSet(ec, upgradeNewImage)
+	r, fakeClient := upgradeTestReconciler(t, ec, sts,
+		upgradeTestPod(ec, 0, upgradeOldImage, true),
+		upgradeTestPod(ec, 1, upgradeOldImage, true),
+		upgradeTestPod(ec, 2, upgradeOldImage, true),
+	)
+
+	memberList, health := upgradeTestHealth(ec, []int64{100, 100, 100}, 0)
+	state := &reconcileState{cluster: ec, sts: sts, memberListResp: memberList, memberHealth: health}
+
+	// Leader is ordinal 0: pods 1 and 2 must go first.
+	res, err := r.reconcileVersionUpgrade(t.Context(), state)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, res)
+	assert.ElementsMatch(t, []string{"test-etcd-0", "test-etcd-2"}, podNames(t, fakeClient, ec.Namespace))
+
+	require.NoError(t, fakeClient.Create(t.Context(), upgradeTestPod(ec, 1, upgradeNewImage, true)))
+	res, err = r.reconcileVersionUpgrade(t.Context(), state)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, res)
+	assert.ElementsMatch(t, []string{"test-etcd-0", "test-etcd-1"}, podNames(t, fakeClient, ec.Namespace))
+
+	// Leader pod is the sole outdated one left: it is finally replaced.
+	require.NoError(t, fakeClient.Create(t.Context(), upgradeTestPod(ec, 2, upgradeNewImage, true)))
+	res, err = r.reconcileVersionUpgrade(t.Context(), state)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, res)
+	assert.ElementsMatch(t, []string{"test-etcd-1", "test-etcd-2"}, podNames(t, fakeClient, ec.Namespace))
+}
+
+func TestUpgradeBlocksWhenMemberLagging(t *testing.T) {
+	ec := upgradeTestCluster()
+	sts := upgradeTestStatefulSet(ec, upgradeNewImage)
+	r, fakeClient := upgradeTestReconciler(t, ec, sts,
+		upgradeTestPod(ec, 0, upgradeOldImage, true),
+		upgradeTestPod(ec, 1, upgradeOldImage, true),
+		upgradeTestPod(ec, 2, upgradeOldImage, true),
+	)
+
+	// Member 1 sits at revision 50 vs leader 100 (< 90%).
+	memberList, health := upgradeTestHealth(ec, []int64{100, 50, 100}, 0)
+	state := &reconcileState{cluster: ec, sts: sts, memberListResp: memberList, memberHealth: health}
+
+	res, err := r.reconcileVersionUpgrade(t.Context(), state)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, res)
+	assert.Len(t, podNames(t, fakeClient, ec.Namespace), 3, "no pod may be deleted while a member lags")
+}
+
+func TestUpgradeBlocksWhenPodNotReadyOrTerminating(t *testing.T) {
+	t.Run("pod not ready", func(t *testing.T) {
+		ec := upgradeTestCluster()
+		sts := upgradeTestStatefulSet(ec, upgradeNewImage)
+		r, fakeClient := upgradeTestReconciler(t, ec, sts,
+			upgradeTestPod(ec, 0, upgradeOldImage, true),
+			upgradeTestPod(ec, 1, upgradeNewImage, false),
+			upgradeTestPod(ec, 2, upgradeOldImage, true),
+		)
+
+		memberList, health := upgradeTestHealth(ec, []int64{100, 100, 100}, 0)
+		state := &reconcileState{cluster: ec, sts: sts, memberListResp: memberList, memberHealth: health}
+
+		res, err := r.reconcileVersionUpgrade(t.Context(), state)
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, res)
+		assert.Len(t, podNames(t, fakeClient, ec.Namespace), 3, "no pod may be deleted while another is not ready")
+	})
+
+	t.Run("pod terminating", func(t *testing.T) {
+		ec := upgradeTestCluster()
+		sts := upgradeTestStatefulSet(ec, upgradeNewImage)
+		terminating := upgradeTestPod(ec, 1, upgradeNewImage, false)
+		terminating.Finalizers = []string{"test.etcd.io/keep"}
+		now := metav1.Now()
+		terminating.DeletionTimestamp = &now
+		r, fakeClient := upgradeTestReconciler(t, ec, sts,
+			upgradeTestPod(ec, 0, upgradeOldImage, true),
+			terminating,
+			upgradeTestPod(ec, 2, upgradeOldImage, true),
+		)
+
+		memberList, health := upgradeTestHealth(ec, []int64{100, 100, 100}, 0)
+		state := &reconcileState{cluster: ec, sts: sts, memberListResp: memberList, memberHealth: health}
+
+		res, err := r.reconcileVersionUpgrade(t.Context(), state)
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, res)
+		assert.Len(t, podNames(t, fakeClient, ec.Namespace), 3, "no pod may be deleted while another terminates")
+	})
+}
+
+func TestUpgradeBlocksWhileLearnerPending(t *testing.T) {
+	ec := upgradeTestCluster()
+	sts := upgradeTestStatefulSet(ec, upgradeOldImage)
+	r, fakeClient := upgradeTestReconciler(t, ec, sts,
+		upgradeTestPod(ec, 0, upgradeOldImage, true),
+		upgradeTestPod(ec, 1, upgradeOldImage, true),
+		upgradeTestPod(ec, 2, upgradeOldImage, true),
+	)
+
+	// Member 2 is a learner far behind the leader: the learner branch of
+	// reconcileClusterState must requeue before any upgrade work starts.
+	memberList, health := upgradeTestHealth(ec, []int64{100, 100, 10}, 0)
+	health[2].Status.IsLearner = true
+	state := &reconcileState{cluster: ec, sts: sts, memberListResp: memberList, memberHealth: health}
+
+	res, err := r.reconcileClusterState(t.Context(), state)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, res)
+
+	got := &appsv1.StatefulSet{}
+	require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKey{Name: ec.Name, Namespace: ec.Namespace}, got))
+	assert.Equal(t, upgradeOldImage, got.Spec.Template.Spec.Containers[0].Image, "template must not be re-rendered")
+	assert.Len(t, podNames(t, fakeClient, ec.Namespace), 3, "no pod may be deleted while a learner is pending")
+}
+
+func TestUpgradeNoopWhenAllPodsUpdated(t *testing.T) {
+	ec := upgradeTestCluster()
+	sts := upgradeTestStatefulSet(ec, upgradeNewImage)
+	r, fakeClient := upgradeTestReconciler(t, ec, sts,
+		upgradeTestPod(ec, 0, upgradeNewImage, true),
+		upgradeTestPod(ec, 1, upgradeNewImage, true),
+		upgradeTestPod(ec, 2, upgradeNewImage, true),
+	)
+
+	memberList, health := upgradeTestHealth(ec, []int64{100, 100, 100}, 0)
+	state := &reconcileState{cluster: ec, sts: sts, memberListResp: memberList, memberHealth: health}
+
+	res, err := r.reconcileVersionUpgrade(t.Context(), state)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, res)
+	assert.Len(t, podNames(t, fakeClient, ec.Namespace), 3)
+}
+
+func TestUpgradeRequeuesWhenPodMissing(t *testing.T) {
+	ec := upgradeTestCluster()
+	sts := upgradeTestStatefulSet(ec, upgradeNewImage)
+	// pod-1 is missing: its replacement is still being created.
+	r, fakeClient := upgradeTestReconciler(t, ec, sts,
+		upgradeTestPod(ec, 0, upgradeOldImage, true),
+		upgradeTestPod(ec, 2, upgradeOldImage, true),
+	)
+
+	memberList, health := upgradeTestHealth(ec, []int64{100, 100, 100}, 0)
+	state := &reconcileState{cluster: ec, sts: sts, memberListResp: memberList, memberHealth: health}
+
+	res, err := r.reconcileVersionUpgrade(t.Context(), state)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, res)
+	assert.Len(t, podNames(t, fakeClient, ec.Namespace), 2, "no pod may be deleted while one is missing")
+
+	// Not-found error other than pod absence must not be swallowed silently:
+	// sanity-check the pods we expect are still the ones present.
+	pod := &corev1.Pod{}
+	err = fakeClient.Get(t.Context(), client.ObjectKey{Name: "test-etcd-1", Namespace: ec.Namespace}, pod)
+	assert.True(t, k8serrors.IsNotFound(err))
+}
+
+func TestOrdinalFromPeerEp(t *testing.T) {
+	tests := []struct {
+		ep       string
+		ordinal  int
+		expectOk bool
+	}{
+		{"http://test-etcd-0.test-etcd.default.svc.cluster.local:2379", 0, true},
+		{"http://test-etcd-12.test-etcd.default.svc.cluster.local:2379", 12, true},
+		{"http://other-sts-1.other-sts.default.svc.cluster.local:2379", 0, false},
+		{"http://test-etcd-x.test-etcd.default.svc.cluster.local:2379", 0, false},
+	}
+	for _, tt := range tests {
+		ordinal, ok := ordinalFromPeerEp("test-etcd", tt.ep)
+		assert.Equal(t, tt.expectOk, ok, tt.ep)
+		if tt.expectOk {
+			assert.Equal(t, tt.ordinal, ordinal, tt.ep)
+		}
+	}
 }

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -243,6 +243,9 @@ func createOrPatchStatefulSet(ctx context.Context, logger logr.Logger, ec *ecv1a
 	stsSpec := appsv1.StatefulSetSpec{
 		Replicas:    &replicas,
 		ServiceName: ec.Name,
+		// OnDelete: pods are only replaced when the upgrade gate deletes them,
+		// never rolled automatically on template changes.
+		UpdateStrategy: appsv1.StatefulSetUpdateStrategy{Type: appsv1.OnDeleteStatefulSetStrategyType},
 		Selector: &metav1.LabelSelector{
 			MatchLabels: labels,
 		},

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -47,6 +47,23 @@ const (
 )
 
 func reconcileStatefulSet(ctx context.Context, logger logr.Logger, ec *ecv1alpha1.EtcdCluster, c client.Client, replicas int32, scheme *runtime.Scheme) (*appsv1.StatefulSet, error) {
+	if _, err := syncStatefulSet(ctx, logger, ec, c, replicas, scheme); err != nil {
+		return nil, err
+	}
+
+	// Wait for statefulset to be ready
+	if err := waitForStatefulSetReady(ctx, logger, c, ec.Name, ec.Namespace); err != nil {
+		return nil, err
+	}
+
+	// Return latest Stateful set. (This is to ensure that we return the latest statefulset for next operation to act on)
+	return getStatefulSet(ctx, c, ec.Name, ec.Namespace)
+}
+
+// syncStatefulSet renders and applies the ConfigMap, member certs and
+// StatefulSet without waiting for readiness. Recovery paths use it while pods
+// are down, when waitForStatefulSetReady could never succeed.
+func syncStatefulSet(ctx context.Context, logger logr.Logger, ec *ecv1alpha1.EtcdCluster, c client.Client, replicas int32, scheme *runtime.Scheme) (*appsv1.StatefulSet, error) {
 
 	// prepare/update configmap for StatefulSet
 	err := applyEtcdClusterState(ctx, ec, int(replicas), c, scheme, logger)
@@ -66,13 +83,6 @@ func reconcileStatefulSet(ctx context.Context, logger logr.Logger, ec *ecv1alpha
 		return nil, err
 	}
 
-	// Wait for statefulset to be ready
-	err = waitForStatefulSetReady(ctx, logger, c, ec.Name, ec.Namespace)
-	if err != nil {
-		return nil, err
-	}
-
-	// Return latest Stateful set. (This is to ensure that we return the latest statefulset for next operation to act on)
 	return getStatefulSet(ctx, c, ec.Name, ec.Namespace)
 }
 

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -60,6 +60,10 @@ func TestReconcileStatefulSet(t *testing.T) {
 	if *sts.Spec.Replicas != 3 {
 		t.Fatalf("expected 3 replicas, got %d", *sts.Spec.Replicas)
 	}
+
+	if sts.Spec.UpdateStrategy.Type != appsv1.OnDeleteStatefulSetStrategyType {
+		t.Fatalf("expected OnDelete update strategy, got %q", sts.Spec.UpdateStrategy.Type)
+	}
 }
 
 func TestWaitForStatefulSetReady(t *testing.T) {
@@ -580,6 +584,7 @@ func TestCreateOrPatchStatefulSetWithPodAnnotations(t *testing.T) {
 			} else {
 				assert.Equal(t, tt.expectedAnnotations, sts.Spec.Template.Annotations)
 			}
+			assert.Equal(t, appsv1.OnDeleteStatefulSetStrategyType, sts.Spec.UpdateStrategy.Type)
 			// Verify statefulset is controlled by EtcdCluster
 			require.Len(t, sts.OwnerReferences, 1)
 			require.Equal(t, sts.OwnerReferences[0].Name, ec.Name)
@@ -694,6 +699,7 @@ func TestCreateOrPatchStatefulSetWithPodLabels(t *testing.T) {
 			assert.NoError(t, err)
 			// Check that pod template has the expected labels
 			assert.Equal(t, tt.expectedLabels, sts.Spec.Template.Labels)
+			assert.Equal(t, appsv1.OnDeleteStatefulSetStrategyType, sts.Spec.UpdateStrategy.Type)
 			// Verify statefulset is controlled by EtcdCluster
 			require.Len(t, sts.OwnerReferences, 1)
 			require.Equal(t, sts.OwnerReferences[0].Name, ec.Name)


### PR DESCRIPTION
## What

A pure `.spec.version` change validated the upgrade path but never re-rendered the StatefulSet — the cluster silently stayed on the old image (repro test in the first commit). This PR makes version changes actually roll out, one pod at a time, gated on cluster health:

- **OnDelete update strategy.** A spec edit re-renders the pod template without restarting anything; the controller then deletes one outdated pod per reconcile, and only while every up-to-date pod is Ready, a leader exists, and every member's revision is within 90% of the leader's. The leader's pod is replaced last.
- **Outdated pods detected by controller revision**, not image string: each pod's `controller-revision-hash` label is compared against `status.updateRevision`. Image comparison broke under pod-mutating admission webhooks (digest/mirror rewrites made every pod permanently "outdated", deleting a healthy member in a loop) and missed non-image template drift, which OnDelete no longer converges on its own. The template is also re-rendered whenever the cluster generation is unobserved, so `etcdOptions`/`podTemplate`/TLS edits roll out too.
- **Pods read via an uncached API reader** (`mgr.GetAPIReader()`): the cached client's first pod Get lazily starts an informer that lists/watches all pods cluster-wide, but the operator only ever reads its own N pods by name. RBAC gains `pods get;delete` only — no list/watch.
- **Failed upgrades recover instead of wedging.** A pod replaced with a broken image (phantom patch tag, flag removed in the new minor) failed every subsequent health check, which blocked template re-rendering, made a `spec.version` rollback look like a downgrade of the never-run template tag, and left the cluster degraded at N-1 members with no spec-level way out. Upgrade-path validation now runs against `status.currentVersion` (what members actually run) so rollback is accepted; on health-check failure the template is re-synced and, while the remaining members still hold quorum, one not-Ready outdated pod is replaced so the fixed template can land. Not-Ready outdated pods are exempt from the all-Ready gate — requiring the victim Ready deadlocked its own replacement.
- `docs/upgrade.md` documents the mechanics, rollback, and the manual step needed after quorum loss.

## Files

- `internal/controller/upgrade.go` — `reconcileVersionUpgrade` (gates + victim ordering: not-Ready outdated first, then lowest ordinal, leader last), `recoverDegradedUpgrade`, `isPodOutdated`, `ordinalFromPeerEp` (`memberHealth` sorts lexically by endpoint, so slice index != ordinal once i >= 10).
- `internal/controller/utils.go` — OnDelete strategy on the StatefulSet; `syncStatefulSet` split out of `reconcileStatefulSet` so the recovery path can apply the template while pods are down, when `waitForStatefulSetReady` could never succeed.
- `internal/controller/etcdcluster_controller.go` — `PodReader` field, the upgrade call where the up-to-date branch used to no-op, the degraded-recovery hook on health-check failure, and the `status.currentVersion` preference in upgrade-path validation.
- `config/rbac/role.yaml` — regenerated via `make manifests`.

## Review

An adversarial review pass produced 3 findings, all blocking/important, each resolved in its own commit: cached-client pod reads silently starting a cluster-wide pod informer (fixed with the uncached reader), image-string outdated detection deleting healthy members in a loop under pod-mutating webhooks and missing non-image drift (fixed with controller-revision detection), and failed upgrades wedging the cluster with no spec-level rollback (fixed with the recovery path).

## Testing

- `upgrade_test.go` (envtest): re-render on version bump and on unobserved spec change; one pod deleted per reconcile; leader pod last; gates hold on a lagging member, a not-Ready or terminating pod, and a pending learner; no-op when all pods are updated; requeue on a missing pod; webhook-mutated pod image ignored; non-image template change rolls pods; not-Ready outdated pod exempt from the Ready gate and replaced; `recoverDegradedUpgrade` table (quorum lost, victim on current template, replacement in flight); `ordinalFromPeerEp` parsing including ordinals >= 10.
- `TestFetchAndValidateState` extended for rollback via `status.currentVersion`.
- Full `make test` and `make verify` pass.

## Descoped follow-ups

(1) No readiness probe on the etcd container: TLS listener flags arrive only via free-form `spec.etcdOptions` (`defaultArgs` hard-codes http, `utils.go:80-88`), so the probe scheme and client-cert requirements cannot be derived reliably; the gate uses etcd revision checks, which are stronger than pod readiness. Follow-up issue. (2) No `MoveLeader` before deleting the leader pod — the helper is absent from `origin/main` (it lives on the unmerged scale-in branch, #400); leader-last ordering is used instead, to be deduped at merge time. (3) No upgrade e2e: the harness requires kind, which this environment cannot run; a test sketch is documented instead. (4) No `Progressing` condition with `Reason=UpgradeInProgress` in `updateConditions` — cosmetic, follow-up. (5) No Warning Event when rolling a cluster without persistent storage (`r.Recorder` is wired but currently unused anywhere, and wiring events adds test surface) — documented in `docs/upgrade.md` instead. (6) Upgrades are not refused/paused for `spec.storageSpec == nil` clusters — documented caveat only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### PR series — operability fixes, TLS & EtcdMirror
<!-- pr-stack:begin -->
Small single-purpose PRs from live kind-cluster testing of the operator. Each stands alone unless an *After* is listed. → = this PR.

| | PR | Lands | After |
|---|----|-------|-------|
| | **Reviewable now — small, any order** | | |
| 🟢 | #374 | Requeue instead of swallowing the client-cert provisioning error | — |
| 🟢 | #391 | Grant `events.k8s.io` RBAC so operator Events are actually recorded | — |
| 🟢 | #392 | Correlate `members[]`/`leaderID` from one health snapshot (consistent leader) | — |
| 🟢 | #393 | Propagate user-supplied `altNames.ipAddresses` into certificates | — |
| 🟢 | #394 | Accept day-suffix `validityDuration` (`365d`, `100d12h`) as documented | — |
| 🟢 | #395 | Surface early reconcile errors as a `Degraded` condition (was empty status) | — |
| 🟢 | #379 | Configurable reconcile worker pool (`--max-concurrent-reconciles`) | — |
| 🟢 | #369 | kind-based stress/scale e2e harness (1/3/7 members, churn, quorum watcher) | — |
| 🟢 | #398 | `podTemplate.spec` scheduling fields: topologySpread, resources, priorityClass, schedulerName | — |
| 🟢 | #397 | First-class Helm chart covering the full `config/` surface | — |
| 🟢 | #399 | Quorum-aware PodDisruptionBudget per EtcdCluster | — |
| 🟢 | #400 | Scale-in removes the right member and transfers leadership first | — |
| 🟢 | #401 | Backend quota + auto-compaction spec fields, NOSPACE alarm surfacing | — |
| 🟢 | #402 | Reconcile-loop gates replace the blocking StatefulSet-ready wait | — |
| 🟢→ | #403 | Quorum-gated one-pod-at-a-time version upgrades via OnDelete | — |
| | **TLS stack — in order** | | |
| 🟢 | #376 | Independent `spec.tls.{peer,client}` surfaces (breaking alpha API) | — |
| ⚪ | #377 | `TLSReady` condition + TLS lifecycle Events | #376 |
| ⚪ | #378 | Multi-member TLS quorum e2e + `PeerCANotShared` | #377 |
| | **EtcdMirror — in order** | | |
| 🟢 | #406 | `EtcdMirror` CRD: one-way cross-cluster replication API (types + CEL) | — |
| 🟢 | #407 | `pkg/mirroragent` replication engine (fenced checkpoint-in-target) | #406 |
| 🟢 | #408 | Periodic reconciliation pass wired into the engine's steady-state loop | #407 |
| 🟢 | #412 | `mirror-agent` binary: config/TLS-reload/statusz/metrics + kind e2e | #408 |
| 🟢 | #413 | EtcdMirror controller: Deployment rendering, statusz-driven conditions, guards, fenced finalizer | #412 |
| 🟢 | #414 | CRD/sample/editor+viewer-role kustomize wiring | #413 |
| 🟢 | #415 | Controller-side phase/condition gauges, shipped PrometheusRule + dashboard | #414 |
| 🟢 | #416 | Full-lifecycle kind e2e: fence overlap, compaction+prune, restart resume, cert rotation, cutover/reversal | #415 |
| | **Parked as drafts pending #363** | | |
| ⚪ | #382 | Per-cluster domain metrics on the operator `/metrics` endpoint | — |
| ⚪ | #384 | EtcdCluster admission webhooks (consolidating with #328) | #363 |
| ⚪ | #386 | `EtcdBackup` CR → object storage (S3/GCS) | #363 |
| ⚪ | #387 | Automatic quorum-loss disaster recovery (bootstrap-latch guarded) | #363 |

🟢 ready · ⚪ draft
<!-- pr-stack:end -->