### PR TITLE
fix(tls): support auto and cert-manager TLS configs for customized controller

### DIFF
--- a/config/samples/sample_autocert_etcdcluster.yaml
+++ b/config/samples/sample_autocert_etcdcluster.yaml
@@ -13,4 +13,4 @@ spec:
     providerCfg:
       autoCfg:
         commonName: "etcd-operator-system"
-        validityDuration: 365d
+        validityDuration: 8760h

--- a/config/samples/sample_certmanager_etcdcluster.yaml
+++ b/config/samples/sample_certmanager_etcdcluster.yaml
@@ -22,6 +22,6 @@ spec:
     providerCfg:
       certManagerCfg:
         commonName: "etcd-operator-system"
-        validityDuration: "365d"
+        validityDuration: "8760h"
         issuerKind: "ClusterIssuer"
         issuerName: "selfsigned"

--- a/internal/controller/etcdcluster.go
+++ b/internal/controller/etcdcluster.go
@@ -19,7 +19,7 @@ func EtcdClusterHash(ec *v1alpha1.EtcdCluster) string {
 	clusterSpec.Size = 0
 	// version is handled separately
 	clusterSpec.Version = ""
-	clusterSpec.EtcdOptions = createArgs(ec.Name, ec.Spec.EtcdOptions)
+	clusterSpec.EtcdOptions = createArgs(ec.Name, ec.Spec.EtcdOptions, clusterTLSEnabled(ec))
 	// we don't want to roll etcd pods when metadata is changed.
 	// instead, we'd do in-place update for them.
 	if clusterSpec.PodTemplate != nil {

--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"strings"
 	"time"
@@ -57,6 +58,8 @@ type reconcileState struct {
 	pods           []*corev1.Pod                // member pods owned by this cluster, sorted by ordinal
 	memberListResp *clientv3.MemberListResponse // member list fetched from the etcd cluster
 	memberHealth   []etcdutils.EpHealth         // health information for each etcd member
+	clientTLS      *tls.Config                  // operator's client TLS config (nil when cluster has no TLS)
+	clientOpts     []etcdutils.Option           // pre-built etcd client options for this loop (e.g. TLS config)
 }
 
 // +kubebuilder:rbac:groups=operator.etcd.io,resources=etcdclusters,verbs=get;list;watch;create;update;patch;delete
@@ -131,12 +134,28 @@ func (r *EtcdClusterReconciler) fetchAndValidateState(ctx context.Context, req c
 		))
 	}
 
+	// Build the operator's etcd-client TLS config (from the server cert Secret)
+	clientTLS, tlsErr := r.buildReconcileClientTLS(ctx, ec)
+	if tlsErr != nil && ec.Spec.TLS != nil {
+		logger.Error(tlsErr, "Failed to build client TLS config; will retry next reconcile")
+	}
+
 	logger.Info("Reconciling EtcdCluster", "spec", ec.Spec)
 
 	pods, err := listOwnedPods(ctx, r.Client, ec)
 	if err != nil {
 		logger.Error(err, "Failed to list pods. Requesting requeue")
 		return nil, ctrl.Result{RequeueAfter: requeueDuration}, nil
+	}
+
+	// Attach the per-reconcile TLS config to every returned state. When TLS is
+	// unused the options slice stays nil.
+	stateWithTLS := func(pods []*corev1.Pod) *reconcileState {
+		s := &reconcileState{cluster: ec, pods: pods, clientTLS: clientTLS}
+		if s.clientTLS != nil {
+			s.clientOpts = []etcdutils.Option{etcdutils.WithTLS(s.clientTLS)}
+		}
+		return s
 	}
 
 	// Validate the upgrade path using the image tag of the first pod.
@@ -149,7 +168,7 @@ func (r *EtcdClusterReconciler) fetchAndValidateState(ctx context.Context, req c
 			if idx == -1 {
 				logger.Info("could not extract image version from pod image",
 					"image", c.Image)
-				return &reconcileState{cluster: ec, pods: pods}, ctrl.Result{}, nil
+				return stateWithTLS(pods), ctrl.Result{}, nil
 			}
 			currentVersion := c.Image[idx+1:]
 			targetVersion := ec.Spec.Version
@@ -163,7 +182,7 @@ func (r *EtcdClusterReconciler) fetchAndValidateState(ctx context.Context, req c
 						"target", targetVersion,
 						"error", err,
 					)
-					return &reconcileState{cluster: ec, pods: pods}, ctrl.Result{}, nil
+					return stateWithTLS(pods), ctrl.Result{}, nil
 				}
 				if err != nil {
 					logger.Error(err, "unsupported upgrade path between current and target versions",
@@ -180,7 +199,17 @@ func (r *EtcdClusterReconciler) fetchAndValidateState(ctx context.Context, req c
 		}
 	}
 
-	return &reconcileState{cluster: ec, pods: pods}, ctrl.Result{}, nil
+	return stateWithTLS(pods), ctrl.Result{}, nil
+}
+
+// buildReconcileClientTLS builds the operator's etcd-client TLS Config for a
+// reconcile loop from the cluster's server certificate Secret. Returns a nil
+// config (and nil error) when the cluster has no TLS configured.
+func (r *EtcdClusterReconciler) buildReconcileClientTLS(ctx context.Context, ec *ecv1alpha1.EtcdCluster) (*tls.Config, error) {
+	if ec.Spec.TLS == nil {
+		return nil, nil
+	}
+	return buildClientTLSConfig(ctx, ec, r.Client)
 }
 
 // bootstrapCluster ensures the headless Service exists and, when no pods are
@@ -211,7 +240,7 @@ func (r *EtcdClusterReconciler) performHealthChecks(ctx context.Context, s *reco
 	logger := log.FromContext(ctx)
 	logger.Info("Now checking health of the cluster members")
 	var err error
-	s.memberListResp, s.memberHealth, err = healthCheck(s.cluster.Name, s.cluster.Namespace, s.pods, logger)
+	s.memberListResp, s.memberHealth, err = healthCheck(s.cluster.Name, s.cluster.Namespace, s.pods, clusterTLSEnabled(s.cluster), s.clientOpts, logger)
 	if err != nil {
 		return fmt.Errorf("health check failed: %w", err)
 	}
@@ -275,10 +304,10 @@ func (r *EtcdClusterReconciler) reconcileClusterState(ctx context.Context, s *re
 			logger.Info("Learner found", "learnerID", learner, "learnerStatus", learnerStatus)
 			if etcdutils.IsLearnerReady(leaderStatus, learnerStatus) {
 				logger.Info("Learner is ready to be promoted to voting member", "learnerID", learner)
-				eps := clientEndpointsFromPods(s.cluster.Name, s.cluster.Namespace, s.pods)
+				eps := clientEndpointsFromPods(s.cluster.Name, s.cluster.Namespace, s.pods, clusterTLSEnabled(s.cluster))
 				// Exclude the learner (last ordinal) from the endpoint list used for promotion.
 				eps = eps[:(len(eps) - 1)]
-				if err := etcdutils.PromoteLearner(eps, learner); err != nil {
+				if err := etcdutils.PromoteLearner(eps, learner, s.clientOpts...); err != nil {
 					return ctrl.Result{}, err
 				}
 			} else {
@@ -293,14 +322,14 @@ func (r *EtcdClusterReconciler) reconcileClusterState(ctx context.Context, s *re
 		return ctrl.Result{}, nil
 	}
 
-	eps := clientEndpointsFromPods(s.cluster.Name, s.cluster.Namespace, s.pods)
+	eps := clientEndpointsFromPods(s.cluster.Name, s.cluster.Namespace, s.pods, clusterTLSEnabled(s.cluster))
 
 	if currentPodCount < int32(s.cluster.Spec.Size) {
 		// Scale out: add a new learner member to etcd, then create its pod.
 		nextOrdinal := int(currentPodCount)
 		_, peerURL := peerEndpointForOrdinalIndex(s.cluster, nextOrdinal)
 		logger.Info("[Scale out] adding a new learner member to etcd cluster", "peerURL", peerURL)
-		if _, err := etcdutils.AddMember(eps, []string{peerURL}, true); err != nil {
+		if _, err := etcdutils.AddMember(eps, []string{peerURL}, true, s.clientOpts...); err != nil {
 			return ctrl.Result{}, err
 		}
 		logger.Info("Learner member added successfully", "peerURL", peerURL)
@@ -320,7 +349,7 @@ func (r *EtcdClusterReconciler) reconcileClusterState(ctx context.Context, s *re
 		logger.Info("[Scale in] removing one member", "memberID", memberID, "pod", podToRemove.Name)
 
 		epsForRemoval := eps[:len(eps)-1]
-		if err := etcdutils.RemoveMember(epsForRemoval, memberID); err != nil {
+		if err := etcdutils.RemoveMember(epsForRemoval, memberID, s.clientOpts...); err != nil {
 			return ctrl.Result{}, err
 		}
 

--- a/internal/controller/pods.go
+++ b/internal/controller/pods.go
@@ -136,23 +136,39 @@ func waitForPodReady(ctx context.Context, logger logr.Logger, c client.Client, p
 // clientEndpointsFromPods builds the client endpoint URL for every pod in the
 // slice, in the same order.  The DNS form is:
 //
-//	http://{podName}.{clusterName}.{namespace}.svc.cluster.local:2379
-func clientEndpointsFromPods(clusterName, namespace string, pods []*corev1.Pod) []string {
+//	{scheme}://{podName}.{clusterName}.{namespace}.svc.cluster.local:2379
+//
+// where scheme reflects the cluster's TLS configuration.
+func clientEndpointsFromPods(clusterName, namespace string, pods []*corev1.Pod, tlsEnabled bool) []string {
 	if len(pods) == 0 {
 		return nil
 	}
 	eps := make([]string, 0, len(pods))
 	for _, pod := range pods {
-		eps = append(eps, clientEndpointForOrdinal(clusterName, namespace, podOrdinal(pod.Name, clusterName)))
+		eps = append(eps, clientEndpointForOrdinal(clusterName, namespace, podOrdinal(pod.Name, clusterName), tlsEnabled))
 	}
 	return eps
 }
 
 // clientEndpointForOrdinal returns the client endpoint URL for a member at the
-// given ordinal index.
-func clientEndpointForOrdinal(clusterName, namespace string, ordinal int) string {
-	return fmt.Sprintf("http://%s-%d.%s.%s.svc.cluster.local:2379",
-		clusterName, ordinal, clusterName, namespace)
+// given ordinal index. The URL scheme is https when tlsEnabled is true, otherwise http.
+func clientEndpointForOrdinal(clusterName, namespace string, ordinal int, tlsEnabled bool) string {
+	return fmt.Sprintf("%s://%s-%d.%s.%s.svc.cluster.local:2379",
+		clusterScheme(tlsEnabled), clusterName, ordinal, clusterName, namespace)
+}
+
+// clusterScheme returns the URL scheme to use for cluster endpoints: "https"
+// when TLS is enabled, "http" otherwise.
+func clusterScheme(tlsEnabled bool) string {
+	if tlsEnabled {
+		return "https"
+	}
+	return "http"
+}
+
+// clusterTLSEnabled reports whether the given cluster has TLS configured.
+func clusterTLSEnabled(ec *ecv1alpha1.EtcdCluster) bool {
+	return ec != nil && ec.Spec.TLS != nil
 }
 
 // areAllMembersHealthy returns true when every entry in the supplied health
@@ -169,14 +185,14 @@ func areAllMembersHealthy(memberHealth []etcdutils.EpHealth) bool {
 
 // healthCheck returns a MemberListResponse and per-endpoint health information
 // for the etcd cluster reachable through the given pods.
-func healthCheck(clusterName, namespace string, pods []*corev1.Pod, lg klog.Logger) (*clientv3.MemberListResponse, []etcdutils.EpHealth, error) {
+func healthCheck(clusterName, namespace string, pods []*corev1.Pod, tlsEnabled bool, clientOpts []etcdutils.Option, lg klog.Logger) (*clientv3.MemberListResponse, []etcdutils.EpHealth, error) {
 	if len(pods) == 0 {
 		return nil, nil, nil
 	}
 
-	endpoints := clientEndpointsFromPods(clusterName, namespace, pods)
+	endpoints := clientEndpointsFromPods(clusterName, namespace, pods, tlsEnabled)
 
-	memberlistResp, err := etcdutils.MemberList(endpoints)
+	memberlistResp, err := etcdutils.MemberList(endpoints, clientOpts...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -188,7 +204,7 @@ func healthCheck(clusterName, namespace string, pods []*corev1.Pod, lg klog.Logg
 	lg.Info("health checking", "podCount", len(pods), "len(members)", memberCnt)
 	endpoints = endpoints[:cnt]
 
-	healthInfos, err := etcdutils.ClusterHealth(endpoints)
+	healthInfos, err := etcdutils.ClusterHealth(endpoints, clientOpts...)
 	if err != nil {
 		return memberlistResp, nil, err
 	}
@@ -208,14 +224,44 @@ func healthCheck(clusterName, namespace string, pods []*corev1.Pod, lg klog.Logg
 // etcd argument helpers
 // ---------------------------------------------------------------------------
 
-func defaultArgs(name string) []string {
-	return []string{
+// etcd TLS cert/CA/key file paths mounted from the certificate Secret volumes.
+// These mirror the VolumeMount paths declared in buildMemberPod.
+const (
+	serverCertMountDir = "/etc/etcd-certs/server"
+	peerCertMountDir   = "/etc/etcd-certs/peer"
+
+	serverCertFile      = serverCertMountDir + "/tls.crt"
+	serverKeyFile       = serverCertMountDir + "/tls.key"
+	serverTrustedCAFile = serverCertMountDir + "/ca.crt"
+
+	peerCertFile      = peerCertMountDir + "/tls.crt"
+	peerKeyFile       = peerCertMountDir + "/tls.key"
+	peerTrustedCAFile = peerCertMountDir + "/ca.crt"
+)
+
+func defaultArgs(name string, tlsEnabled bool) []string {
+	scheme := clusterScheme(tlsEnabled)
+	args := make([]string, 0, 13)
+	args = append(args,
 		"--name=$(POD_NAME)",
-		"--listen-peer-urls=http://0.0.0.0:2380",
-		"--listen-client-urls=http://0.0.0.0:2379",
-		fmt.Sprintf("--initial-advertise-peer-urls=http://$(POD_NAME).%s.$(POD_NAMESPACE).svc.cluster.local:2380", name),
-		fmt.Sprintf("--advertise-client-urls=http://$(POD_NAME).%s.$(POD_NAMESPACE).svc.cluster.local:2379", name),
+		fmt.Sprintf("--listen-peer-urls=%s://0.0.0.0:2380", scheme),
+		fmt.Sprintf("--listen-client-urls=%s://0.0.0.0:2379", scheme),
+		fmt.Sprintf("--initial-advertise-peer-urls=%s://$(POD_NAME).%s.$(POD_NAMESPACE).svc.cluster.local:2380", scheme, name),
+		fmt.Sprintf("--advertise-client-urls=%s://$(POD_NAME).%s.$(POD_NAMESPACE).svc.cluster.local:2379", scheme, name),
+	)
+	if !tlsEnabled {
+		return args
 	}
+	return append(args,
+		"--cert-file="+serverCertFile,
+		"--key-file="+serverKeyFile,
+		"--trusted-ca-file="+serverTrustedCAFile,
+		"--client-cert-auth=true",
+		"--peer-cert-file="+peerCertFile,
+		"--peer-key-file="+peerKeyFile,
+		"--peer-trusted-ca-file="+peerTrustedCAFile,
+		"--peer-client-cert-auth=true",
+	)
 }
 
 const (
@@ -262,7 +308,7 @@ func buildMemberPod(ec *ecv1alpha1.EtcdCluster, podName string, initialClusterSt
 		Name:    "etcd",
 		Image:   fmt.Sprintf("%s:%s", ec.Spec.ImageRegistry, ec.Spec.Version),
 		Command: []string{"/usr/local/bin/etcd"},
-		Args:    createArgs(ec.Name, ec.Spec.EtcdOptions),
+		Args:    createArgs(ec.Name, ec.Spec.EtcdOptions, clusterTLSEnabled(ec)),
 		Env:     envVars,
 		Ports: []corev1.ContainerPort{
 			{Name: "client", ContainerPort: 2379},
@@ -313,7 +359,8 @@ func buildMemberPod(ec *ecv1alpha1.EtcdCluster, podName string, initialClusterSt
 		}
 	}
 
-	// TLS certificate volumes (mounted as secrets).
+	// setup TLS certificate volumes. Both the pod Volume and VolumeMount are
+	// declared together so the etcd TLS args file paths resolve at runtime.
 	if ec.Spec.TLS != nil {
 		podSpec.Volumes = append(podSpec.Volumes,
 			corev1.Volume{
@@ -327,6 +374,20 @@ func buildMemberPod(ec *ecv1alpha1.EtcdCluster, podName string, initialClusterSt
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{SecretName: getPeerCertName(ec.Name)},
 				},
+			},
+		)
+
+		etcdContainer := &podSpec.Containers[0]
+		etcdContainer.VolumeMounts = append(etcdContainer.VolumeMounts,
+			corev1.VolumeMount{
+				Name:      "server-secret",
+				MountPath: serverCertMountDir,
+				ReadOnly:  true,
+			},
+			corev1.VolumeMount{
+				Name:      "peer-secret",
+				MountPath: peerCertMountDir,
+				ReadOnly:  true,
 			},
 		)
 	}

--- a/internal/controller/pods_test.go
+++ b/internal/controller/pods_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -487,6 +488,7 @@ func TestCreatingArgs(t *testing.T) {
 		testName       string
 		etcdOptions    []string
 		clusterName    string
+		tlsEnabled     bool
 		expectedResult []string
 	}{
 		{
@@ -499,6 +501,27 @@ func TestCreatingArgs(t *testing.T) {
 				"--listen-client-urls=http://0.0.0.0:2379",
 				"--initial-advertise-peer-urls=http://$(POD_NAME).testCluster.$(POD_NAMESPACE).svc.cluster.local:2380",
 				"--advertise-client-urls=http://$(POD_NAME).testCluster.$(POD_NAMESPACE).svc.cluster.local:2379",
+			},
+		},
+		{
+			testName:    "TLS enabled adds TLS args and https schemes",
+			etcdOptions: nil,
+			clusterName: "testCluster",
+			tlsEnabled:  true,
+			expectedResult: []string{
+				"--name=$(POD_NAME)",
+				"--listen-peer-urls=https://0.0.0.0:2380",
+				"--listen-client-urls=https://0.0.0.0:2379",
+				"--initial-advertise-peer-urls=https://$(POD_NAME).testCluster.$(POD_NAMESPACE).svc.cluster.local:2380",
+				"--advertise-client-urls=https://$(POD_NAME).testCluster.$(POD_NAMESPACE).svc.cluster.local:2379",
+				"--cert-file=" + serverCertFile,
+				"--key-file=" + serverKeyFile,
+				"--trusted-ca-file=" + serverTrustedCAFile,
+				"--client-cert-auth=true",
+				"--peer-cert-file=" + peerCertFile,
+				"--peer-key-file=" + peerKeyFile,
+				"--peer-trusted-ca-file=" + peerTrustedCAFile,
+				"--peer-client-cert-auth=true",
 			},
 		},
 		{
@@ -516,6 +539,30 @@ func TestCreatingArgs(t *testing.T) {
 				"--advertise-client-urls=http://$(POD_NAME).testCluster.$(POD_NAMESPACE).svc.cluster.local:2379",
 				"--max-wals=7",
 				"--discovery-failbox=proxy",
+			},
+		},
+		{
+			testName: "TLS enabled with custom etcdOptions",
+			etcdOptions: []string{
+				"--max-wals=7",
+			},
+			clusterName: "testCluster",
+			tlsEnabled:  true,
+			expectedResult: []string{
+				"--name=$(POD_NAME)",
+				"--listen-peer-urls=https://0.0.0.0:2380",
+				"--listen-client-urls=https://0.0.0.0:2379",
+				"--initial-advertise-peer-urls=https://$(POD_NAME).testCluster.$(POD_NAMESPACE).svc.cluster.local:2380",
+				"--advertise-client-urls=https://$(POD_NAME).testCluster.$(POD_NAMESPACE).svc.cluster.local:2379",
+				"--cert-file=" + serverCertFile,
+				"--key-file=" + serverKeyFile,
+				"--trusted-ca-file=" + serverTrustedCAFile,
+				"--client-cert-auth=true",
+				"--peer-cert-file=" + peerCertFile,
+				"--peer-key-file=" + peerKeyFile,
+				"--peer-trusted-ca-file=" + peerTrustedCAFile,
+				"--peer-client-cert-auth=true",
+				"--max-wals=7",
 			},
 		},
 		{
@@ -566,11 +613,34 @@ func TestCreatingArgs(t *testing.T) {
 				"--experimental-peer-skip-client-san-verification",
 			},
 		},
+		{
+			testName: "TLS overwrite default TLS arg",
+			etcdOptions: []string{
+				"--cert-file=/custom/cert-path",
+			},
+			clusterName: "testCluster",
+			tlsEnabled:  true,
+			expectedResult: []string{
+				"--name=$(POD_NAME)",
+				"--listen-peer-urls=https://0.0.0.0:2380",
+				"--listen-client-urls=https://0.0.0.0:2379",
+				"--initial-advertise-peer-urls=https://$(POD_NAME).testCluster.$(POD_NAMESPACE).svc.cluster.local:2380",
+				"--advertise-client-urls=https://$(POD_NAME).testCluster.$(POD_NAMESPACE).svc.cluster.local:2379",
+				"--key-file=" + serverKeyFile,
+				"--trusted-ca-file=" + serverTrustedCAFile,
+				"--client-cert-auth=true",
+				"--peer-cert-file=" + peerCertFile,
+				"--peer-key-file=" + peerKeyFile,
+				"--peer-trusted-ca-file=" + peerTrustedCAFile,
+				"--peer-client-cert-auth=true",
+				"--cert-file=/custom/cert-path",
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
-			result := createArgs(tt.clusterName, tt.etcdOptions)
+			result := createArgs(tt.clusterName, tt.etcdOptions, tt.tlsEnabled)
 			assert.Equal(t, tt.expectedResult, result)
 		})
 	}
@@ -582,17 +652,22 @@ func TestCreatingArgs(t *testing.T) {
 
 func TestClientEndpointForOrdinal(t *testing.T) {
 	tests := []struct {
-		ordinal  int
-		expected string
+		name       string
+		ordinal    int
+		tlsEnabled bool
+		expected   string
 	}{
-		{0, "http://test-cluster-0.test-cluster.default.svc.cluster.local:2379"},
-		{1, "http://test-cluster-1.test-cluster.default.svc.cluster.local:2379"},
-		{2, "http://test-cluster-2.test-cluster.default.svc.cluster.local:2379"},
+		{name: "ordinal 0 no TLS", ordinal: 0, tlsEnabled: false, expected: "http://test-cluster-0.test-cluster.default.svc.cluster.local:2379"},
+		{name: "ordinal 1 no TLS", ordinal: 1, tlsEnabled: false, expected: "http://test-cluster-1.test-cluster.default.svc.cluster.local:2379"},
+		{name: "ordinal 2 no TLS", ordinal: 2, tlsEnabled: false, expected: "http://test-cluster-2.test-cluster.default.svc.cluster.local:2379"},
+		{name: "ordinal 0 with TLS", ordinal: 0, tlsEnabled: true, expected: "https://test-cluster-0.test-cluster.default.svc.cluster.local:2379"},
+		{name: "ordinal 1 with TLS", ordinal: 1, tlsEnabled: true, expected: "https://test-cluster-1.test-cluster.default.svc.cluster.local:2379"},
+		{name: "ordinal 2 with TLS", ordinal: 2, tlsEnabled: true, expected: "https://test-cluster-2.test-cluster.default.svc.cluster.local:2379"},
 	}
 
 	for _, tt := range tests {
-		t.Run(fmt.Sprintf("ordinal %d", tt.ordinal), func(t *testing.T) {
-			result := clientEndpointForOrdinal("test-cluster", "default", tt.ordinal)
+		t.Run(tt.name, func(t *testing.T) {
+			result := clientEndpointForOrdinal("test-cluster", "default", tt.ordinal, tt.tlsEnabled)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -608,18 +683,22 @@ func TestClientEndpointsFromPods(t *testing.T) {
 		}
 	}
 
+	threePods := []*corev1.Pod{
+		makePod("test-sts", "default", 0),
+		makePod("test-sts", "default", 1),
+		makePod("test-sts", "default", 2),
+	}
+
 	tests := []struct {
-		name     string
-		pods     []*corev1.Pod
-		expected []string
+		name       string
+		pods       []*corev1.Pod
+		tlsEnabled bool
+		expected   []string
 	}{
 		{
-			name: "3 pods",
-			pods: []*corev1.Pod{
-				makePod("test-sts", "default", 0),
-				makePod("test-sts", "default", 1),
-				makePod("test-sts", "default", 2),
-			},
+			name:       "3 pods no TLS",
+			pods:       threePods,
+			tlsEnabled: false,
 			expected: []string{
 				"http://test-sts-0.test-sts.default.svc.cluster.local:2379",
 				"http://test-sts-1.test-sts.default.svc.cluster.local:2379",
@@ -627,15 +706,26 @@ func TestClientEndpointsFromPods(t *testing.T) {
 			},
 		},
 		{
-			name:     "no pods",
-			pods:     nil,
-			expected: []string(nil),
+			name:       "3 pods with TLS",
+			pods:       threePods,
+			tlsEnabled: true,
+			expected: []string{
+				"https://test-sts-0.test-sts.default.svc.cluster.local:2379",
+				"https://test-sts-1.test-sts.default.svc.cluster.local:2379",
+				"https://test-sts-2.test-sts.default.svc.cluster.local:2379",
+			},
+		},
+		{
+			name:       "no pods",
+			pods:       nil,
+			tlsEnabled: false,
+			expected:   []string(nil),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := clientEndpointsFromPods("test-sts", "default", tt.pods)
+			result := clientEndpointsFromPods("test-sts", "default", tt.pods, tt.tlsEnabled)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -705,4 +795,71 @@ func TestNextOrdinal(t *testing.T) {
 			assert.Equal(t, tt.want, got, "nextOrdinal(%v, %d) should return %d", tt.list, tt.expectedReplica, tt.want)
 		})
 	}
+}
+
+func TestBuildMemberPodTLSVolumes(t *testing.T) {
+	mkCluster := func(tls *ecv1alpha1.TLSCertificate, storage *ecv1alpha1.StorageSpec) *ecv1alpha1.EtcdCluster {
+		return &ecv1alpha1.EtcdCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "tls-cluster", Namespace: "default", UID: "1"},
+			Spec: ecv1alpha1.EtcdClusterSpec{
+				Size:        3,
+				Version:     "3.5.17",
+				TLS:         tls,
+				StorageSpec: storage,
+			},
+		}
+	}
+
+	t.Run("TLS cluster mounts both secrets readonly and adds TLS args", func(t *testing.T) {
+		ec := mkCluster(&ecv1alpha1.TLSCertificate{Provider: "auto"}, nil)
+		pod := buildMemberPod(ec, "tls-cluster-0", etcdClusterStateNew, "ignored")
+
+		container := pod.Spec.Containers[0]
+
+		// VolumeMounts: server + peer, both read-only.
+		var mounts []corev1.VolumeMount
+		for _, m := range container.VolumeMounts {
+			if m.Name == "server-secret" || m.Name == "peer-secret" {
+				mounts = append(mounts, m)
+			}
+		}
+		require.Len(t, mounts, 2, "expected server-secret and peer-secret mounts")
+		for _, m := range mounts {
+			assert.True(t, m.ReadOnly, "mount %s must be read-only", m.Name)
+		}
+		assert.Contains(t, []string{mounts[0].MountPath, mounts[1].MountPath}, serverCertMountDir)
+		assert.Contains(t, []string{mounts[0].MountPath, mounts[1].MountPath}, peerCertMountDir)
+
+		// Pod-level Volumes for both secrets.
+		volNames := map[string]bool{}
+		for _, v := range pod.Spec.Volumes {
+			volNames[v.Name] = true
+		}
+		assert.True(t, volNames["server-secret"], "server-secret volume present")
+		assert.True(t, volNames["peer-secret"], "peer-secret volume present")
+
+		// Args must include the TLS flags and https schemes.
+		args := strings.Join(container.Args, "\n")
+		assert.Contains(t, args, "--cert-file="+serverCertFile)
+		assert.Contains(t, args, "--peer-cert-file="+peerCertFile)
+		assert.Contains(t, args, "--listen-client-urls=https://0.0.0.0:2379")
+		assert.Contains(t, args, "--listen-peer-urls=https://0.0.0.0:2380")
+	})
+
+	t.Run("non-TLS cluster adds no secret mounts and stays http", func(t *testing.T) {
+		ec := mkCluster(nil, nil)
+		pod := buildMemberPod(ec, "tls-cluster-0", etcdClusterStateNew, "ignored")
+
+		for _, m := range pod.Spec.Containers[0].VolumeMounts {
+			assert.NotEqual(t, "server-secret", m.Name, "non-TLS pod must not mount server-secret")
+			assert.NotEqual(t, "peer-secret", m.Name, "non-TLS pod must not mount peer-secret")
+		}
+		for _, v := range pod.Spec.Volumes {
+			assert.NotEqual(t, "server-secret", v.Name)
+			assert.NotEqual(t, "peer-secret", v.Name)
+		}
+		args := strings.Join(pod.Spec.Containers[0].Args, "\n")
+		assert.NotContains(t, args, "--cert-file=")
+		assert.Contains(t, args, "--listen-client-urls=http://0.0.0.0:2379")
+	})
 }

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -2,6 +2,8 @@ package controller
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"log"
 	"net"
@@ -127,8 +129,8 @@ func getArgName(s string) string {
 	return strings.TrimSpace(s)
 }
 
-func createArgs(name string, etcdOptions []string) []string {
-	defaultArgs := defaultArgs(name)
+func createArgs(name string, etcdOptions []string, tlsEnabled bool) []string {
+	defaultArgs := defaultArgs(name, tlsEnabled)
 	if len(etcdOptions) > 0 {
 		for i := range etcdOptions {
 			argName := getArgName(etcdOptions[i])
@@ -175,11 +177,13 @@ func createHeadlessServiceIfNotExist(ctx context.Context, logger logr.Logger, c 
 }
 
 // peerEndpointForOrdinalIndex returns the member name and peer URL for a given
-// ordinal, used both to build ETCD_INITIAL_CLUSTER and to call AddMember.
+// ordinal, used both to build ETCD_INITIAL_CLUSTER and to call AddMember. The
+// peer URL scheme reflects the cluster's TLS configuration (https when TLS is
+// configured, http otherwise).
 func peerEndpointForOrdinalIndex(ec *ecv1alpha1.EtcdCluster, index int) (string, string) {
 	name := fmt.Sprintf("%s-%d", ec.Name, index)
-	return name, fmt.Sprintf("http://%s-%d.%s.%s.svc.cluster.local:2380",
-		ec.Name, index, ec.Name, ec.Namespace)
+	return name, fmt.Sprintf("%s://%s-%d.%s.%s.svc.cluster.local:2380",
+		clusterScheme(clusterTLSEnabled(ec)), ec.Name, index, ec.Name, ec.Namespace)
 }
 
 // ---------------------------------------------------------------------------
@@ -377,6 +381,61 @@ func patchCertificateSecret(ctx context.Context, ec *ecv1alpha1.EtcdCluster, c c
 		return fmt.Errorf("failed to update certificate secret with ownerReference: %w", err)
 	}
 	return nil
+}
+
+// verifySecretHasCA returns an error if the supplied certificate Secret lacks
+// a ca.crt data key. etcd requires --trusted-ca-file / --peer-trusted-ca-file,
+// so a Secret without the CA cannot drive a TLS-enabled cluster. The auto
+// provider always writes ca.crt; cert-manager only does so for CA-type Issuers
+// (SelfSigned/CA), so the missing-key case surfaces an actionable error rather
+// than mounting a non-existent file.
+func verifySecretHasCA(secret *corev1.Secret, provider string) error {
+	if _, ok := secret.Data[corev1.ServiceAccountRootCAKey]; !ok {
+		// corev1.ServiceAccountRootCAKey == "ca.crt".
+		return fmt.Errorf("certificate Secret %s (provider %s) is missing the ca.crt key; "+
+			"for cert-manager use a SelfSigned or CA Issuer (ACME does not emit ca.crt)",
+			secret.Name, provider)
+	}
+	return nil
+}
+
+// buildClientTLSConfig assembles the operator's TLS config from the cluster's
+// server certificate Secret. The operator reuses the server identity (tls.crt/tls.key)
+// and trusts the server CA (ca.crt), so the control plane can reach a TLS-enabled etcd client listener.
+func buildClientTLSConfig(ctx context.Context, ec *ecv1alpha1.EtcdCluster, c client.Client) (*tls.Config, error) {
+	secret := &corev1.Secret{}
+	if err := c.Get(ctx, client.ObjectKey{Name: getServerCertName(ec.Name), Namespace: ec.Namespace}, secret); err != nil {
+		return nil, fmt.Errorf("failed to get server certificate secret for client TLS: %w", err)
+	}
+
+	if err := verifySecretHasCA(secret, ec.Spec.TLS.Provider); err != nil {
+		return nil, err
+	}
+
+	certData, ok := secret.Data[corev1.TLSCertKey]
+	if !ok || len(certData) == 0 {
+		return nil, fmt.Errorf("server certificate secret %s is missing tls.crt", secret.Name)
+	}
+	keyData, ok := secret.Data[corev1.TLSPrivateKeyKey]
+	if !ok || len(keyData) == 0 {
+		return nil, fmt.Errorf("server certificate secret %s is missing tls.key", secret.Name)
+	}
+
+	keyPair, err := tls.X509KeyPair(certData, keyData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load server keypair for client TLS: %w", err)
+	}
+
+	caPool := x509.NewCertPool()
+	if !caPool.AppendCertsFromPEM(secret.Data[corev1.ServiceAccountRootCAKey]) {
+		return nil, fmt.Errorf("failed to parse ca.crt from server certificate secret %s", secret.Name)
+	}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{keyPair},
+		RootCAs:      caPool,
+		MinVersion:   tls.VersionTLS12,
+	}, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -286,3 +286,62 @@ func TestCreateCMCertificateConfig(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// peerEndpointForOrdinalIndex — scheme reflects TLS configuration
+// ---------------------------------------------------------------------------
+
+func TestPeerEndpointForOrdinal(t *testing.T) {
+	mkCluster := func(name, namespace string, tls *ecv1alpha1.TLSCertificate) *ecv1alpha1.EtcdCluster {
+		return &ecv1alpha1.EtcdCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, UID: "1"},
+			Spec:       ecv1alpha1.EtcdClusterSpec{TLS: tls},
+		}
+	}
+
+	httpCluster := mkCluster("test-cluster", "default", nil)
+	httpsCluster := mkCluster("test-cluster", "default", &ecv1alpha1.TLSCertificate{Provider: "auto"})
+
+	// Replace the trailing scheme expectations; the member name is scheme-agnostic.
+	const wantName = "test-cluster-0"
+	httpName, httpURL := peerEndpointForOrdinalIndex(httpCluster, 0)
+	httpsName, httpsURL := peerEndpointForOrdinalIndex(httpsCluster, 0)
+
+	assert.Equal(t, wantName, httpName)
+	assert.Equal(t, wantName, httpsName)
+
+	assert.Equal(t, "http://test-cluster-0.test-cluster.default.svc.cluster.local:2380", httpURL)
+	assert.Equal(t, "https://test-cluster-0.test-cluster.default.svc.cluster.local:2380", httpsURL)
+}
+
+// ---------------------------------------------------------------------------
+// verifySecretHasCA — error path when a cert Secret lacks ca.crt
+// ---------------------------------------------------------------------------
+
+func TestVerifySecretHasCA(t *testing.T) {
+	mkSecret := func(data map[string][]byte) *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "x-tls", Namespace: "default"},
+			Data:       data,
+		}
+	}
+
+	t.Run("with ca.crt passes", func(t *testing.T) {
+		err := verifySecretHasCA(mkSecret(map[string][]byte{
+			"tls.crt": []byte("cert"),
+			"tls.key": []byte("key"),
+			"ca.crt":  []byte("ca"),
+		}), string(certificate.Auto))
+		assert.NoError(t, err)
+	})
+
+	t.Run("without ca.crt errors with provider hint", func(t *testing.T) {
+		err := verifySecretHasCA(mkSecret(map[string][]byte{
+			"tls.crt": []byte("cert"),
+			"tls.key": []byte("key"),
+		}), string(certificate.CertManager))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ca.crt")
+		assert.Contains(t, err.Error(), "cert-manager")
+	})
+}

--- a/internal/etcdutils/etcdutils.go
+++ b/internal/etcdutils/etcdutils.go
@@ -2,6 +2,7 @@ package etcdutils
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"sort"
@@ -17,13 +18,49 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
-func MemberList(eps []string) (*clientv3.MemberListResponse, error) {
-	cfg := clientv3.Config{
+// Option configures a clientv3.Config built by the helpers in this package.
+// It is the single, backward-compatible extension point that callers use to add
+// TLS (WithTLS) without changing positional signatures.
+type Option func(*clientConfig)
+
+type clientConfig struct {
+	tls *tls.Config
+}
+
+// WithTLS applies the given tls.Config to the etcd client so the operator can
+// reach a TLS-enabled cluster. Callers without TLS pass no option.
+func WithTLS(tlsCfg *tls.Config) Option {
+	return func(c *clientConfig) { c.tls = tlsCfg }
+}
+
+// applyOptions builds the base clientv3.Config shared by MemberList,
+// AddMember, PromoteLearner and RemoveMember, then applies the given options.
+func applyOptions(eps []string, opts ...Option) clientv3.Config {
+	cfg := clientConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return clientv3.Config{
 		Endpoints:            eps,
 		DialTimeout:          2 * time.Second,
 		DialKeepAliveTime:    2 * time.Second,
 		DialKeepAliveTimeout: 6 * time.Second,
+		TLS:                  cfg.tls,
 	}
+}
+
+// closeAndCancel closes the client and, if Close errored, keeps the cancel
+// path non-fatal. Used by the single-call helpers below.
+func closeAndCancel(c *clientv3.Client, cancel context.CancelFunc) {
+	if err := c.Close(); err != nil {
+		cancel()
+		return
+	}
+	cancel()
+}
+
+func MemberList(eps []string, opts ...Option) (*clientv3.MemberListResponse, error) {
+	cfg := applyOptions(eps, opts...)
 
 	c, err := clientv3.New(cfg)
 	if err != nil {
@@ -31,14 +68,7 @@ func MemberList(eps []string) (*clientv3.MemberListResponse, error) {
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer func() {
-		err := c.Close()
-		if err != nil {
-			cancel()
-			return
-		}
-		cancel()
-	}()
+	defer func() { closeAndCancel(c, cancel) }()
 
 	return c.MemberList(ctx)
 }
@@ -120,7 +150,7 @@ func FindLearnerStatus(healthInfos []EpHealth, logger logr.Logger) (uint64, *cli
 	return learner, learnerStatus
 }
 
-func ClusterHealth(eps []string) ([]EpHealth, error) {
+func ClusterHealth(eps []string, opts ...Option) ([]EpHealth, error) {
 	lg, err := logutil.CreateDefaultZapLogger(zap.InfoLevel)
 	if err != nil {
 		return nil, err
@@ -128,14 +158,9 @@ func ClusterHealth(eps []string) ([]EpHealth, error) {
 
 	var cfgs = make([]*clientv3.Config, 0, len(eps))
 	for _, ep := range eps {
-		cfg := &clientv3.Config{
-			Endpoints:            []string{ep},
-			DialTimeout:          2 * time.Second,
-			DialKeepAliveTime:    2 * time.Second,
-			DialKeepAliveTimeout: 6 * time.Second,
-		}
+		cfg := applyOptions([]string{ep}, opts...)
 
-		cfgs = append(cfgs, cfg)
+		cfgs = append(cfgs, &cfg)
 	}
 
 	healthCh := make(chan EpHealth, len(eps))
@@ -200,13 +225,8 @@ func ClusterHealth(eps []string) ([]EpHealth, error) {
 	return healthList, nil
 }
 
-func AddMember(eps []string, peerURLs []string, learner bool) (*clientv3.MemberAddResponse, error) {
-	cfg := clientv3.Config{
-		Endpoints:            eps,
-		DialTimeout:          2 * time.Second,
-		DialKeepAliveTime:    2 * time.Second,
-		DialKeepAliveTimeout: 6 * time.Second,
-	}
+func AddMember(eps []string, peerURLs []string, learner bool, opts ...Option) (*clientv3.MemberAddResponse, error) {
+	cfg := applyOptions(eps, opts...)
 
 	c, err := clientv3.New(cfg)
 	if err != nil {
@@ -214,14 +234,7 @@ func AddMember(eps []string, peerURLs []string, learner bool) (*clientv3.MemberA
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer func() {
-		err := c.Close()
-		if err != nil {
-			cancel()
-			return
-		}
-		cancel()
-	}()
+	defer func() { closeAndCancel(c, cancel) }()
 
 	if learner {
 		return c.MemberAddAsLearner(ctx, peerURLs)
@@ -230,13 +243,8 @@ func AddMember(eps []string, peerURLs []string, learner bool) (*clientv3.MemberA
 	return c.MemberAdd(ctx, peerURLs)
 }
 
-func PromoteLearner(eps []string, learnerId uint64) error {
-	cfg := clientv3.Config{
-		Endpoints:            eps,
-		DialTimeout:          2 * time.Second,
-		DialKeepAliveTime:    2 * time.Second,
-		DialKeepAliveTimeout: 6 * time.Second,
-	}
+func PromoteLearner(eps []string, learnerId uint64, opts ...Option) error {
+	cfg := applyOptions(eps, opts...)
 
 	c, err := clientv3.New(cfg)
 	if err != nil {
@@ -244,26 +252,14 @@ func PromoteLearner(eps []string, learnerId uint64) error {
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer func() {
-		err := c.Close()
-		if err != nil {
-			cancel()
-			return
-		}
-		cancel()
-	}()
+	defer func() { closeAndCancel(c, cancel) }()
 
 	_, err = c.MemberPromote(ctx, learnerId)
 	return err
 }
 
-func RemoveMember(eps []string, memberID uint64) error {
-	cfg := clientv3.Config{
-		Endpoints:            eps,
-		DialTimeout:          2 * time.Second,
-		DialKeepAliveTime:    2 * time.Second,
-		DialKeepAliveTimeout: 6 * time.Second,
-	}
+func RemoveMember(eps []string, memberID uint64, opts ...Option) error {
+	cfg := applyOptions(eps, opts...)
 
 	c, err := clientv3.New(cfg)
 	if err != nil {
@@ -271,14 +267,7 @@ func RemoveMember(eps []string, memberID uint64) error {
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer func() {
-		err := c.Close()
-		if err != nil {
-			cancel()
-			return
-		}
-		cancel()
-	}()
+	defer func() { closeAndCancel(c, cancel) }()
 
 	_, err = c.MemberRemove(ctx, memberID)
 	return err

--- a/internal/etcdutils/etcdutils_test.go
+++ b/internal/etcdutils/etcdutils_test.go
@@ -1,11 +1,13 @@
 package etcdutils
 
 import (
+	"crypto/tls"
 	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -335,4 +337,28 @@ func TestHealthReportSwap(t *testing.T) {
 	// Check if the elements are swapped
 	assert.Equal(t, "http://localhost:2380", healthReports[0].Ep)
 	assert.Equal(t, "http://localhost:2379", healthReports[1].Ep)
+}
+
+// ---------------------------------------------------------------------------
+// Option / WithTLS — TLS config is applied to clientv3.Config
+// ---------------------------------------------------------------------------
+
+func TestApplyOptionsTLSConfig(t *testing.T) {
+	// applyOptions is the single point where every helper (MemberList,
+	// ClusterHealth, AddMember, PromoteLearner, RemoveMember) builds the
+	// clientv3.Config; asserting here covers all five call paths.
+	eps := []string{"https://127.0.0.1:2379"}
+
+	t.Run("no options leaves TLS nil", func(t *testing.T) {
+		cfg := applyOptions(eps)
+		assert.Nil(t, cfg.TLS)
+		assert.Equal(t, eps, cfg.Endpoints)
+	})
+
+	t.Run("WithTLS sets the tls.Config", func(t *testing.T) {
+		wantTLS := &tls.Config{MinVersion: tls.VersionTLS12}
+		cfg := applyOptions(eps, WithTLS(wantTLS))
+		require.NotNil(t, cfg.TLS)
+		assert.Equal(t, uint16(tls.VersionTLS12), cfg.TLS.MinVersion)
+	})
 }

--- a/pkg/certificate/auto/provider.go
+++ b/pkg/certificate/auto/provider.go
@@ -294,7 +294,11 @@ func (ac *Provider) createNewSecret(ctx context.Context, secretKey client.Object
 		return fmt.Errorf("validity duration converts to 0 years, must be at least 1 year")
 	}
 
-	tlsInfo, selfCertErr := transport.SelfCert(zap.NewNop(), tmpDir, hosts, validityYears)
+	// transport.SelfCert generates a self-signed cert whose ExtKeyUsage
+	// defaults to ServerAuth only. The operator reuses the server Secret
+	// as its own mTLS client identity against the etcd client listener.
+	// The cert must also carry ClientAuth.
+	tlsInfo, selfCertErr := transport.SelfCert(zap.NewNop(), tmpDir, hosts, validityYears, x509.ExtKeyUsageClientAuth)
 	if selfCertErr != nil {
 		return fmt.Errorf("certificate creation via transport.SelfCert failed: %w", selfCertErr)
 	}

--- a/pkg/certificate/auto/provider_test.go
+++ b/pkg/certificate/auto/provider_test.go
@@ -1,0 +1,66 @@
+package auto
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	interfaces "go.etcd.io/etcd-operator/pkg/certificate/interfaces"
+)
+
+// The operator uses the server certificate as a client to check etcd member
+// status, so the auto-generated cert must carry the ClientAuth key usage.
+func TestEnsureCertificateSecretCertHasClientAuth(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	fakeClient := clientfake.NewClientBuilder().WithScheme(scheme).Build()
+	provider := New(fakeClient)
+
+	secretKey := client.ObjectKey{Name: "test-server-tls", Namespace: "default"}
+	cfg := &interfaces.Config{
+		CommonName:       "etcd.test",
+		ValidityDuration: interfaces.DefaultAutoValidity,
+		AltNames: interfaces.AltNames{
+			DNSNames: []string{"test.default.svc.cluster.local"},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	require.NoError(t, provider.EnsureCertificateSecret(ctx, secretKey, cfg))
+
+	// Fetch the generated Secret and verify the cert carries ClientAuth.
+	secret := &corev1.Secret{}
+	require.NoError(t, fakeClient.Get(ctx, secretKey, secret))
+
+	certPEM, ok := secret.Data["tls.crt"]
+	require.True(t, ok, "secret must contain tls.crt")
+	require.NotEmpty(t, certPEM)
+
+	block, _ := pem.Decode(certPEM)
+	require.NotNil(t, block, "tls.crt is valid PEM")
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err, "tls.crt parses as a certificate")
+
+	assert.Contains(t, cert.ExtKeyUsage, x509.ExtKeyUsageClientAuth,
+		"auto cert must carry ClientAuth so the operator can present it as a client (design D4-a)")
+	assert.Contains(t, cert.ExtKeyUsage, x509.ExtKeyUsageServerAuth,
+		"auto cert must keep ServerAuth for its primary server role")
+
+	// Sanity: the secret is structurally complete for an etcd TLS mount.
+	assert.NotEmpty(t, secret.Data["tls.key"])
+	assert.NotEmpty(t, secret.Data["ca.crt"])
+	assert.Equal(t, corev1.SecretTypeTLS, secret.Type)
+}

--- a/test/e2e/auto_provider_test.go
+++ b/test/e2e/auto_provider_test.go
@@ -201,7 +201,7 @@ func TestClusterAutoCertCreation(t *testing.T) {
 	feature.Assess("Verify Data Operations",
 		func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 			// verify etcdCluster is accessible via client certificate with put and get
-			verifyDataOperations(t, c, etcdClusterName, "test-key", "test-value")
+			verifyDataOperations(t, c, etcdClusterName, "test-key", "test-value", true)
 			return ctx
 		},
 	)

--- a/test/e2e/cert_manager_test.go
+++ b/test/e2e/cert_manager_test.go
@@ -269,7 +269,7 @@ func TestClusterCertCreation(t *testing.T) {
 	feature.Assess("Verify Data Operations",
 		func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 			// verify etcdCluster is accessible via client certificate with put and get
-			verifyDataOperations(t, c, etcdClusterName, "test-key", "test-value")
+			verifyDataOperations(t, c, etcdClusterName, "test-key", "test-value", true)
 			return ctx
 		},
 	)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -310,7 +310,7 @@ func TestPodRecovery(t *testing.T) {
 			}
 
 			// Verify cluster replication works across recovered pod
-			verifyDataOperations(t, c, etcdClusterName, "replication-test", "value")
+			verifyDataOperations(t, c, etcdClusterName, "replication-test", "value", false)
 
 			stdout, stderr, err := execInPod(t, c, targetPodName, namespace, []string{"etcdctl", "get", "replication-test"})
 			if err != nil {
@@ -378,7 +378,7 @@ func TestEtcdClusterFunctionality(t *testing.T) {
 	})
 
 	feature.Assess("test data operations", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-		verifyDataOperations(t, c, etcdClusterName, "test-key", "test-value")
+		verifyDataOperations(t, c, etcdClusterName, "test-key", "test-value", false)
 		return ctx
 	})
 

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -109,15 +109,18 @@ func waitForPodReadiness(t *testing.T, c *envconf.Config, name string, expectedR
 	var pods corev1.PodList
 	return wait.For(func(ctx context.Context) (bool, error) {
 		if err := c.Client().Resources().List(ctx, &pods, resources.WithLabelSelector(label)); err != nil {
+			t.Logf("failed to list pods by label %s, %s", label, err)
 			return false, nil
 		}
 
 		if len(pods.Items) != expectedReplicas {
+			t.Logf("list pods by label %s, want %d, got %d", label, expectedReplicas, len(pods.Items))
 			return false, nil
 		}
 
 		for _, pod := range pods.Items {
 			if !podReady(&pod) {
+				t.Logf("pod %s is not ready yet, phase is %s", pod.Name, pod.Status.Phase)
 				return false, nil
 			}
 		}
@@ -274,26 +277,50 @@ func getClusterEndpointHashKVs(t *testing.T, c *envconf.Config, podName string) 
 	return out
 }
 
-func verifyDataOperations(t *testing.T, c *envconf.Config, etcdClusterName, testKey, testValue string) {
+const (
+	etcdServerCertMountDir = "/etc/etcd-certs/server"
+
+	etcdServerCertFile = etcdServerCertMountDir + "/tls.crt"
+	etcdServerKeyFile  = etcdServerCertMountDir + "/tls.key"
+	etcdServerCAFile   = etcdServerCertMountDir + "/ca.crt"
+)
+
+func etcdctlCmd(podName, etcdClusterName, namespace string, tlsEnabled bool) []string {
+	args := []string{"etcdctl"}
+	if tlsEnabled {
+		endpoint := fmt.Sprintf("https://%s.%s.%s.svc.cluster.local:2379",
+			podName, etcdClusterName, namespace)
+		args = append(args,
+			"--cacert="+etcdServerCAFile,
+			"--cert="+etcdServerCertFile,
+			"--key="+etcdServerKeyFile,
+			"--endpoints="+endpoint,
+		)
+	}
+	return args
+}
+
+func verifyDataOperations(t *testing.T, c *envconf.Config, etcdClusterName, key, val string, tlsEnabled bool) {
 	podName := fmt.Sprintf("%s-0", etcdClusterName)
 
 	// Write key-value data
-	command := []string{"etcdctl", "put", testKey, testValue}
+	cmd := etcdctlCmd(podName, etcdClusterName, namespace, tlsEnabled)
+	command := append(cmd, "put", key, val)
 	_, stderr, err := execInPod(t, c, podName, namespace, command)
 	if err != nil {
 		t.Fatalf("Failed to write data: %v, stderr: %s", err, stderr)
 	}
 
 	// Read key-value data
-	command = []string{"etcdctl", "get", testKey}
+	command = append(cmd, "get", key, val)
 	stdout, stderr, err := execInPod(t, c, podName, namespace, command)
 	if err != nil {
 		t.Fatalf("Failed to read data: %v, stderr: %s", err, stderr)
 	}
 
 	lines := strings.Split(strings.TrimSpace(stdout), "\n")
-	if len(lines) < 2 || lines[0] != testKey || lines[1] != testValue {
-		t.Errorf("Expected key-value pair [%s=%s], but got output: %s", testKey, testValue, stdout)
+	if len(lines) < 2 || lines[0] != key || lines[1] != val {
+		t.Errorf("Expected key-value pair [%s=%s], but got output: %s", key, val, stdout)
 	}
 }
 


### PR DESCRIPTION
# Summary

This PR wires up TLS support on the customized controller so that TLS-enabled etcd clusters can be created successfully. It targets the customized-controller branch and addresses #409.

I tested both the `auto` and `cert-manager` TLS configuration types, and both can create a TLS-enabled etcd cluster correctly.

# Notes

1. validityDuration cannot use the d suffix (e.g. 365d)

time.ParseDuration cannot parse strings like 365d; v0.2.0 produces the same error. This is by design in the Go standard library — see [golang/go#17767](https://github.com/golang/go/issues/17767).

To make the sample YAML work out of the box, I changed validityDuration to 8760h (= 365 × 24h). With this value, the sample YAML creates an etcd cluster successfully.

If support for parsing the `d` suffix is desired, it can be addressed in a follow-up PR.

2. Client TLS does not yet handshake with the etcd server

Currently the controller uses the server TLS certificate as the etcd client certificate to talk to the etcd server; it does not use client TLS.

Because the client ca.crt is issued by an independent CA and is not included in the etcd server's --trusted-ca-file, client TLS cannot complete a handshake with the etcd server today.

Future work: bundle the client CA together with the server CA and add the bundle to the etcd server's trust chain (--trusted-ca-file). Once that is in place, client TLS will be able to communicate with the etcd server normally.

/cc @ahrtr @nwnt 