### PR TITLE
feat(tls): support TLS-aware pods and operator mTLS client identity

### DIFF
--- a/internal/controller/etcdcluster.go
+++ b/internal/controller/etcdcluster.go
@@ -19,7 +19,7 @@ func EtcdClusterHash(ec *v1alpha1.EtcdCluster) string {
 	clusterSpec.Size = 0
 	// version is handled separately
 	clusterSpec.Version = ""
-	clusterSpec.EtcdOptions = createArgs(ec.Name, ec.Spec.EtcdOptions)
+	clusterSpec.EtcdOptions = createArgs(ec.Name, ec.Spec.EtcdOptions, clusterTLSEnabled(ec))
 	// we don't want to roll etcd pods when metadata is changed.
 	// instead, we'd do in-place update for them.
 	if clusterSpec.PodTemplate != nil {

--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"strings"
 	"time"
@@ -57,6 +58,7 @@ type reconcileState struct {
 	pods           []*corev1.Pod                // member pods owned by this cluster, sorted by ordinal
 	memberListResp *clientv3.MemberListResponse // member list fetched from the etcd cluster
 	memberHealth   []etcdutils.EpHealth         // health information for each etcd member
+	tlsConfig      *tls.Config                  // etcd client TLS config used by every etcdutils call in this loop (nil for non-TLS clusters)
 }
 
 // +kubebuilder:rbac:groups=operator.etcd.io,resources=etcdclusters,verbs=get;list;watch;create;update;patch;delete
@@ -131,6 +133,12 @@ func (r *EtcdClusterReconciler) fetchAndValidateState(ctx context.Context, req c
 		))
 	}
 
+	// Build the operator's etcd-client TLS config (from the server cert Secret)
+	clientTLS, tlsErr := r.buildReconcileClientTLS(ctx, ec)
+	if tlsErr != nil {
+		logger.Error(tlsErr, "Failed to build client TLS config; will retry next reconcile")
+	}
+
 	logger.Info("Reconciling EtcdCluster", "spec", ec.Spec)
 
 	pods, err := listOwnedPods(ctx, r.Client, ec)
@@ -138,6 +146,9 @@ func (r *EtcdClusterReconciler) fetchAndValidateState(ctx context.Context, req c
 		logger.Error(err, "Failed to list pods. Requesting requeue")
 		return nil, ctrl.Result{RequeueAfter: requeueDuration}, nil
 	}
+
+	// When TLS is unused tlsConfig stays nil.
+	rs := &reconcileState{cluster: ec, pods: pods, tlsConfig: clientTLS}
 
 	// Validate the upgrade path using the image tag of the first pod.
 	if len(pods) > 0 {
@@ -149,7 +160,7 @@ func (r *EtcdClusterReconciler) fetchAndValidateState(ctx context.Context, req c
 			if idx == -1 {
 				logger.Info("could not extract image version from pod image",
 					"image", c.Image)
-				return &reconcileState{cluster: ec, pods: pods}, ctrl.Result{}, nil
+				return rs, ctrl.Result{}, nil
 			}
 			currentVersion := c.Image[idx+1:]
 			targetVersion := ec.Spec.Version
@@ -163,7 +174,7 @@ func (r *EtcdClusterReconciler) fetchAndValidateState(ctx context.Context, req c
 						"target", targetVersion,
 						"error", err,
 					)
-					return &reconcileState{cluster: ec, pods: pods}, ctrl.Result{}, nil
+					return rs, ctrl.Result{}, nil
 				}
 				if err != nil {
 					logger.Error(err, "unsupported upgrade path between current and target versions",
@@ -180,7 +191,17 @@ func (r *EtcdClusterReconciler) fetchAndValidateState(ctx context.Context, req c
 		}
 	}
 
-	return &reconcileState{cluster: ec, pods: pods}, ctrl.Result{}, nil
+	return rs, ctrl.Result{}, nil
+}
+
+// buildReconcileClientTLS builds the operator's etcd-client TLS Config for a
+// reconcile loop from the cluster's server certificate Secret. Returns a nil
+// config (and nil error) when the cluster has no TLS configured.
+func (r *EtcdClusterReconciler) buildReconcileClientTLS(ctx context.Context, ec *ecv1alpha1.EtcdCluster) (*tls.Config, error) {
+	if ec.Spec.TLS == nil {
+		return nil, nil
+	}
+	return buildClientTLSConfig(ctx, ec, r.Client)
 }
 
 // bootstrapCluster ensures the headless Service exists and, when no pods are
@@ -211,7 +232,7 @@ func (r *EtcdClusterReconciler) performHealthChecks(ctx context.Context, s *reco
 	logger := log.FromContext(ctx)
 	logger.Info("Now checking health of the cluster members")
 	var err error
-	s.memberListResp, s.memberHealth, err = healthCheck(s.cluster.Name, s.cluster.Namespace, s.pods, logger)
+	s.memberListResp, s.memberHealth, err = healthCheck(s.cluster.Name, s.cluster.Namespace, s.pods, clusterTLSEnabled(s.cluster), s.tlsConfig, logger)
 	if err != nil {
 		return fmt.Errorf("health check failed: %w", err)
 	}
@@ -275,10 +296,10 @@ func (r *EtcdClusterReconciler) reconcileClusterState(ctx context.Context, s *re
 			logger.Info("Learner found", "learnerID", learner, "learnerStatus", learnerStatus)
 			if etcdutils.IsLearnerReady(leaderStatus, learnerStatus) {
 				logger.Info("Learner is ready to be promoted to voting member", "learnerID", learner)
-				eps := clientEndpointsFromPods(s.cluster.Name, s.cluster.Namespace, s.pods)
+				eps := clientEndpointsFromPods(s.cluster.Name, s.cluster.Namespace, s.pods, clusterTLSEnabled(s.cluster))
 				// Exclude the learner (last ordinal) from the endpoint list used for promotion.
 				eps = eps[:(len(eps) - 1)]
-				if err := etcdutils.PromoteLearner(etcdutils.ClientConfig{Endpoints: eps}, learner); err != nil {
+				if err := etcdutils.PromoteLearner(etcdutils.ClientConfig{Endpoints: eps, TLS: s.tlsConfig}, learner); err != nil {
 					return ctrl.Result{}, err
 				}
 			} else {
@@ -293,14 +314,14 @@ func (r *EtcdClusterReconciler) reconcileClusterState(ctx context.Context, s *re
 		return ctrl.Result{}, nil
 	}
 
-	eps := clientEndpointsFromPods(s.cluster.Name, s.cluster.Namespace, s.pods)
+	eps := clientEndpointsFromPods(s.cluster.Name, s.cluster.Namespace, s.pods, clusterTLSEnabled(s.cluster))
 
 	if currentPodCount < int32(s.cluster.Spec.Size) {
 		// Scale out: add a new learner member to etcd, then create its pod.
 		nextOrdinal := int(currentPodCount)
 		_, peerURL := peerEndpointForOrdinalIndex(s.cluster, nextOrdinal)
 		logger.Info("[Scale out] adding a new learner member to etcd cluster", "peerURL", peerURL)
-		if _, err := etcdutils.AddMember(etcdutils.ClientConfig{Endpoints: eps}, []string{peerURL}, true); err != nil {
+		if _, err := etcdutils.AddMember(etcdutils.ClientConfig{Endpoints: eps, TLS: s.tlsConfig}, []string{peerURL}, true); err != nil {
 			return ctrl.Result{}, err
 		}
 		logger.Info("Learner member added successfully", "peerURL", peerURL)
@@ -320,7 +341,7 @@ func (r *EtcdClusterReconciler) reconcileClusterState(ctx context.Context, s *re
 		logger.Info("[Scale in] removing one member", "memberID", memberID, "pod", podToRemove.Name)
 
 		epsForRemoval := eps[:len(eps)-1]
-		if err := etcdutils.RemoveMember(etcdutils.ClientConfig{Endpoints: epsForRemoval}, memberID); err != nil {
+		if err := etcdutils.RemoveMember(etcdutils.ClientConfig{Endpoints: epsForRemoval, TLS: s.tlsConfig}, memberID); err != nil {
 			return ctrl.Result{}, err
 		}
 

--- a/internal/controller/pods.go
+++ b/internal/controller/pods.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"maps"
@@ -136,23 +137,39 @@ func waitForPodReady(ctx context.Context, logger logr.Logger, c client.Client, p
 // clientEndpointsFromPods builds the client endpoint URL for every pod in the
 // slice, in the same order.  The DNS form is:
 //
-//	http://{podName}.{clusterName}.{namespace}.svc.cluster.local:2379
-func clientEndpointsFromPods(clusterName, namespace string, pods []*corev1.Pod) []string {
+//	{scheme}://{podName}.{clusterName}.{namespace}.svc.cluster.local:2379
+//
+// where scheme reflects the cluster's TLS configuration.
+func clientEndpointsFromPods(clusterName, namespace string, pods []*corev1.Pod, tlsEnabled bool) []string {
 	if len(pods) == 0 {
 		return nil
 	}
 	eps := make([]string, 0, len(pods))
 	for _, pod := range pods {
-		eps = append(eps, clientEndpointForOrdinal(clusterName, namespace, podOrdinal(pod.Name, clusterName)))
+		eps = append(eps, clientEndpointForOrdinal(clusterName, namespace, podOrdinal(pod.Name, clusterName), tlsEnabled))
 	}
 	return eps
 }
 
 // clientEndpointForOrdinal returns the client endpoint URL for a member at the
-// given ordinal index.
-func clientEndpointForOrdinal(clusterName, namespace string, ordinal int) string {
-	return fmt.Sprintf("http://%s-%d.%s.%s.svc.cluster.local:2379",
-		clusterName, ordinal, clusterName, namespace)
+// given ordinal index. The URL scheme is https when tlsEnabled is true, otherwise http.
+func clientEndpointForOrdinal(clusterName, namespace string, ordinal int, tlsEnabled bool) string {
+	return fmt.Sprintf("%s://%s-%d.%s.%s.svc.cluster.local:2379",
+		clusterScheme(tlsEnabled), clusterName, ordinal, clusterName, namespace)
+}
+
+// clusterScheme returns the URL scheme to use for cluster endpoints: "https"
+// when TLS is enabled, "http" otherwise.
+func clusterScheme(tlsEnabled bool) string {
+	if tlsEnabled {
+		return "https"
+	}
+	return "http"
+}
+
+// clusterTLSEnabled reports whether the given cluster has TLS configured.
+func clusterTLSEnabled(ec *ecv1alpha1.EtcdCluster) bool {
+	return ec != nil && ec.Spec.TLS != nil
 }
 
 // areAllMembersHealthy returns true when every entry in the supplied health
@@ -169,14 +186,14 @@ func areAllMembersHealthy(memberHealth []etcdutils.EpHealth) bool {
 
 // healthCheck returns a MemberListResponse and per-endpoint health information
 // for the etcd cluster reachable through the given pods.
-func healthCheck(clusterName, namespace string, pods []*corev1.Pod, lg klog.Logger) (*clientv3.MemberListResponse, []etcdutils.EpHealth, error) {
+func healthCheck(clusterName, namespace string, pods []*corev1.Pod, tlsEnabled bool, tlsConfig *tls.Config, lg klog.Logger) (*clientv3.MemberListResponse, []etcdutils.EpHealth, error) {
 	if len(pods) == 0 {
 		return nil, nil, nil
 	}
 
-	endpoints := clientEndpointsFromPods(clusterName, namespace, pods)
+	endpoints := clientEndpointsFromPods(clusterName, namespace, pods, tlsEnabled)
 
-	memberlistResp, err := etcdutils.MemberList(etcdutils.ClientConfig{Endpoints: endpoints})
+	memberlistResp, err := etcdutils.MemberList(etcdutils.ClientConfig{Endpoints: endpoints, TLS: tlsConfig})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -188,7 +205,7 @@ func healthCheck(clusterName, namespace string, pods []*corev1.Pod, lg klog.Logg
 	lg.Info("health checking", "podCount", len(pods), "len(members)", memberCnt)
 	endpoints = endpoints[:cnt]
 
-	healthInfos, err := etcdutils.ClusterHealth(etcdutils.ClientConfig{Endpoints: endpoints})
+	healthInfos, err := etcdutils.ClusterHealth(etcdutils.ClientConfig{Endpoints: endpoints, TLS: tlsConfig})
 	if err != nil {
 		return memberlistResp, nil, err
 	}
@@ -208,14 +225,44 @@ func healthCheck(clusterName, namespace string, pods []*corev1.Pod, lg klog.Logg
 // etcd argument helpers
 // ---------------------------------------------------------------------------
 
-func defaultArgs(name string) []string {
-	return []string{
+// etcd TLS cert/CA/key file paths mounted from the certificate Secret volumes.
+// These mirror the VolumeMount paths declared in buildMemberPod.
+const (
+	serverCertMountDir = "/etc/etcd-certs/server"
+	peerCertMountDir   = "/etc/etcd-certs/peer"
+
+	serverCertFile      = serverCertMountDir + "/tls.crt"
+	serverKeyFile       = serverCertMountDir + "/tls.key"
+	serverTrustedCAFile = serverCertMountDir + "/ca.crt"
+
+	peerCertFile      = peerCertMountDir + "/tls.crt"
+	peerKeyFile       = peerCertMountDir + "/tls.key"
+	peerTrustedCAFile = peerCertMountDir + "/ca.crt"
+)
+
+func defaultArgs(name string, tlsEnabled bool) []string {
+	scheme := clusterScheme(tlsEnabled)
+	args := make([]string, 0, 13)
+	args = append(args,
 		"--name=$(POD_NAME)",
-		"--listen-peer-urls=http://0.0.0.0:2380",
-		"--listen-client-urls=http://0.0.0.0:2379",
-		fmt.Sprintf("--initial-advertise-peer-urls=http://$(POD_NAME).%s.$(POD_NAMESPACE).svc.cluster.local:2380", name),
-		fmt.Sprintf("--advertise-client-urls=http://$(POD_NAME).%s.$(POD_NAMESPACE).svc.cluster.local:2379", name),
+		fmt.Sprintf("--listen-peer-urls=%s://0.0.0.0:2380", scheme),
+		fmt.Sprintf("--listen-client-urls=%s://0.0.0.0:2379", scheme),
+		fmt.Sprintf("--initial-advertise-peer-urls=%s://$(POD_NAME).%s.$(POD_NAMESPACE).svc.cluster.local:2380", scheme, name),
+		fmt.Sprintf("--advertise-client-urls=%s://$(POD_NAME).%s.$(POD_NAMESPACE).svc.cluster.local:2379", scheme, name),
+	)
+	if !tlsEnabled {
+		return args
 	}
+	return append(args,
+		"--cert-file="+serverCertFile,
+		"--key-file="+serverKeyFile,
+		"--trusted-ca-file="+serverTrustedCAFile,
+		"--client-cert-auth=true",
+		"--peer-cert-file="+peerCertFile,
+		"--peer-key-file="+peerKeyFile,
+		"--peer-trusted-ca-file="+peerTrustedCAFile,
+		"--peer-client-cert-auth=true",
+	)
 }
 
 const (
@@ -262,7 +309,7 @@ func buildMemberPod(ec *ecv1alpha1.EtcdCluster, podName string, initialClusterSt
 		Name:    "etcd",
 		Image:   fmt.Sprintf("%s:%s", ec.Spec.ImageRegistry, ec.Spec.Version),
 		Command: []string{"/usr/local/bin/etcd"},
-		Args:    createArgs(ec.Name, ec.Spec.EtcdOptions),
+		Args:    createArgs(ec.Name, ec.Spec.EtcdOptions, clusterTLSEnabled(ec)),
 		Env:     envVars,
 		Ports: []corev1.ContainerPort{
 			{Name: "client", ContainerPort: 2379},
@@ -313,7 +360,8 @@ func buildMemberPod(ec *ecv1alpha1.EtcdCluster, podName string, initialClusterSt
 		}
 	}
 
-	// TLS certificate volumes (mounted as secrets).
+	// setup TLS certificate volumes. Both the pod Volume and VolumeMount are
+	// declared together so the etcd TLS args file paths resolve at runtime.
 	if ec.Spec.TLS != nil {
 		podSpec.Volumes = append(podSpec.Volumes,
 			corev1.Volume{
@@ -327,6 +375,20 @@ func buildMemberPod(ec *ecv1alpha1.EtcdCluster, podName string, initialClusterSt
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{SecretName: getPeerCertName(ec.Name)},
 				},
+			},
+		)
+
+		etcdContainer := &podSpec.Containers[0]
+		etcdContainer.VolumeMounts = append(etcdContainer.VolumeMounts,
+			corev1.VolumeMount{
+				Name:      "server-secret",
+				MountPath: serverCertMountDir,
+				ReadOnly:  true,
+			},
+			corev1.VolumeMount{
+				Name:      "peer-secret",
+				MountPath: peerCertMountDir,
+				ReadOnly:  true,
 			},
 		)
 	}

--- a/internal/controller/pods_test.go
+++ b/internal/controller/pods_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -487,6 +488,7 @@ func TestCreatingArgs(t *testing.T) {
 		testName       string
 		etcdOptions    []string
 		clusterName    string
+		tlsEnabled     bool
 		expectedResult []string
 	}{
 		{
@@ -499,6 +501,27 @@ func TestCreatingArgs(t *testing.T) {
 				"--listen-client-urls=http://0.0.0.0:2379",
 				"--initial-advertise-peer-urls=http://$(POD_NAME).testCluster.$(POD_NAMESPACE).svc.cluster.local:2380",
 				"--advertise-client-urls=http://$(POD_NAME).testCluster.$(POD_NAMESPACE).svc.cluster.local:2379",
+			},
+		},
+		{
+			testName:    "TLS enabled adds TLS args and https schemes",
+			etcdOptions: nil,
+			clusterName: "testCluster",
+			tlsEnabled:  true,
+			expectedResult: []string{
+				"--name=$(POD_NAME)",
+				"--listen-peer-urls=https://0.0.0.0:2380",
+				"--listen-client-urls=https://0.0.0.0:2379",
+				"--initial-advertise-peer-urls=https://$(POD_NAME).testCluster.$(POD_NAMESPACE).svc.cluster.local:2380",
+				"--advertise-client-urls=https://$(POD_NAME).testCluster.$(POD_NAMESPACE).svc.cluster.local:2379",
+				"--cert-file=" + serverCertFile,
+				"--key-file=" + serverKeyFile,
+				"--trusted-ca-file=" + serverTrustedCAFile,
+				"--client-cert-auth=true",
+				"--peer-cert-file=" + peerCertFile,
+				"--peer-key-file=" + peerKeyFile,
+				"--peer-trusted-ca-file=" + peerTrustedCAFile,
+				"--peer-client-cert-auth=true",
 			},
 		},
 		{
@@ -516,6 +539,30 @@ func TestCreatingArgs(t *testing.T) {
 				"--advertise-client-urls=http://$(POD_NAME).testCluster.$(POD_NAMESPACE).svc.cluster.local:2379",
 				"--max-wals=7",
 				"--discovery-failbox=proxy",
+			},
+		},
+		{
+			testName: "TLS enabled with custom etcdOptions",
+			etcdOptions: []string{
+				"--max-wals=7",
+			},
+			clusterName: "testCluster",
+			tlsEnabled:  true,
+			expectedResult: []string{
+				"--name=$(POD_NAME)",
+				"--listen-peer-urls=https://0.0.0.0:2380",
+				"--listen-client-urls=https://0.0.0.0:2379",
+				"--initial-advertise-peer-urls=https://$(POD_NAME).testCluster.$(POD_NAMESPACE).svc.cluster.local:2380",
+				"--advertise-client-urls=https://$(POD_NAME).testCluster.$(POD_NAMESPACE).svc.cluster.local:2379",
+				"--cert-file=" + serverCertFile,
+				"--key-file=" + serverKeyFile,
+				"--trusted-ca-file=" + serverTrustedCAFile,
+				"--client-cert-auth=true",
+				"--peer-cert-file=" + peerCertFile,
+				"--peer-key-file=" + peerKeyFile,
+				"--peer-trusted-ca-file=" + peerTrustedCAFile,
+				"--peer-client-cert-auth=true",
+				"--max-wals=7",
 			},
 		},
 		{
@@ -566,11 +613,34 @@ func TestCreatingArgs(t *testing.T) {
 				"--experimental-peer-skip-client-san-verification",
 			},
 		},
+		{
+			testName: "TLS overwrite default TLS arg",
+			etcdOptions: []string{
+				"--cert-file=/custom/cert-path",
+			},
+			clusterName: "testCluster",
+			tlsEnabled:  true,
+			expectedResult: []string{
+				"--name=$(POD_NAME)",
+				"--listen-peer-urls=https://0.0.0.0:2380",
+				"--listen-client-urls=https://0.0.0.0:2379",
+				"--initial-advertise-peer-urls=https://$(POD_NAME).testCluster.$(POD_NAMESPACE).svc.cluster.local:2380",
+				"--advertise-client-urls=https://$(POD_NAME).testCluster.$(POD_NAMESPACE).svc.cluster.local:2379",
+				"--key-file=" + serverKeyFile,
+				"--trusted-ca-file=" + serverTrustedCAFile,
+				"--client-cert-auth=true",
+				"--peer-cert-file=" + peerCertFile,
+				"--peer-key-file=" + peerKeyFile,
+				"--peer-trusted-ca-file=" + peerTrustedCAFile,
+				"--peer-client-cert-auth=true",
+				"--cert-file=/custom/cert-path",
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
-			result := createArgs(tt.clusterName, tt.etcdOptions)
+			result := createArgs(tt.clusterName, tt.etcdOptions, tt.tlsEnabled)
 			assert.Equal(t, tt.expectedResult, result)
 		})
 	}
@@ -582,17 +652,22 @@ func TestCreatingArgs(t *testing.T) {
 
 func TestClientEndpointForOrdinal(t *testing.T) {
 	tests := []struct {
-		ordinal  int
-		expected string
+		name       string
+		ordinal    int
+		tlsEnabled bool
+		expected   string
 	}{
-		{0, "http://test-cluster-0.test-cluster.default.svc.cluster.local:2379"},
-		{1, "http://test-cluster-1.test-cluster.default.svc.cluster.local:2379"},
-		{2, "http://test-cluster-2.test-cluster.default.svc.cluster.local:2379"},
+		{name: "ordinal 0 no TLS", ordinal: 0, tlsEnabled: false, expected: "http://test-cluster-0.test-cluster.default.svc.cluster.local:2379"},
+		{name: "ordinal 1 no TLS", ordinal: 1, tlsEnabled: false, expected: "http://test-cluster-1.test-cluster.default.svc.cluster.local:2379"},
+		{name: "ordinal 2 no TLS", ordinal: 2, tlsEnabled: false, expected: "http://test-cluster-2.test-cluster.default.svc.cluster.local:2379"},
+		{name: "ordinal 0 with TLS", ordinal: 0, tlsEnabled: true, expected: "https://test-cluster-0.test-cluster.default.svc.cluster.local:2379"},
+		{name: "ordinal 1 with TLS", ordinal: 1, tlsEnabled: true, expected: "https://test-cluster-1.test-cluster.default.svc.cluster.local:2379"},
+		{name: "ordinal 2 with TLS", ordinal: 2, tlsEnabled: true, expected: "https://test-cluster-2.test-cluster.default.svc.cluster.local:2379"},
 	}
 
 	for _, tt := range tests {
-		t.Run(fmt.Sprintf("ordinal %d", tt.ordinal), func(t *testing.T) {
-			result := clientEndpointForOrdinal("test-cluster", "default", tt.ordinal)
+		t.Run(tt.name, func(t *testing.T) {
+			result := clientEndpointForOrdinal("test-cluster", "default", tt.ordinal, tt.tlsEnabled)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -608,18 +683,22 @@ func TestClientEndpointsFromPods(t *testing.T) {
 		}
 	}
 
+	threePods := []*corev1.Pod{
+		makePod("test-sts", "default", 0),
+		makePod("test-sts", "default", 1),
+		makePod("test-sts", "default", 2),
+	}
+
 	tests := []struct {
-		name     string
-		pods     []*corev1.Pod
-		expected []string
+		name       string
+		pods       []*corev1.Pod
+		tlsEnabled bool
+		expected   []string
 	}{
 		{
-			name: "3 pods",
-			pods: []*corev1.Pod{
-				makePod("test-sts", "default", 0),
-				makePod("test-sts", "default", 1),
-				makePod("test-sts", "default", 2),
-			},
+			name:       "3 pods no TLS",
+			pods:       threePods,
+			tlsEnabled: false,
 			expected: []string{
 				"http://test-sts-0.test-sts.default.svc.cluster.local:2379",
 				"http://test-sts-1.test-sts.default.svc.cluster.local:2379",
@@ -627,15 +706,26 @@ func TestClientEndpointsFromPods(t *testing.T) {
 			},
 		},
 		{
-			name:     "no pods",
-			pods:     nil,
-			expected: []string(nil),
+			name:       "3 pods with TLS",
+			pods:       threePods,
+			tlsEnabled: true,
+			expected: []string{
+				"https://test-sts-0.test-sts.default.svc.cluster.local:2379",
+				"https://test-sts-1.test-sts.default.svc.cluster.local:2379",
+				"https://test-sts-2.test-sts.default.svc.cluster.local:2379",
+			},
+		},
+		{
+			name:       "no pods",
+			pods:       nil,
+			tlsEnabled: false,
+			expected:   []string(nil),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := clientEndpointsFromPods("test-sts", "default", tt.pods)
+			result := clientEndpointsFromPods("test-sts", "default", tt.pods, tt.tlsEnabled)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -705,4 +795,71 @@ func TestNextOrdinal(t *testing.T) {
 			assert.Equal(t, tt.want, got, "nextOrdinal(%v, %d) should return %d", tt.list, tt.expectedReplica, tt.want)
 		})
 	}
+}
+
+func TestBuildMemberPodTLSVolumes(t *testing.T) {
+	mkCluster := func(tls *ecv1alpha1.TLSCertificate, storage *ecv1alpha1.StorageSpec) *ecv1alpha1.EtcdCluster {
+		return &ecv1alpha1.EtcdCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "tls-cluster", Namespace: "default", UID: "1"},
+			Spec: ecv1alpha1.EtcdClusterSpec{
+				Size:        3,
+				Version:     "3.5.17",
+				TLS:         tls,
+				StorageSpec: storage,
+			},
+		}
+	}
+
+	t.Run("TLS cluster mounts both secrets readonly and adds TLS args", func(t *testing.T) {
+		ec := mkCluster(&ecv1alpha1.TLSCertificate{Provider: "auto"}, nil)
+		pod := buildMemberPod(ec, "tls-cluster-0", etcdClusterStateNew, "ignored")
+
+		container := pod.Spec.Containers[0]
+
+		// VolumeMounts: server + peer, both read-only.
+		var mounts []corev1.VolumeMount
+		for _, m := range container.VolumeMounts {
+			if m.Name == "server-secret" || m.Name == "peer-secret" {
+				mounts = append(mounts, m)
+			}
+		}
+		require.Len(t, mounts, 2, "expected server-secret and peer-secret mounts")
+		for _, m := range mounts {
+			assert.True(t, m.ReadOnly, "mount %s must be read-only", m.Name)
+		}
+		assert.Contains(t, []string{mounts[0].MountPath, mounts[1].MountPath}, serverCertMountDir)
+		assert.Contains(t, []string{mounts[0].MountPath, mounts[1].MountPath}, peerCertMountDir)
+
+		// Pod-level Volumes for both secrets.
+		volNames := map[string]bool{}
+		for _, v := range pod.Spec.Volumes {
+			volNames[v.Name] = true
+		}
+		assert.True(t, volNames["server-secret"], "server-secret volume present")
+		assert.True(t, volNames["peer-secret"], "peer-secret volume present")
+
+		// Args must include the TLS flags and https schemes.
+		args := strings.Join(container.Args, "\n")
+		assert.Contains(t, args, "--cert-file="+serverCertFile)
+		assert.Contains(t, args, "--peer-cert-file="+peerCertFile)
+		assert.Contains(t, args, "--listen-client-urls=https://0.0.0.0:2379")
+		assert.Contains(t, args, "--listen-peer-urls=https://0.0.0.0:2380")
+	})
+
+	t.Run("non-TLS cluster adds no secret mounts and stays http", func(t *testing.T) {
+		ec := mkCluster(nil, nil)
+		pod := buildMemberPod(ec, "tls-cluster-0", etcdClusterStateNew, "ignored")
+
+		for _, m := range pod.Spec.Containers[0].VolumeMounts {
+			assert.NotEqual(t, "server-secret", m.Name, "non-TLS pod must not mount server-secret")
+			assert.NotEqual(t, "peer-secret", m.Name, "non-TLS pod must not mount peer-secret")
+		}
+		for _, v := range pod.Spec.Volumes {
+			assert.NotEqual(t, "server-secret", v.Name)
+			assert.NotEqual(t, "peer-secret", v.Name)
+		}
+		args := strings.Join(pod.Spec.Containers[0].Args, "\n")
+		assert.NotContains(t, args, "--cert-file=")
+		assert.Contains(t, args, "--listen-client-urls=http://0.0.0.0:2379")
+	})
 }

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -2,6 +2,8 @@ package controller
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"log"
 	"net"
@@ -127,8 +129,8 @@ func getArgName(s string) string {
 	return strings.TrimSpace(s)
 }
 
-func createArgs(name string, etcdOptions []string) []string {
-	defaultArgs := defaultArgs(name)
+func createArgs(name string, etcdOptions []string, tlsEnabled bool) []string {
+	defaultArgs := defaultArgs(name, tlsEnabled)
 	if len(etcdOptions) > 0 {
 		for i := range etcdOptions {
 			argName := getArgName(etcdOptions[i])
@@ -175,11 +177,13 @@ func createHeadlessServiceIfNotExist(ctx context.Context, logger logr.Logger, c 
 }
 
 // peerEndpointForOrdinalIndex returns the member name and peer URL for a given
-// ordinal, used both to build ETCD_INITIAL_CLUSTER and to call AddMember.
+// ordinal, used both to build ETCD_INITIAL_CLUSTER and to call AddMember. The
+// peer URL scheme reflects the cluster's TLS configuration (https when TLS is
+// configured, http otherwise).
 func peerEndpointForOrdinalIndex(ec *ecv1alpha1.EtcdCluster, index int) (string, string) {
 	name := fmt.Sprintf("%s-%d", ec.Name, index)
-	return name, fmt.Sprintf("http://%s-%d.%s.%s.svc.cluster.local:2380",
-		ec.Name, index, ec.Name, ec.Namespace)
+	return name, fmt.Sprintf("%s://%s-%d.%s.%s.svc.cluster.local:2380",
+		clusterScheme(clusterTLSEnabled(ec)), ec.Name, index, ec.Name, ec.Namespace)
 }
 
 // ---------------------------------------------------------------------------
@@ -377,6 +381,61 @@ func patchCertificateSecret(ctx context.Context, ec *ecv1alpha1.EtcdCluster, c c
 		return fmt.Errorf("failed to update certificate secret with ownerReference: %w", err)
 	}
 	return nil
+}
+
+// verifySecretHasCA returns an error if the supplied certificate Secret lacks
+// a ca.crt data key. etcd requires --trusted-ca-file / --peer-trusted-ca-file,
+// so a Secret without the CA cannot drive a TLS-enabled cluster. The auto
+// provider always writes ca.crt; cert-manager only does so for CA-type Issuers
+// (SelfSigned/CA), so the missing-key case surfaces an actionable error rather
+// than mounting a non-existent file.
+func verifySecretHasCA(secret *corev1.Secret, provider string) error {
+	if _, ok := secret.Data[corev1.ServiceAccountRootCAKey]; !ok {
+		// corev1.ServiceAccountRootCAKey == "ca.crt".
+		return fmt.Errorf("certificate Secret %s (provider %s) is missing the ca.crt key; "+
+			"for cert-manager use a SelfSigned or CA Issuer (ACME does not emit ca.crt)",
+			secret.Name, provider)
+	}
+	return nil
+}
+
+// buildClientTLSConfig assembles the operator's TLS config from the cluster's
+// server certificate Secret. The operator reuses the server identity (tls.crt/tls.key)
+// and trusts the server CA (ca.crt), so the control plane can reach a TLS-enabled etcd client listener.
+func buildClientTLSConfig(ctx context.Context, ec *ecv1alpha1.EtcdCluster, c client.Client) (*tls.Config, error) {
+	secret := &corev1.Secret{}
+	if err := c.Get(ctx, client.ObjectKey{Name: getServerCertName(ec.Name), Namespace: ec.Namespace}, secret); err != nil {
+		return nil, fmt.Errorf("failed to get server certificate secret for client TLS: %w", err)
+	}
+
+	if err := verifySecretHasCA(secret, ec.Spec.TLS.Provider); err != nil {
+		return nil, err
+	}
+
+	certData, ok := secret.Data[corev1.TLSCertKey]
+	if !ok || len(certData) == 0 {
+		return nil, fmt.Errorf("server certificate secret %s is missing tls.crt", secret.Name)
+	}
+	keyData, ok := secret.Data[corev1.TLSPrivateKeyKey]
+	if !ok || len(keyData) == 0 {
+		return nil, fmt.Errorf("server certificate secret %s is missing tls.key", secret.Name)
+	}
+
+	keyPair, err := tls.X509KeyPair(certData, keyData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load server keypair for client TLS: %w", err)
+	}
+
+	caPool := x509.NewCertPool()
+	if !caPool.AppendCertsFromPEM(secret.Data[corev1.ServiceAccountRootCAKey]) {
+		return nil, fmt.Errorf("failed to parse ca.crt from server certificate secret %s", secret.Name)
+	}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{keyPair},
+		RootCAs:      caPool,
+		MinVersion:   tls.VersionTLS12,
+	}, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -160,6 +160,19 @@ func createHeadlessServiceIfNotExist(ctx context.Context, logger logr.Logger, c 
 				Spec: corev1.ServiceSpec{
 					ClusterIP: "None",
 					Selector:  etcdClusterLabels(ec),
+					// PublishNotReadyAddresses keeps each member's Pod IP in the
+					// headless Service's DNS A record set even while the Pod is
+					// NotReady (e.g. a newly created member whose etcd process is
+					// still bootstrapping). etcd v3.6's peer-port TLS handler runs
+					// checkCertSAN, which forward-DNS-resolves the cert's DNSName
+					// and checks the connecting Pod IP against the returned A
+					// records. Without this flag CoreDNS returns only Ready Pod
+					// IPs, so a new member's own IP is absent from the lookup
+					// result, every peer handshake it initiates is rejected
+					// ("tls: \"<ip>\" does not match any of DNSNames"), its etcd
+					// bootstrap dies, and the Pod stays NotReady forever — a
+					// chicken-and-egg deadlock during cluster scale-out.
+					PublishNotReadyAddresses: true,
 				},
 			}
 			if err := controllerutil.SetControllerReference(ec, headlessSvc, scheme); err != nil {

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -286,3 +286,62 @@ func TestCreateCMCertificateConfig(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// peerEndpointForOrdinalIndex — scheme reflects TLS configuration
+// ---------------------------------------------------------------------------
+
+func TestPeerEndpointForOrdinal(t *testing.T) {
+	mkCluster := func(name, namespace string, tls *ecv1alpha1.TLSCertificate) *ecv1alpha1.EtcdCluster {
+		return &ecv1alpha1.EtcdCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, UID: "1"},
+			Spec:       ecv1alpha1.EtcdClusterSpec{TLS: tls},
+		}
+	}
+
+	httpCluster := mkCluster("test-cluster", "default", nil)
+	httpsCluster := mkCluster("test-cluster", "default", &ecv1alpha1.TLSCertificate{Provider: "auto"})
+
+	// Replace the trailing scheme expectations; the member name is scheme-agnostic.
+	const wantName = "test-cluster-0"
+	httpName, httpURL := peerEndpointForOrdinalIndex(httpCluster, 0)
+	httpsName, httpsURL := peerEndpointForOrdinalIndex(httpsCluster, 0)
+
+	assert.Equal(t, wantName, httpName)
+	assert.Equal(t, wantName, httpsName)
+
+	assert.Equal(t, "http://test-cluster-0.test-cluster.default.svc.cluster.local:2380", httpURL)
+	assert.Equal(t, "https://test-cluster-0.test-cluster.default.svc.cluster.local:2380", httpsURL)
+}
+
+// ---------------------------------------------------------------------------
+// verifySecretHasCA — error path when a cert Secret lacks ca.crt
+// ---------------------------------------------------------------------------
+
+func TestVerifySecretHasCA(t *testing.T) {
+	mkSecret := func(data map[string][]byte) *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "x-tls", Namespace: "default"},
+			Data:       data,
+		}
+	}
+
+	t.Run("with ca.crt passes", func(t *testing.T) {
+		err := verifySecretHasCA(mkSecret(map[string][]byte{
+			"tls.crt": []byte("cert"),
+			"tls.key": []byte("key"),
+			"ca.crt":  []byte("ca"),
+		}), string(certificate.Auto))
+		assert.NoError(t, err)
+	})
+
+	t.Run("without ca.crt errors with provider hint", func(t *testing.T) {
+		err := verifySecretHasCA(mkSecret(map[string][]byte{
+			"tls.crt": []byte("cert"),
+			"tls.key": []byte("key"),
+		}), string(certificate.CertManager))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ca.crt")
+		assert.Contains(t, err.Error(), "cert-manager")
+	})
+}

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -54,6 +54,16 @@ func TestCreateHeadlessServiceIfNotExist(t *testing.T) {
 			"app":        "test-etcd",
 			"controller": "test-etcd",
 		}, service.Spec.Selector)
+		// PublishNotReadyAddresses must be true so that during a cluster scale-out
+		// (e.g. 1->3 nodes), CoreDNS returns the NotReady new member's Pod IP in
+		// the headless Service's A record set. etcd v3.6's peer-port checkCertSAN
+		// does a forward-DNS lookup of the cert's DNSName against the connecting
+		// pod IP; without this flag, the new member's IP is missing from the
+		// lookup result, peer TLS handshake fails ("tls: \"<ip>\" does not match any
+		// of DNSNames"), etcd bootstrap dies, and the new pod never becomes Ready.
+		// See analysis in internal/controller/utils.go createHeadlessServiceIfNotExist.
+		assert.True(t, service.Spec.PublishNotReadyAddresses,
+			"headless Service for an etcd cluster MUST publish not-ready addresses; otherwise peer-bootstrap TLS hangs forever")
 		require.Len(t, service.OwnerReferences, 1)
 		assert.Equal(t, ec.Name, service.OwnerReferences[0].Name)
 	})

--- a/test/e2e/auto_provider_test.go
+++ b/test/e2e/auto_provider_test.go
@@ -201,7 +201,7 @@ func TestClusterAutoCertCreation(t *testing.T) {
 	feature.Assess("Verify Data Operations",
 		func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 			// verify etcdCluster is accessible via client certificate with put and get
-			verifyDataOperations(t, c, etcdClusterName, "test-key", "test-value")
+			verifyDataOperations(t, c, etcdClusterName, "test-key", "test-value", true)
 			return ctx
 		},
 	)

--- a/test/e2e/cert_manager_test.go
+++ b/test/e2e/cert_manager_test.go
@@ -269,7 +269,7 @@ func TestClusterCertCreation(t *testing.T) {
 	feature.Assess("Verify Data Operations",
 		func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 			// verify etcdCluster is accessible via client certificate with put and get
-			verifyDataOperations(t, c, etcdClusterName, "test-key", "test-value")
+			verifyDataOperations(t, c, etcdClusterName, "test-key", "test-value", true)
 			return ctx
 		},
 	)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -312,7 +312,7 @@ func TestPodRecovery(t *testing.T) {
 			}
 
 			// Verify cluster replication works across recovered pod
-			verifyDataOperations(t, c, etcdClusterName, "replication-test", "value")
+			verifyDataOperations(t, c, etcdClusterName, "replication-test", "value", false)
 
 			stdout, stderr, err := execInPod(t, c, targetPodName, namespace, []string{"etcdctl", "get", "replication-test"})
 			if err != nil {
@@ -380,7 +380,7 @@ func TestEtcdClusterFunctionality(t *testing.T) {
 	})
 
 	feature.Assess("test data operations", func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-		verifyDataOperations(t, c, etcdClusterName, "test-key", "test-value")
+		verifyDataOperations(t, c, etcdClusterName, "test-key", "test-value", false)
 		return ctx
 	})
 

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -109,18 +109,25 @@ func waitForPodReadiness(t *testing.T, c *envconf.Config, name string, expectedR
 	var pods corev1.PodList
 	return wait.For(func(ctx context.Context) (bool, error) {
 		if err := c.Client().Resources().List(ctx, &pods, resources.WithLabelSelector(label)); err != nil {
+			t.Logf("failed to list pods by label %s, %s", label, err)
 			return false, nil
 		}
 
-		if len(pods.Items) != expectedReplicas {
-			return false, nil
-		}
-
+		var readyCnt = 0
+		var unreadyPods []string
 		for _, pod := range pods.Items {
 			if !podReady(&pod) {
-				return false, nil
+				unreadyPods = append(unreadyPods, pod.Name)
+			} else {
+				readyCnt++
 			}
 		}
+		if readyCnt != expectedReplicas {
+			t.Logf("found pods(%d/%d/%d) by label(%s). unready pods: %s",
+				readyCnt, len(pods.Items), expectedReplicas, label, unreadyPods)
+			return false, nil
+		}
+
 		return true, nil
 	}, wait.WithTimeout(5*time.Minute), wait.WithInterval(10*time.Second))
 }
@@ -274,26 +281,50 @@ func getClusterEndpointHashKVs(t *testing.T, c *envconf.Config, podName string) 
 	return out
 }
 
-func verifyDataOperations(t *testing.T, c *envconf.Config, etcdClusterName, testKey, testValue string) {
+const (
+	etcdServerCertMountDir = "/etc/etcd-certs/server"
+
+	etcdServerCertFile = etcdServerCertMountDir + "/tls.crt"
+	etcdServerKeyFile  = etcdServerCertMountDir + "/tls.key"
+	etcdServerCAFile   = etcdServerCertMountDir + "/ca.crt"
+)
+
+func etcdctlCmd(podName, etcdClusterName, namespace string, tlsEnabled bool) []string {
+	args := []string{"etcdctl"}
+	if tlsEnabled {
+		endpoint := fmt.Sprintf("https://%s.%s.%s.svc.cluster.local:2379",
+			podName, etcdClusterName, namespace)
+		args = append(args,
+			"--cacert="+etcdServerCAFile,
+			"--cert="+etcdServerCertFile,
+			"--key="+etcdServerKeyFile,
+			"--endpoints="+endpoint,
+		)
+	}
+	return args
+}
+
+func verifyDataOperations(t *testing.T, c *envconf.Config, etcdClusterName, key, val string, tlsEnabled bool) {
 	podName := fmt.Sprintf("%s-0", etcdClusterName)
 
 	// Write key-value data
-	command := []string{"etcdctl", "put", testKey, testValue}
+	cmd := etcdctlCmd(podName, etcdClusterName, namespace, tlsEnabled)
+	command := append(cmd, "put", key, val)
 	_, stderr, err := execInPod(t, c, podName, namespace, command)
 	if err != nil {
 		t.Fatalf("Failed to write data: %v, stderr: %s", err, stderr)
 	}
 
 	// Read key-value data
-	command = []string{"etcdctl", "get", testKey}
+	command = append(cmd, "get", key)
 	stdout, stderr, err := execInPod(t, c, podName, namespace, command)
 	if err != nil {
 		t.Fatalf("Failed to read data: %v, stderr: %s", err, stderr)
 	}
 
 	lines := strings.Split(strings.TrimSpace(stdout), "\n")
-	if len(lines) < 2 || lines[0] != testKey || lines[1] != testValue {
-		t.Errorf("Expected key-value pair [%s=%s], but got output: %s", testKey, testValue, stdout)
+	if len(lines) < 2 || lines[0] != key || lines[1] != val {
+		t.Errorf("Expected key-value pair [%s=%s], but got output: %s", key, val, stdout)
 	}
 }
 

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -110,6 +111,9 @@ func waitForPodReadiness(t *testing.T, c *envconf.Config, name string, expectedR
 	return wait.For(func(ctx context.Context) (bool, error) {
 		if err := c.Client().Resources().List(ctx, &pods, resources.WithLabelSelector(label)); err != nil {
 			t.Logf("failed to list pods by label %s, %s", label, err)
+			for _, pod := range pods.Items {
+				dumpPodLogs(context.TODO(), t, c, &pod, 500)
+			}
 			return false, nil
 		}
 
@@ -366,4 +370,22 @@ func httpViaProxy(ctx context.Context, r *rest.Request, pod corev1.Pod, failpoin
 		Body(strings.NewReader(term)).
 		Do(ctx)
 	return result.Error()
+}
+
+// dumpPodLogs streams the last `tailLine` lines of `pod`'s log via the apiserver and pipes them into t.Logf
+func dumpPodLogs(ctx context.Context, t *testing.T, c *envconf.Config, pod *corev1.Pod, tailLine int64) {
+	t.Helper()
+	if pod == nil {
+		return
+	}
+	client := kubernetes.NewForConfigOrDie(c.Client().RESTConfig())
+	req := client.CoreV1().Pods(namespace).GetLogs(pod.Name, &corev1.PodLogOptions{TailLines: &tailLine})
+	stream, streamErr := req.Stream(ctx)
+	if streamErr != nil {
+		t.Logf("failed to stream log for pod %s/%s: %s", pod.Namespace, pod.Name, streamErr)
+		return
+	}
+	body, _ := io.ReadAll(stream)
+	_ = stream.Close()
+	t.Logf("pod %s/%s log tail:\n%s", pod.Namespace, pod.Name, string(body))
 }


### PR DESCRIPTION
Changes:
1. enable server-side and client-side mTLS communication (~400 lines)
2. fix verifyDataOperations in e2e tests. The old one talks to etcdserver without TLS.
3. add dumpPodLogs helper function in e2e tests.
4. publish not-ready addresses on etcd headless Service.

1,2,4 have to stay togethor, otherwise the e2e tests will fail. 
3 is a super minor change, so I put it in this PR.

### Questions might be asked:

**Why set PublishNotReadyAddresses=true in headless Service?**

In etcd v3.6, the peer listener performs an additional custom `checkSAN` validation after the Go TLS handshake (`client/pkg/transport/listener.go`). This validation conducts forward and reverse DNS lookups on the client certificate's SAN entries and matches the results against the connecting pod's actual IP. It is independent of standard certificate chain validation and cannot be disabled via flags on the peer port.

Headless Services have a default `publishNotReadyAddresses: false`. During bootstrap, a new member is in a NotReady state. Consequently, CoreDNS excludes its IP from the Headless Service's A records.

As a result, the new member's own IP never appears in the forward DNS lookup results. `checkSAN` rejects every peer handshake with the error tls: "<ip>" does not match any of DNSNames. etcd fails to start and returns EOF, causing the pod to enter a `CrashLoopBackOff` state. Since subsequent startup attempts trigger the same check before the pod becomes `Ready`, it can never recover. This creates a chicken-and-egg deadlock: the pod must be Ready to pass the TLS handshake, but it needs to pass the TLS handshake to become Ready.

e2e test `TestClusterAutoCertCreation/cluster-auto-cert-creation/Wait_for_etcd_pods_readiness` fails when `publishNotReadyAddresses: false`.

pod-0 logs contain errors like 
```
{"level":"warn","ts":"2026-07-21T06:45:30.310841Z","caller":"embed/config_logging.go:185","msg":"rejected connection on peer endpoint","remote-addr":"10.244.0.8:43166","server-name":"etcd-cluster-auto-cert-0.etcd-cluster-auto-cert.etcd-operator-system.svc.cluster.local","ip-addresses":[],"dns-names":["etcd-operator-system","*.etcd-cluster-auto-cert.etcd-operator-system.svc.cluster.local","etcd-cluster-auto-cert.etcd-operator-system.svc.cluster.local"],"error":"tls: \"10.244.0.8\" does not match any of DNSNames [\"etcd-operator-system\" \"*.etcd-cluster-auto-cert.etcd-operator-system.svc.cluster.local\" \"etcd-cluster-auto-cert.etcd-operator-system.svc.cluster.local\"] (lookup etcd-operator-system on 10.96.0.10:53: no such host)"}
```

pod-1 logs:
```
{"level":"warn","ts":"2026-07-21T06:45:30.310937Z","caller":"etcdserver/cluster_util.go:86","msg":"failed to get cluster response","address":"https://etcd-cluster-auto-cert-0.etcd-cluster-auto-cert.etcd-operator-system.svc.cluster.local:2380/members","error":"Get \"https://etcd-cluster-auto-cert-0.etcd-cluster-auto-cert.etcd-operator-system.svc.cluster.local:2380/members\": EOF"}
{"level":"error","ts":"2026-07-21T06:45:30.311297Z","caller":"etcdserver/server.go:309","msg":"bootstrap failed","error":"cannot fetch cluster info from peer urls: could not retrieve cluster information from the given URLs","stacktrace":"go.etcd.io/etcd/server/v3/etcdserver.NewServer\n\tgo.etcd.io/etcd/server/v3/etcdserver/server.go:309\ngo.etcd.io/etcd/server/v3/embed.StartEtcd\n\tgo.etcd.io/etcd/server/v3/embed/etcd.go:262\ngo.etcd.io/etcd/server/v3/etcdmain.startEtcd\n\tgo.etcd.io/etcd/server/v3/etcdmain/etcd.go:207\ngo.etcd.io/etcd/server/v3/etcdmain.startEtcdOrProxyV2\n\tgo.etcd.io/etcd/server/v3/etcdmain/etcd.go:129\ngo.etcd.io/etcd/server/v3/etcdmain.Main\n\tgo.etcd.io/etcd/server/v3/etcdmain/main.go:40\nmain.main\n\tgo.etcd.io/etcd/server/v3/main.go:31\nruntime.main\n\truntime/proc.go:285"}
```

sub-task 3 of https://github.com/etcd-io/etcd-operator/pull/428
link to https://github.com/etcd-io/etcd-operator/issues/409 and https://github.com/etcd-io/etcd-operator/issues/362

/cc @ahrtr @nwnt 