### PR TITLE
Exclude etcd version from spec hash calculation

### DIFF
--- a/internal/controller/etcdcluster.go
+++ b/internal/controller/etcdcluster.go
@@ -17,6 +17,8 @@ func EtcdClusterHash(ec *v1alpha1.EtcdCluster) string {
 	clusterSpec := ec.DeepCopy().Spec
 	// size is not used for calculating the hash
 	clusterSpec.Size = 0
+	// version is handled separately
+	clusterSpec.Version = ""
 	clusterSpec.EtcdOptions = createArgs(ec.Name, ec.Spec.EtcdOptions)
 	// we don't want to roll etcd pods when metadata is changed.
 	// instead, we'd do in-place update for them.

--- a/internal/controller/etcdcluster_test.go
+++ b/internal/controller/etcdcluster_test.go
@@ -55,6 +55,11 @@ func TestEtcdClusterHash(t *testing.T) {
 		c.Spec.PodTemplate = nil
 		return c
 	}
+	withVersionChanged := func() *v1alpha1.EtcdCluster {
+		c := baseCluster.DeepCopy()
+		c.Spec.Version = "v8.8.8"
+		return c
+	}
 
 	// Define our table-driven test cases
 	tests := []struct {
@@ -90,6 +95,11 @@ func TestEtcdClusterHash(t *testing.T) {
 			cluster:     withNilTemplate(),
 			expectEqual: false,
 			checkLength: true,
+		},
+		{
+			name:        "Version check - Modifying etcd version must NOT change the hash",
+			cluster:     withVersionChanged(),
+			expectEqual: true,
 		},
 	}
 


### PR DESCRIPTION
Addressing this comment from the hash calculation PR https://github.com/etcd-io/etcd-operator/pull/422#discussion_r3580434361

cc @ahrtr 