### PR TITLE
Add hashing to etcd pod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	k8s.io/apimachinery v0.36.2
 	k8s.io/client-go v0.36.2
 	k8s.io/klog/v2 v2.140.0
+	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/controller-runtime v0.24.1
 )
 
@@ -33,7 +34,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	k8s.io/streaming v0.36.2 // indirect
-	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/gateway-api v1.5.0 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect

--- a/internal/controller/etcdcluster.go
+++ b/internal/controller/etcdcluster.go
@@ -1,0 +1,30 @@
+package controller
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+
+	"k8s.io/utils/dump"
+
+	"go.etcd.io/etcd-operator/api/v1alpha1"
+)
+
+const (
+	hashLength = 12
+)
+
+func EtcdClusterHash(ec *v1alpha1.EtcdCluster) string {
+	clusterSpec := ec.DeepCopy().Spec
+	// size is not used for calculating the hash
+	clusterSpec.Size = 0
+	clusterSpec.EtcdOptions = createArgs(ec.Name, ec.Spec.EtcdOptions)
+	// we don't want to roll etcd pods when metadata is changed.
+	// instead, we'd do in-place update for them.
+	if clusterSpec.PodTemplate != nil {
+		clusterSpec.PodTemplate.Metadata = nil
+	}
+	deterministicString := dump.ForHash(clusterSpec)
+	hasher := sha256.New()
+	hasher.Write([]byte(deterministicString))
+	return hex.EncodeToString(hasher.Sum(nil))[:hashLength]
+}

--- a/internal/controller/etcdcluster_test.go
+++ b/internal/controller/etcdcluster_test.go
@@ -1,0 +1,112 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"go.etcd.io/etcd-operator/api/v1alpha1"
+)
+
+func TestEtcdClusterHash(t *testing.T) {
+	// Baseline configuration to compare mutations against
+	baseCluster := &v1alpha1.EtcdCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "prod-etcd", Namespace: "default"},
+		Spec: v1alpha1.EtcdClusterSpec{
+			Size:          3,
+			ImageRegistry: "gcr.io/etcd-development/etcd",
+			Version:       "v3.5.0",
+			EtcdOptions:   []string{"--auto-compaction-retention=1"},
+			PodTemplate: &v1alpha1.PodTemplate{
+				Metadata: &v1alpha1.PodMetadata{
+					Labels:      map[string]string{"app": "etcd"},
+					Annotations: map[string]string{"prometheus.io/scrape": "true"},
+				},
+				Spec: &v1alpha1.PodSpec{
+					NodeSelector: map[string]string{"hardware": "ssd"},
+				},
+			},
+		},
+	}
+
+	// Calculate base hash once to use as a benchmark in assertions
+	baseHash := EtcdClusterHash(baseCluster)
+
+	// Helper inline functions to generate mutated clusters cleanly
+	withSize := func(size int) *v1alpha1.EtcdCluster {
+		c := baseCluster.DeepCopy()
+		c.Spec.Size = size
+		return c
+	}
+	withMetaChanged := func() *v1alpha1.EtcdCluster {
+		c := baseCluster.DeepCopy()
+		c.Spec.PodTemplate.Metadata.Labels["canary"] = "true"
+		c.Spec.PodTemplate.Metadata.Annotations["prometheus.io/port"] = "2379"
+		return c
+	}
+	withOptionsChanged := func() *v1alpha1.EtcdCluster {
+		c := baseCluster.DeepCopy()
+		c.Spec.EtcdOptions = []string{"--auto-compaction-retention=1", "--max-txn-ops=10000"}
+		return c
+	}
+	withNilTemplate := func() *v1alpha1.EtcdCluster {
+		c := baseCluster.DeepCopy()
+		c.Spec.PodTemplate = nil
+		return c
+	}
+
+	// Define our table-driven test cases
+	tests := []struct {
+		name         string
+		cluster      *v1alpha1.EtcdCluster
+		expectEqual  bool
+		expectedHash string // Used when checking explicit values, like base or exact match
+		checkLength  bool
+	}{
+		{
+			name:        "Deterministic - Identical configuration must return the identical hash",
+			cluster:     baseCluster.DeepCopy(),
+			expectEqual: true,
+			checkLength: true,
+		},
+		{
+			name:        "Size Bypass - Scaling the cluster size must NOT change the hash",
+			cluster:     withSize(9),
+			expectEqual: true,
+		},
+		{
+			name:        "Metadata Bypass - Modifying pod metadata must NOT change the hash",
+			cluster:     withMetaChanged(),
+			expectEqual: true,
+		},
+		{
+			name:        "Core Spec Change - Modifying EtcdOptions must force a brand new hash",
+			cluster:     withOptionsChanged(),
+			expectEqual: false,
+		},
+		{
+			name:        "Nil Guard Check - A missing PodTemplate must not panic and must hash cleanly",
+			cluster:     withNilTemplate(),
+			expectEqual: false,
+			checkLength: true,
+		},
+	}
+
+	// Loop through the table executing each row in isolation
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			currentHash := EtcdClusterHash(tt.cluster)
+
+			if tt.checkLength {
+				assert.Len(t, currentHash, hashLength, "Hash must respect the %d-character limit constraint", hashLength)
+			}
+
+			if tt.expectEqual {
+				assert.Equal(t, baseHash, currentHash, "Hash should be identical to the baseline reference hash")
+			} else {
+				assert.NotEqual(t, baseHash, currentHash, "Hash should have changed compared to the baseline reference hash")
+			}
+		})
+	}
+}

--- a/internal/controller/pods.go
+++ b/internal/controller/pods.go
@@ -218,6 +218,10 @@ func defaultArgs(name string) []string {
 	}
 }
 
+const (
+	HashMetadataKey = "operator.etcd.io/spec-hash"
+)
+
 // buildMemberPod constructs the Pod object for a single etcd member.
 func buildMemberPod(ec *ecv1alpha1.EtcdCluster, podName string, initialClusterState etcdClusterState, initialCluster string) *corev1.Pod {
 	// Start with custom labels then overwrite with the mandatory defaults so
@@ -228,12 +232,13 @@ func buildMemberPod(ec *ecv1alpha1.EtcdCluster, podName string, initialClusterSt
 	}
 	maps.Copy(labels, etcdClusterLabels(ec))
 
-	// Annotations are purely from the PodTemplate; nil when not provided.
-	var annotations map[string]string
+	// Apply annotations from EtcdCluster and add additional annnotations required by etcd operator
+	annotations := make(map[string]string)
 	if ec.Spec.PodTemplate != nil && ec.Spec.PodTemplate.Metadata != nil &&
 		len(ec.Spec.PodTemplate.Metadata.Annotations) > 0 {
-		annotations = ec.Spec.PodTemplate.Metadata.Annotations
+		maps.Copy(annotations, ec.Spec.PodTemplate.Metadata.Annotations)
 	}
+	annotations[HashMetadataKey] = EtcdClusterHash(ec)
 
 	envVars := []corev1.EnvVar{
 		{

--- a/internal/controller/pods_test.go
+++ b/internal/controller/pods_test.go
@@ -307,12 +307,19 @@ func TestCreateMemberPodWithAnnotations(t *testing.T) {
 	_ = corev1.AddToScheme(scheme)
 	_ = ecv1alpha1.AddToScheme(scheme)
 
+	cluster := &ecv1alpha1.EtcdCluster{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", UID: "1"},
+		Spec: ecv1alpha1.EtcdClusterSpec{
+			Size:    3,
+			Version: "3.5.17",
+		},
+	}
+
 	tests := []struct {
 		name                string
 		clusterName         string
 		podTemplate         *ecv1alpha1.PodTemplate
 		expectedAnnotations map[string]string
-		expectNil           bool
 	}{
 		{
 			name:        "creates pod with custom annotations",
@@ -329,13 +336,11 @@ func TestCreateMemberPodWithAnnotations(t *testing.T) {
 				"prometheus.io/scrape": "true",
 				"prometheus.io/port":   "2379",
 			},
-			expectNil: false,
 		},
 		{
 			name:        "creates pod without annotations when PodTemplate is nil",
 			clusterName: "test-etcd-no-podtemplate",
 			podTemplate: nil,
-			expectNil:   true,
 		},
 		{
 			name:        "creates pod without annotations when annotations map is empty",
@@ -345,20 +350,15 @@ func TestCreateMemberPodWithAnnotations(t *testing.T) {
 					Annotations: map[string]string{},
 				},
 			},
-			expectNil: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ec := &ecv1alpha1.EtcdCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: tt.clusterName, Namespace: "default", UID: "1"},
-				Spec: ecv1alpha1.EtcdClusterSpec{
-					Size:        3,
-					Version:     "3.5.17",
-					PodTemplate: tt.podTemplate,
-				},
-			}
+			ec := cluster.DeepCopy()
+			ec.Name = tt.clusterName
+			ec.Spec.PodTemplate = tt.podTemplate
+
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec).Build()
 
 			err := createMemberPod(ctx, logger, fakeClient, ec, 0, scheme)
@@ -367,13 +367,15 @@ func TestCreateMemberPodWithAnnotations(t *testing.T) {
 			pod := &corev1.Pod{}
 			require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: tt.clusterName + "-0", Namespace: "default"}, pod))
 
-			if tt.expectNil {
-				assert.Nil(t, pod.Annotations)
-			} else {
-				assert.Equal(t, tt.expectedAnnotations, pod.Annotations)
-			}
 			require.Len(t, pod.OwnerReferences, 1)
 			assert.Equal(t, ec.Name, pod.OwnerReferences[0].Name)
+
+			// the operator can insert more annotations, but we can guarantee that the expected KVs would be there
+			for k, v := range tt.expectedAnnotations {
+				value, ok := pod.Annotations[k]
+				assert.True(t, ok, "the annotaion entry with key %s and value %s doesn't exist in the pod", k, v)
+				assert.Equal(t, v, value, "mismatch value for key %s: want %s, got %s", k, v, value)
+			}
 		})
 	}
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -27,6 +27,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 	"sigs.k8s.io/e2e-framework/klient/wait"
@@ -35,6 +36,7 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
 	ecv1alpha1 "go.etcd.io/etcd-operator/api/v1alpha1"
+	"go.etcd.io/etcd-operator/internal/controller"
 )
 
 var etcdVersion = os.Getenv("ETCD_VERSION")
@@ -411,5 +413,77 @@ func TestEtcdClusterFunctionality(t *testing.T) {
 		return ctx
 	})
 
+	_ = testEnv.Test(t, feature.Feature())
+}
+
+func TestClusterHash(t *testing.T) {
+	feature := features.New("data-persistence")
+
+	const etcdClusterName = "etcd-hash"
+	const size = 3
+
+	etcdCluster := &ecv1alpha1.EtcdCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "operator.etcd.io/v1alpha1",
+			Kind:       "EtcdCluster",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      etcdClusterName,
+			Namespace: namespace,
+		},
+		Spec: ecv1alpha1.EtcdClusterSpec{
+			Size:    size,
+			Version: "v3.5.18",
+			StorageSpec: &ecv1alpha1.StorageSpec{
+				AccessModes:       corev1.ReadWriteOnce,
+				StorageClassName:  "standard",
+				PVCName:           "test-pvc",
+				VolumeSizeRequest: resource.MustParse("64Mi"),
+				VolumeSizeLimit:   resource.MustParse("64Mi"),
+			},
+		},
+	}
+
+	clusterHash := controller.EtcdClusterHash(etcdCluster)
+
+	feature.Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+		client := cfg.Client()
+
+		// create the etcd cluster
+		if err := client.Resources().Create(ctx, etcdCluster); err != nil {
+			t.Fatalf("unable to create etcd cluster: %s", err)
+		}
+
+		// get the etcd cluster object
+		var ec ecv1alpha1.EtcdCluster
+		if err := client.Resources().Get(ctx, etcdClusterName, namespace, &ec); err != nil {
+			t.Fatalf("unable to fetch etcd cluster: %s", err)
+		}
+
+		return ctx
+	})
+
+	feature.Assess("verify all Pods have the etcd-cluster hash annotation",
+		func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+			var pods corev1.PodList
+			if err := c.Client().Resources().List(
+				ctx,
+				&pods,
+				resources.WithLabelSelector(fmt.Sprintf("app=%s", etcdClusterName))); err != nil {
+				t.Fatalf("unable to retrieve the member pods with labels %s and annotation %s", "fix", "me")
+			}
+
+			for _, pod := range pods.Items {
+				podAnnotation, ok := pod.Annotations[controller.HashMetadataKey]
+				if !ok {
+					t.Errorf("pod %s does not have its cluster hash: annotations: %v", pod.Name, pod.Annotations)
+				}
+				if podAnnotation != clusterHash {
+					t.Errorf("pod %s has a mismatched cluster hash: want %s, got %s: pod annotations: %v",
+						pod.Name, clusterHash, podAnnotation, pod.Annotations)
+				}
+			}
+			return ctx
+		})
 	_ = testEnv.Test(t, feature.Feature())
 }


### PR DESCRIPTION
Ref: #411

The original migration PR doesn't implement the drift detection like the StatefulSets controlller does.  This is needed so that each reconciliation loop can then observe the drift and act accordingly by rolling the pods.

Remaining items to be implemented (likely in separate PRs):
  - Controller to update the pod metadata if the metadata drift is detected.  The pod metadata drift should not require a pod reroll.
  - Implement controller logic to roll the etcd member pods when a drift is detected based on the calculated hash.

cc @ahrtr @silentred 