### PR TITLE
fix(controller): align etcdcluster hash between controller and tests

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -65,8 +65,8 @@ func main() {
 	var secureMetrics bool
 	var enableHTTP2 bool
 	var tlsOpts []func(*tls.Config)
-	flag.StringVar(&imageRegistry, "image-registry", "gcr.io/etcd-development/etcd",
-		"The container registry to pull etcd images from. Defaults to gcr.io/etcd-development/etcd.")
+	flag.StringVar(&imageRegistry, "image-registry", controller.DefaultImageRegistry,
+		"The container registry to pull etcd images from. Defaults to "+controller.DefaultImageRegistry+".")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")

--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -165,9 +165,10 @@ func (r *EtcdClusterReconciler) fetchAndValidateState(ctx context.Context, req c
 		return nil, ctrl.Result{}, err
 	}
 
-	if ec.Spec.ImageRegistry == "" {
-		ec.Spec.ImageRegistry = r.ImageRegistry
-	}
+	// Apply operator-side defaults so downstream phases (hash, pod builder,
+	// cert wiring) all see consistent values regardless of which fields the
+	// user left empty.
+	r.PopulateDefaultValues(ec)
 
 	pods, err := listOwnedPods(ctx, r.Client, ec)
 	if err != nil {
@@ -176,6 +177,17 @@ func (r *EtcdClusterReconciler) fetchAndValidateState(ctx context.Context, req c
 	}
 
 	return &reconcileState{cluster: ec, pods: pods}, ctrl.Result{}, nil
+}
+
+// PopulateDefaultValues mutates `ec` in place to apply operator-side defaults
+// for any EtcdClusterSpec field that the user left empty. Defaults are sourced
+// from the reconciler instance (e.g. its ImageRegistry), keeping the reconcile
+// loop the single owner of how a partially-specified Spec becomes a fully
+// resolved one.
+func (r *EtcdClusterReconciler) PopulateDefaultValues(ec *ecv1alpha1.EtcdCluster) {
+	if ec.Spec.ImageRegistry == "" {
+		ec.Spec.ImageRegistry = r.ImageRegistry
+	}
 }
 
 // buildReconcileClientTLS builds the operator's etcd-client TLS Config for a

--- a/internal/controller/etcdcluster_test.go
+++ b/internal/controller/etcdcluster_test.go
@@ -50,6 +50,13 @@ func TestEtcdClusterHash(t *testing.T) {
 		c.Spec.EtcdOptions = []string{"--auto-compaction-retention=1", "--max-txn-ops=10000"}
 		return c
 	}
+	withImageRegistryChanged := func() *v1alpha1.EtcdCluster {
+		// ImageRegistry is a user-declarable spec field, so changing it must
+		// trigger a pod roll via hash divergence.
+		c := baseCluster.DeepCopy()
+		c.Spec.ImageRegistry = "registry.example.com/etcd"
+		return c
+	}
 	withNilTemplate := func() *v1alpha1.EtcdCluster {
 		c := baseCluster.DeepCopy()
 		c.Spec.PodTemplate = nil
@@ -100,6 +107,11 @@ func TestEtcdClusterHash(t *testing.T) {
 			name:        "Version check - Modifying etcd version must NOT change the hash",
 			cluster:     withVersionChanged(),
 			expectEqual: true,
+		},
+		{
+			name:        "Core Spec Change - Modifying ImageRegistry must force a brand new hash",
+			cluster:     withImageRegistryChanged(),
+			expectEqual: false,
 		},
 	}
 

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -30,6 +30,10 @@ import (
 const (
 	etcdDataDir = "/var/lib/etcd"
 	volumeName  = "etcd-data"
+
+	// DefaultImageRegistry is the fallback container image registry used by
+	// the CLI flag default and by tests that wire an EtcdClusterReconciler.
+	DefaultImageRegistry = "gcr.io/etcd-development/etcd"
 )
 
 type etcdClusterState string

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -462,6 +462,11 @@ func TestClusterHash(t *testing.T) {
 			t.Fatalf("unable to fetch etcd cluster: %s", err)
 		}
 
+		// The EtcdClusterHash spec.imageRegistry was mutated before
+		// computing EtcdClusterHash for the pod annotation. So we have to
+		// apply the same logic (setting default values) before hashing.
+		reconciler := &controller.EtcdClusterReconciler{ImageRegistry: controller.DefaultImageRegistry}
+		reconciler.PopulateDefaultValues(etcdCluster)
 		clusterHash = controller.EtcdClusterHash(etcdCluster)
 		return ctx
 	})


### PR DESCRIPTION
## Problem

  - **Controller reconcile.** `fetchAndValidateState` filled `ec.Spec.ImageRegistry = r.ImageRegistry` in place, and `buildMemberPod` later called `EtcdClusterHash(ec)` to compute the  pod-template hash annotation.
  - **Unit / e2e tests.** `TestEtcdClusterHash` and e2e `TestClusterHash` just `Get`'d the cluster and called `EtcdClusterHash(etcdCluster)` directly, with no default fill, so `ec.Spec.ImageRegistry` was still `""`.

  A cluster whose user left `ImageRegistry` empty therefore produced **different** hashes on the controller path than on the test paths. That broke the contract that the pod hash
  annotation should match what the tests expect the operator to produce, and it meant the controller and the test could disagree on whether a spec change required a pod roll.

  ## Fix

  Centralize the operator-side defaulting into a new `FillEtcdClusterDefaultValues(ec, defaultImageRegistry)` helper in `internal/controller/utils.go`, and call it from both paths so `EtcdClusterHash` always sees the same input.

  The helper mutates the spec in memory only; the user-owned `Spec` is never persisted back, so the CR is not polluted with operator policy. Currently it fills only `ImageRegistry`, but the helper is the natural home for any future operator-side defaults (TLS material, storage class, etc.).

  Another fix is to ignore `ImageRegistry` when hashing, by adding `clusterSpec.ImageRegistry = ""`. This will ignore changes of `ImageRegistry` unless introducing a dedicated logic for it. So I did not choose this fix.

Link to https://github.com/etcd-io/etcd-operator/pull/445

/cc @ahrtr 