### PR TITLE
fix: healthCheck returns error if MemberList fails

### DIFF
--- a/internal/controller/pods.go
+++ b/internal/controller/pods.go
@@ -178,7 +178,7 @@ func healthCheck(clusterName, namespace string, pods []*corev1.Pod, lg klog.Logg
 
 	memberlistResp, err := etcdutils.MemberList(endpoints)
 	if err != nil {
-		return nil, nil, nil
+		return nil, nil, err
 	}
 	memberCnt := len(memberlistResp.Members)
 


### PR DESCRIPTION
MemberList may fail if DNS of headless service is not ready yet. This may cause controller to delete pod-0.

/cc @ahrtr @nwnt 