### PR TITLE
Add MoveLeader function

### DIFF
--- a/internal/etcdutils/etcdutils.go
+++ b/internal/etcdutils/etcdutils.go
@@ -114,8 +114,8 @@ func FindLeaderStatus(healthInfos []EpHealth, logger logr.Logger) (uint64, *clie
 	if leaderStatus != nil {
 		logger.Info("Leader found", "leaderID", leader)
 	}
-	return leader, leaderStatus
 
+	return leader, leaderStatus
 }
 
 func FindLearnerStatus(healthInfos []EpHealth, logger logr.Logger) (uint64, *clientv3.StatusResponse) {
@@ -247,5 +247,18 @@ func RemoveMember(cfg ClientConfig, memberID uint64) error {
 	defer func() { closeAndCancel(c, cancel) }()
 
 	_, err = c.MemberRemove(ctx, memberID)
+	return err
+}
+
+func MoveLeader(cfg ClientConfig, memberId uint64) error {
+	c, err := clientv3.New(cfg.buildConfig())
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer func() { closeAndCancel(c, cancel) }()
+
+	_, err = c.MoveLeader(ctx, memberId)
 	return err
 }


### PR DESCRIPTION
As part of the custom controller to handle config update, we need to move the leader to a different existing member.  This PR is to add such functionality, with unit tests.  New test setup is also required as all of the existing unit tests only test a single member.  However, to move a leader, you need a cluster with more than one member.

@silentred @ahrtr 