### PR TITLE
bump go 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module go.etcd.io/etcd-operator
 
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/cert-manager/cert-manager v1.21.0

--- a/tools/mod/go.mod
+++ b/tools/mod/go.mod
@@ -2,7 +2,7 @@ module go.etcd.io/etcd-operator/tools/mod
 
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/elastic/crd-ref-docs v0.3.0


### PR DESCRIPTION
Part of https://github.com/etcd-io/etcd/issues/22283

Dockerfile dependency PR - https://github.com/etcd-io/etcd-operator/pull/459