### PR TITLE
feat: support normal member scale-out via the shared member lifecycle

### DIFF
--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -206,7 +206,7 @@ func (r *EtcdClusterReconciler) fetchAndValidateState(ctx context.Context, req c
 		return nil, ctrl.Result{RequeueAfter: requeueDuration}, nil
 	}
 
-	pods, err := listOwnedPods(ctx, r.Client, ec)
+	pods, err := listOwnedPods(ctx, r.Client, ec, members)
 	if err != nil {
 		logger.Error(err, "Failed to list pods. Requesting requeue")
 		return nil, ctrl.Result{RequeueAfter: requeueDuration}, nil
@@ -301,8 +301,8 @@ func (r *EtcdClusterReconciler) ensureClusterPrereqs(ctx context.Context, s *rec
 			logger.Error(err, "Failed to create Client Certificate.")
 		}
 		// Server/peer certs must exist before buildReconcileClientTLS below reads
-		// the server cert Secret. createMemberPod also calls this (idempotently)
-		// once a member's pod is created.
+		// the server cert Secret. reconcileProvisioning also calls this
+		// (idempotently) before creating a member's Pod.
 		// TODO: buildReconcileClientTLS reuses this member server
 		// certificate as the operator's own client identity (see its comment
 		// in utils.go) — that's the wrong cert for the operator to depend on;
@@ -370,11 +370,14 @@ func (r *EtcdClusterReconciler) refreshClusterState(ctx context.Context, s *reco
 // to the next; only an item that actually takes a mutating action ends the
 // loop.
 //
-// Steps 4-8 are TODO no-ops in this milestone (M2) — the mechanics they'd
+// Steps 4-7 are TODO no-ops in this milestone (M2) — the mechanics they'd
 // trigger (join/promote/repair/leave, CORRUPT/NOSPACE remediation,
 // lost-quorum recovery) land in M3-M5 — but the detection that decides
 // *whether* a step claims the loop is real, so the priority order itself is
 // reviewable now, ahead of any of that behavior landing.
+// Item 8 is partially implemented: the provisioning case reconciles one
+// EtcdMember at a time until it is Ready; the replacing case (§4.9 item 8's
+// second bullet) lands in a follow-up PR.
 func (r *EtcdClusterReconciler) dispatch(ctx context.Context, s *reconcileState) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
@@ -439,13 +442,10 @@ func (r *EtcdClusterReconciler) dispatch(ctx context.Context, s *reconcileState)
 	// and the cluster is still unhealthy (M5).
 
 	// 8. Advance whatever's left not-Ready (Pending/Provisioning/Replacing).
-	// An existing learner always wins this slot (requirement 11).
-	if notReady := pickNotReadyMember(s.members); notReady != nil {
-		// TODO: §4.9 item 8 — promote if a caught-up learner,
-		// otherwise continue the member's join/replace progress (§4.6, M3).
-		logger.Info("Member not Ready; join/promotion not implemented yet",
-			"member", notReady.Name, "phase", notReady.Status.Phase)
-		return ctrl.Result{RequeueAfter: requeueDuration}, nil
+	// An existing learner always wins this slot (requirement 11); with more
+	// than one not-ready member but no learner, the lowest ordinal wins.
+	if notReady := pickNotReadyMember(s); notReady != nil {
+		return r.reconcileEtcdMember(ctx, s, notReady)
 	}
 
 	// 9. Everything existing is Ready (§4.2's gate), so update-config/scale/upgrade
@@ -537,11 +537,8 @@ func (r *EtcdClusterReconciler) updateConfig(ctx context.Context, s *reconcileSt
 // the lowest gap, else max+1) and always removing the highest ordinal first
 // on scale-in (requirement 2).
 //
-// Creating the EtcdMember object — and, for ordinal 0, its cert/PVC/Pod
-// directly (the bootstrap special case, §4.6 step 2) — is the only mechanic
-// this milestone (M2) implements. For every other ordinal, the general join
-// mechanics (MemberAdd + cert/PVC/Pod) are §4.6's TODO (M3), so a
-// newly-created EtcdMember simply sits at Phase: Pending until then. Scale-in
+// Scale-out only creates one Pending EtcdMember. The shared member lifecycle
+// owns bootstrap, member addition, Pod creation, and learner promotion. Scale-in
 // deletes the EtcdMember directly; the finalizer (§4.3) blocks its actual
 // removal until the Terminating leave sequence (§4.6, M3) runs.
 func (r *EtcdClusterReconciler) scaleCluster(ctx context.Context, s *reconcileState) (ctrl.Result, error) {
@@ -558,20 +555,8 @@ func (r *EtcdClusterReconciler) scaleCluster(ctx context.Context, s *reconcileSt
 	if currentCount < desiredSize {
 		ordinal := nextOrdinal(memberOrdinals(s.members))
 		logger.Info("[Scale out] creating a new EtcdMember", "ordinal", ordinal)
-		member, err := createEtcdMember(ctx, r.Client, s.cluster, ordinal, r.Scheme)
-		if err != nil {
+		if _, err := createEtcdMember(ctx, r.Client, s.cluster, ordinal, r.Scheme); err != nil {
 			return ctrl.Result{}, err
-		}
-
-		if ordinal == 0 {
-			// Bootstrap special case: the first member starts as a full
-			// voting member with its Pod created directly — there's no
-			// cluster yet to MemberAdd(learner) into.
-			if err := createMemberPod(ctx, logger, r.Client, s.cluster, ordinal, r.Scheme); err != nil {
-				return ctrl.Result{}, err
-			}
-		} else {
-			logger.Info("Join mechanics not implemented yet; member stays Pending", "member", member.Name)
 		}
 		return ctrl.Result{RequeueAfter: requeueDuration}, nil
 	}
@@ -785,8 +770,6 @@ func (r *EtcdClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&ecv1alpha1.EtcdCluster{}).
 		Owns(&ecv1alpha1.EtcdMember{}).
-		Owns(&corev1.Pod{}).
-		Owns(&corev1.PersistentVolumeClaim{}).
 		Owns(&corev1.Service{})
 
 	if isCertManagerCRDPresent(mgr) {

--- a/internal/controller/etcdcluster_controller_test.go
+++ b/internal/controller/etcdcluster_controller_test.go
@@ -34,16 +34,35 @@ import (
 )
 
 // TestFetchAndValidateState verifies the fetchAndValidateState helper across
-// a range of conditions (missing cluster, no pods, pods owned by this cluster,
-// and pods owned by a different cluster).
+// a range of conditions (missing cluster, no pods, pods owned via their
+// EtcdMember by this cluster, and pods owned via a member of a different
+// cluster).
 func TestFetchAndValidateState(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
 	_ = ecv1alpha1.AddToScheme(scheme)
 
-	// helper to build a minimal owned pod with a specific etcd image tag.
-	ownedPod := func(clusterName, namespace, uid, imageTag string) *corev1.Pod {
-		return &corev1.Pod{
+	// helper to build a minimal EtcdMember together with its Pod (controlled
+	// by that member), running a specific etcd image tag. The member's
+	// controller reference points at an EtcdCluster with the given UID.
+	memberAndPod := func(clusterName, namespace, clusterUID, imageTag string) (*ecv1alpha1.EtcdMember, *corev1.Pod) {
+		member := &ecv1alpha1.EtcdMember{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterName + "-0",
+				Namespace: namespace,
+				Labels:    clusterNameLabels(clusterName),
+				UID:       types.UID("member-" + clusterName + "-0"),
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: ecv1alpha1.GroupVersion.String(),
+					Kind:       "EtcdCluster",
+					Name:       clusterName,
+					UID:        types.UID(clusterUID),
+					Controller: new(true),
+				}},
+			},
+			Spec: ecv1alpha1.EtcdMemberSpec{ClusterName: clusterName, Ordinal: 0},
+		}
+		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      clusterName + "-0",
 				Namespace: namespace,
@@ -53,10 +72,10 @@ func TestFetchAndValidateState(t *testing.T) {
 				},
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion: ecv1alpha1.GroupVersion.String(),
-					Kind:       "EtcdCluster",
-					Name:       clusterName,
-					UID:        types.UID(uid),
-					Controller: pointerToBool(true),
+					Kind:       "EtcdMember",
+					Name:       member.Name,
+					UID:        member.UID,
+					Controller: new(true),
 				}},
 			},
 			Spec: corev1.PodSpec{
@@ -65,14 +84,18 @@ func TestFetchAndValidateState(t *testing.T) {
 				},
 			},
 		}
+		return member, pod
 	}
+	ownedMember, ownedPod := memberAndPod("etcd", "default", "2", "3.5.17")
+	foreignMember, foreignPod := memberAndPod("etcd", "default", "other-uid", "3.5.17")
 
 	cases := []struct {
-		name   string
-		req    ctrl.Request
-		ec     *ecv1alpha1.EtcdCluster
-		pods   []*corev1.Pod
-		assert func(t *testing.T, state *reconcileState, res ctrl.Result, err error)
+		name    string
+		req     ctrl.Request
+		ec      *ecv1alpha1.EtcdCluster
+		members []*ecv1alpha1.EtcdMember
+		pods    []*corev1.Pod
+		assert  func(t *testing.T, state *reconcileState, res ctrl.Result, err error)
 	}{
 		{
 			name: "EtcdCluster Not Found",
@@ -104,8 +127,9 @@ func TestFetchAndValidateState(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "etcd", Namespace: "default", UID: "2"},
 				Spec:       ecv1alpha1.EtcdClusterSpec{Size: 1, Version: "3.5.17"},
 			},
-			pods: []*corev1.Pod{ownedPod("etcd", "default", "2", "3.5.17")},
-			req:  ctrl.Request{NamespacedName: types.NamespacedName{Name: "etcd", Namespace: "default"}},
+			members: []*ecv1alpha1.EtcdMember{ownedMember},
+			pods:    []*corev1.Pod{ownedPod},
+			req:     ctrl.Request{NamespacedName: types.NamespacedName{Name: "etcd", Namespace: "default"}},
 			assert: func(t *testing.T, state *reconcileState, res ctrl.Result, err error) {
 				require.NotNil(t, state)
 				assert.Equal(t, "etcd", state.cluster.Name)
@@ -120,9 +144,11 @@ func TestFetchAndValidateState(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "etcd", Namespace: "default", UID: "3"},
 				Spec:       ecv1alpha1.EtcdClusterSpec{Size: 1, Version: "3.5.17"},
 			},
-			// Pod has different UID owner → filtered out by listOwnedPods.
-			pods: []*corev1.Pod{ownedPod("etcd", "default", "other-uid", "3.5.17")},
-			req:  ctrl.Request{NamespacedName: types.NamespacedName{Name: "etcd", Namespace: "default"}},
+			// The Pod's controlling member belongs to a different cluster
+			// (UID mismatch) → filtered out by listOwnedPods.
+			members: []*ecv1alpha1.EtcdMember{foreignMember},
+			pods:    []*corev1.Pod{foreignPod},
+			req:     ctrl.Request{NamespacedName: types.NamespacedName{Name: "etcd", Namespace: "default"}},
 			assert: func(t *testing.T, state *reconcileState, res ctrl.Result, err error) {
 				require.NotNil(t, state)
 				assert.Empty(t, state.pods)
@@ -139,6 +165,9 @@ func TestFetchAndValidateState(t *testing.T) {
 			objs := []client.Object{}
 			if tc.ec != nil {
 				objs = append(objs, tc.ec)
+			}
+			for _, member := range tc.members {
+				objs = append(objs, member)
 			}
 			for _, pod := range tc.pods {
 				objs = append(objs, pod)
@@ -303,11 +332,10 @@ func TestEnsureClusterPrereqs(t *testing.T) {
 	})
 }
 
-// TestScaleClusterBootstrap verifies the scale-out dispatcher step's
-// bootstrap special case (§4.6 step 2): with zero existing members, it
-// creates EtcdMember ordinal 0 and its Pod directly. For any other ordinal,
-// only the EtcdMember shell is created — join mechanics are M3's TODO.
-func TestScaleClusterBootstrap(t *testing.T) {
+// TestScaleCluster verifies that scaling only changes the desired set of
+// EtcdMember objects. Provisioning is owned by reconcileEtcdMember and must
+// never run from this policy-level helper.
+func TestScaleCluster(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
 	_ = ecv1alpha1.AddToScheme(scheme)
@@ -324,7 +352,7 @@ func TestScaleClusterBootstrap(t *testing.T) {
 		},
 	}
 
-	t.Run("No members — creates EtcdMember ordinal 0 and its Pod", func(t *testing.T) {
+	t.Run("`scaleCluster` creates exactly one Pending member without a Pod", func(t *testing.T) {
 		ctx := t.Context()
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
@@ -345,11 +373,15 @@ func TestScaleClusterBootstrap(t *testing.T) {
 		assert.Contains(t, member.Finalizers, memberCleanupFinalizer)
 		require.Len(t, member.OwnerReferences, 1)
 		assert.Equal(t, ec.Name, member.OwnerReferences[0].Name)
+		assert.Equal(t, ec.Name, member.Labels[clusterNameLabel])
+
+		members := &ecv1alpha1.EtcdMemberList{}
+		require.NoError(t, fakeClient.List(ctx, members, client.InNamespace(ec.Namespace)))
+		assert.Len(t, members.Items, 1)
 
 		pod := &corev1.Pod{}
-		require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: "etcd-0", Namespace: ec.Namespace}, pod))
-		require.Len(t, pod.OwnerReferences, 1)
-		assert.Equal(t, ec.Name, pod.OwnerReferences[0].Name)
+		err = fakeClient.Get(ctx, client.ObjectKey{Name: "etcd-0", Namespace: ec.Namespace}, pod)
+		assert.True(t, apierrors.IsNotFound(err), "scaleCluster must not provision the bootstrap Pod")
 	})
 
 	t.Run("One ready member — creates EtcdMember shell only, no Pod", func(t *testing.T) {
@@ -364,7 +396,7 @@ func TestScaleClusterBootstrap(t *testing.T) {
 					Kind:       "EtcdCluster",
 					Name:       ec.Name,
 					UID:        ec.UID,
-					Controller: pointerToBool(true),
+					Controller: new(true),
 				}},
 			},
 			Spec:   ecv1alpha1.EtcdMemberSpec{ClusterName: ec.Name, Ordinal: 0, Version: ec.Spec.Version},
@@ -501,7 +533,11 @@ func TestDispatch(t *testing.T) {
 			Status:     ecv1alpha1.EtcdMemberStatus{Phase: ecv1alpha1.EtcdMemberPending},
 		}
 
-		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec, &pending).Build()
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&ecv1alpha1.EtcdMember{}).
+			WithObjects(ec, &pending).
+			Build()
 		r := &EtcdClusterReconciler{Client: fakeClient, Scheme: scheme}
 		state := &reconcileState{cluster: ec, members: []ecv1alpha1.EtcdMember{pending}}
 
@@ -511,7 +547,8 @@ func TestDispatch(t *testing.T) {
 
 		list := &ecv1alpha1.EtcdMemberList{}
 		require.NoError(t, fakeClient.List(ctx, list, client.InNamespace(ec.Namespace)))
-		assert.Len(t, list.Items, 1)
+		require.Len(t, list.Items, 1)
+		assert.Equal(t, ecv1alpha1.EtcdMemberProvisioning, list.Items[0].Status.Phase)
 	})
 
 	t.Run("Falls through to scale-out when everything is Ready", func(t *testing.T) {
@@ -526,7 +563,7 @@ func TestDispatch(t *testing.T) {
 					Kind:       "EtcdCluster",
 					Name:       ec.Name,
 					UID:        ec.UID,
-					Controller: pointerToBool(true),
+					Controller: new(true),
 				}},
 			},
 			Spec:   ecv1alpha1.EtcdMemberSpec{ClusterName: ec.Name, Ordinal: 0, Version: ec.Spec.Version},
@@ -550,6 +587,65 @@ func TestDispatch(t *testing.T) {
 		require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: "etcd-1", Namespace: ec.Namespace}, member))
 		assert.Equal(t, 1, member.Spec.Ordinal)
 	})
+}
+
+func TestGapAwareScaleOutCreatesLowestMissingOrdinal(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, ecv1alpha1.AddToScheme(scheme))
+
+	clusterUID := types.UID("cluster-uid")
+	cluster := &ecv1alpha1.EtcdCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "etcd", Namespace: "default", UID: clusterUID},
+		Spec:       ecv1alpha1.EtcdClusterSpec{Size: 3, Version: "3.5.17"},
+	}
+	readyMember := func(ordinal int) ecv1alpha1.EtcdMember {
+		return ecv1alpha1.EtcdMember{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      etcdMemberName(cluster.Name, ordinal),
+				Namespace: cluster.Namespace,
+			},
+			Spec: ecv1alpha1.EtcdMemberSpec{
+				ClusterName: cluster.Name,
+				Ordinal:     ordinal,
+				Version:     cluster.Spec.Version,
+			},
+			Status: ecv1alpha1.EtcdMemberStatus{Phase: ecv1alpha1.EtcdMemberReady},
+		}
+	}
+	member0 := readyMember(0)
+	member2 := readyMember(2)
+	pod0 := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: member0.Name, Namespace: cluster.Namespace}}
+	pod2 := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: member2.Name, Namespace: cluster.Namespace}}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&ecv1alpha1.EtcdMember{}).
+		WithObjects(cluster, &member0, &member2, pod0, pod2).
+		Build()
+	reconciler := &EtcdClusterReconciler{Client: fakeClient, Scheme: scheme}
+	state := &reconcileState{
+		cluster: cluster,
+		members: []ecv1alpha1.EtcdMember{member0, member2},
+		pods:    []*corev1.Pod{pod0, pod2},
+	}
+
+	result, err := reconciler.scaleCluster(t.Context(), state)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, result)
+	target := &ecv1alpha1.EtcdMember{}
+	require.NoError(t, fakeClient.Get(t.Context(), client.ObjectKey{
+		Name: "etcd-1", Namespace: cluster.Namespace,
+	}, target))
+	require.Len(t, target.OwnerReferences, 1)
+	require.Equal(t, clusterUID, target.OwnerReferences[0].UID)
+	assert.Equal(t, 1, target.Spec.Ordinal)
+
+	// First lifecycle pass durably enters Provisioning.
+	state.members = []ecv1alpha1.EtcdMember{member0, *target, member2}
+	result, err = reconciler.reconcileEtcdMember(t.Context(), state, target)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, result)
+	assert.Equal(t, ecv1alpha1.EtcdMemberProvisioning, target.Status.Phase)
 }
 
 // TestReconcilePaused verifies requirement 15's pause gate: Spec.Paused

--- a/internal/controller/etcdmember.go
+++ b/internal/controller/etcdmember.go
@@ -18,13 +18,21 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	ecv1alpha1 "go.etcd.io/etcd-operator/api/v1alpha1"
+	"go.etcd.io/etcd-operator/internal/etcdutils"
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
 )
 
 // memberCleanupFinalizer is added to every EtcdMember at creation time so the
@@ -33,6 +41,389 @@ import (
 // controller-initiated scale-in or a human operator deleting it directly.
 const memberCleanupFinalizer = "operator.etcd.io/member-cleanup"
 
+// reconcileEtcdMember is the shared lifecycle entry point for every normal
+// provisioning attempt and its interruption recovery. Future lifecycle
+// phases attach focused handlers here without moving provisioning back into
+// scaleCluster or dispatch.
+func (r *EtcdClusterReconciler) reconcileEtcdMember(
+	ctx context.Context,
+	state *reconcileState,
+	member *ecv1alpha1.EtcdMember,
+) (ctrl.Result, error) {
+	switch member.Status.Phase {
+	// Creating the EtcdMember object and writing its status Phase are two
+	// separate calls in createEtcdMember. If the operator crashes in between,
+	// the object survives with an empty Phase, which must resume provisioning.
+	case "", ecv1alpha1.EtcdMemberPending, ecv1alpha1.EtcdMemberProvisioning:
+		return r.reconcileProvisioning(ctx, state, member)
+	// placeholder for Terminating, Recreating and Replacing
+	default:
+		return ctrl.Result{}, nil
+	}
+}
+
+// reconcileProvisioning establishes the durable write-before-mutate phase
+// boundary and drives normal provisioning as a linear sequence of idempotent
+// steps: prerequisites (certificates, PVC), membership registration, Pod
+// creation, and health convergence. Ordinal 0 with no live membership is the
+// bootstrap voter branch; every other unregistered peer is added as a
+// learner.
+func (r *EtcdClusterReconciler) reconcileProvisioning(
+	ctx context.Context,
+	state *reconcileState,
+	member *ecv1alpha1.EtcdMember,
+) (ctrl.Result, error) {
+	// 1. Phase boundary (write-before-mutate): persist Phase=Provisioning
+	// before any membership or Pod mutation. On first entry stop here and
+	// requeue, so a crash right after this write resumes provisioning instead
+	// of restarting it.
+	enteringProvisioning := member.Status.Phase == "" || member.Status.Phase == ecv1alpha1.EtcdMemberPending
+	if enteringProvisioning {
+		if err := r.updateEtcdMemberStatus(ctx, member, func(status *ecv1alpha1.EtcdMemberStatus) {
+			status.Phase = ecv1alpha1.EtcdMemberProvisioning
+		}); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{RequeueAfter: requeueDuration}, nil
+	}
+
+	// 2. Idempotent prerequisite: the shared TLS certificates must exist
+	// before the member's Pod mounts them.
+	if err := r.provisionCertificates(ctx, state); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// 3. Idempotent prerequisite: the member's own PVC for ReadWriteOnce
+	// storage.
+	if err := r.provisionPVC(ctx, state, member); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// 4. Initial state and membership registration. Bootstrap — ordinal 0
+	// with no live membership — starts the very first voter for the brand-new cluster; this is the only
+	// path that starts etcd with cluster-state=new. Every other unregistered
+	// peer is added as a learner (etcd admits only one learner at a time, so
+	// wait while another learner is still joining). Reaching this again after
+	// a crash between MemberAdd and Pod creation is expected — the add is
+	// idempotent here because registration is checked against live state.
+	bootstrap := member.Spec.Ordinal == 0 &&
+		(state.memberListResp == nil || len(state.memberListResp.Members) == 0)
+
+	if !bootstrap {
+		if etcdNode := findEtcdNodeForEtcdMember(state, member); etcdNode == nil {
+			if err := r.addLearner(state, member); err != nil {
+				return ctrl.Result{}, err
+			}
+			// addLearner updated the membership of etcd cluster, so
+			// we need to refresh the reconcileState by requeuing the request.
+			return ctrl.Result{RequeueAfter: requeueDuration}, nil
+		}
+	}
+
+	// 5. Pod creation: the member is registered (or is the bootstrap voter)
+	// but its Pod is absent (interrupted run, or the Pod was deleted
+	// mid-provisioning). Render ETCD_INITIAL_CLUSTER from the authoritative
+	// topology, create the Pod, and requeue to give it enough time to
+	// start.
+	if pod := findPodForEtcdMember(state, member); pod == nil {
+		if err := r.createPodForEtcdMember(ctx, state, member, bootstrap); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{RequeueAfter: requeueDuration}, nil
+	}
+
+	// 6. Convergence: wait until this member's endpoint reports healthy.
+	health, err := findHealthStatusForEtcdMember(state, member)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if !health.Health {
+		// TODO(#472): once a common recovery ladder exists, replace the
+		// member once RecreateCount has reached its limit; otherwise
+		// recreate the Pod and increment RecreateCount.
+		return ctrl.Result{RequeueAfter: requeueDuration}, nil
+	}
+
+	// 7. Promotion: if the member is still a learner, wait until the leader
+	// considers it caught up, then promote it to a voting member.
+	etcdNode := findEtcdNodeForEtcdMember(state, member)
+	if etcdNode == nil {
+		return ctrl.Result{}, fmt.Errorf("live etcd node for EtcdMember %q is not mapped", member.Name)
+	}
+	if etcdNode.IsLearner {
+		if res, err := r.promoteLearnerForEtcdMember(ctx, state, member, etcdNode); err != nil || !res.IsZero() {
+			return res, err
+		}
+	}
+
+	// 8. Completion: healthy voting member — mark it Ready.
+	if err := r.updateEtcdMemberStatus(ctx, member, func(status *ecv1alpha1.EtcdMemberStatus) {
+		status.Phase = ecv1alpha1.EtcdMemberReady
+		status.RecreateCount = 0
+	}); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{RequeueAfter: requeueDuration}, nil
+}
+
+// provisionCertificates ensures the cluster's shared server/peer TLS
+// certificates exist before a member's Pod mounts them. Idempotent.
+func (r *EtcdClusterReconciler) provisionCertificates(ctx context.Context, state *reconcileState) error {
+	if err := applyEtcdMemberCerts(ctx, state.cluster, r.Client); err != nil {
+		return fmt.Errorf("provisioning certificates for EtcdCluster %q: %w", state.cluster.Name, err)
+	}
+	return nil
+}
+
+// provisionPVC ensures the member's own PVC exists. A per-member PVC is only
+// needed for ReadWriteOnce storage; clusters without a storage spec or with
+// ReadWriteMany storage skip it. Idempotent.
+func (r *EtcdClusterReconciler) provisionPVC(ctx context.Context, state *reconcileState, member *ecv1alpha1.EtcdMember) error {
+	cluster := state.cluster
+	// ReadWriteMany is assumed to be statically provisioned (e.g. a shared
+	// NFS-backed PVC) and managed outside the operator, so no per-member PVC
+	// is created for it.
+	if cluster.Spec.StorageSpec == nil || cluster.Spec.StorageSpec.AccessModes == corev1.ReadWriteMany {
+		return nil
+	}
+	podName := memberPodName(cluster.Name, member.Spec.Ordinal)
+	if err := createPVCForMember(ctx, r.Client, cluster, member, podName, r.Scheme); err != nil {
+		return fmt.Errorf("provisioning PVC for EtcdMember %q: %w", member.Name, err)
+	}
+	return nil
+}
+
+// addLearner registers the member in the live etcd membership as a learner.
+// The member's Pod is created in a later pass that renders
+// ETCD_INITIAL_CLUSTER from a fresh membership snapshot.
+func (r *EtcdClusterReconciler) addLearner(state *reconcileState, member *ecv1alpha1.EtcdMember) error {
+	endpoints := clientEndpointsFromPods(state.cluster.Name, state.cluster.Namespace, state.pods, clusterTLSEnabled(state.cluster))
+	if len(endpoints) == 0 {
+		return fmt.Errorf("cannot add learner for EtcdMember %q: no live client endpoints", member.Name)
+	}
+
+	_, peerURL := peerEndpointForOrdinalIndex(state.cluster, member.Spec.Ordinal)
+	if _, err := etcdutils.AddMember(etcdutils.ClientConfig{Endpoints: endpoints, TLS: state.tlsConfig}, []string{peerURL}, true); err != nil {
+		return fmt.Errorf("failed to add learner for EtcdMember %q: %w", member.Name, err)
+	}
+
+	return nil
+}
+
+// promoteLearnerForEtcdMember promotes the member's learner to a voting
+// member. A failed promotion is logged and retried on a later pass; the
+// absence of live client endpoints is an error because no endpoint exists to
+// reach the membership at all.
+func (r *EtcdClusterReconciler) promoteLearnerForEtcdMember(
+	ctx context.Context,
+	state *reconcileState,
+	member *ecv1alpha1.EtcdMember,
+	etcdNode *etcdserverpb.Member,
+) (ctrl.Result, error) {
+	endpoints := clientEndpointsFromPods(
+		state.cluster.Name,
+		state.cluster.Namespace,
+		state.pods,
+		clusterTLSEnabled(state.cluster),
+	)
+	if len(endpoints) == 0 {
+		return ctrl.Result{}, fmt.Errorf("promoting learner for EtcdMember %q: no live client endpoints", member.Name)
+	}
+	if err := etcdutils.PromoteLearner(
+		etcdutils.ClientConfig{Endpoints: endpoints, TLS: state.tlsConfig},
+		etcdNode.ID,
+	); err != nil {
+		log.FromContext(ctx).Error(err, fmt.Sprintf("failed to promote learner for EtcdMember %q", member.Name))
+		return ctrl.Result{RequeueAfter: requeueDuration}, nil
+	}
+	return ctrl.Result{}, nil
+}
+
+// createPodForEtcdMember creates the Pod for a member that is already
+// registered (or is the bootstrap voter): the initial cluster state is new
+// only for bootstrap, ETCD_INITIAL_CLUSTER is rendered from the authoritative
+// topology, and the Pod is created if absent. Idempotent.
+func (r *EtcdClusterReconciler) createPodForEtcdMember(
+	ctx context.Context,
+	state *reconcileState,
+	member *ecv1alpha1.EtcdMember,
+	bootstrap bool,
+) error {
+	initialClusterState := etcdClusterStateExisting
+	if bootstrap {
+		initialClusterState = etcdClusterStateNew
+	}
+	return r.ensureProvisioningPod(ctx, state, member, initialClusterState, initialClusterForPod(state, member, bootstrap))
+}
+
+// initialClusterForPod renders ETCD_INITIAL_CLUSTER for the member's Pod: a
+// self-contained one-member string for bootstrap, otherwise the cluster
+// membership rendered from the cluster's EtcdMembers.
+func initialClusterForPod(state *reconcileState, member *ecv1alpha1.EtcdMember, bootstrap bool) string {
+	if bootstrap {
+		name, peerURL := peerEndpointForOrdinalIndex(state.cluster, member.Spec.Ordinal)
+		return fmt.Sprintf("%s=%s", name, peerURL)
+	}
+	return renderInitialCluster(state.cluster, state.members)
+}
+
+func (r *EtcdClusterReconciler) ensureProvisioningPod(
+	ctx context.Context,
+	state *reconcileState,
+	member *ecv1alpha1.EtcdMember,
+	initialClusterState etcdClusterState,
+	initialCluster string,
+) error {
+	if findPodForEtcdMember(state, member) != nil {
+		return nil
+	}
+
+	if err := createMemberPod(
+		ctx,
+		log.FromContext(ctx),
+		r.Client,
+		state.cluster,
+		member,
+		initialClusterState,
+		initialCluster,
+		r.Scheme,
+	); err != nil {
+		return fmt.Errorf("creating Pod for EtcdMember %q: %w", member.Name, err)
+	}
+
+	if err := r.updateEtcdMemberStatus(ctx, member, func(status *ecv1alpha1.EtcdMemberStatus) {
+		status.RecreateCount++
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// findPodForEtcdMember looks up the member's Pod in the reconcile snapshot:
+// Pods are listed once per reconcile, so a nil result means the Pod was
+// absent at snapshot time.
+func findPodForEtcdMember(state *reconcileState, member *ecv1alpha1.EtcdMember) *corev1.Pod {
+	podName := memberPodName(state.cluster.Name, member.Spec.Ordinal)
+	for _, p := range state.pods {
+		if p.Name == podName {
+			return p
+		}
+	}
+	return nil
+}
+
+// updateEtcdMemberStatus applies a mutation to the latest persisted member
+// status, retries optimistic-lock conflicts, and avoids unchanged writes.
+func (r *EtcdClusterReconciler) updateEtcdMemberStatus(
+	ctx context.Context,
+	member *ecv1alpha1.EtcdMember,
+	mutate func(*ecv1alpha1.EtcdMemberStatus),
+) error {
+	key := client.ObjectKeyFromObject(member)
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current := &ecv1alpha1.EtcdMember{}
+		if err := r.Get(ctx, key, current); err != nil {
+			return err
+		}
+
+		desired := current.DeepCopy()
+		mutate(&desired.Status)
+		if equality.Semantic.DeepEqual(current.Status, desired.Status) {
+			member.Status = desired.Status
+			member.ResourceVersion = current.ResourceVersion
+			return nil
+		}
+
+		if err := r.Status().Update(ctx, desired); err != nil {
+			return err
+		}
+		member.Status = desired.Status
+		member.ResourceVersion = desired.ResourceVersion
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("updating status for EtcdMember %q: %w", key.String(), err)
+	}
+	return nil
+}
+
+// findEtcdNodeForEtcdMember correlates an EtcdMember resource with the
+// current etcd membership by name: a live node matches when its etcd name —
+// or, while a newly added node has not started and is still unnamed, the name
+// encoded in its peer URL — equals the EtcdMember's name.
+func findEtcdNodeForEtcdMember(state *reconcileState, member *ecv1alpha1.EtcdMember) *etcdserverpb.Member {
+	if state.memberListResp == nil {
+		return nil
+	}
+
+	for _, node := range state.memberListResp.Members {
+		for _, peerURL := range node.PeerURLs {
+			memberName := node.Name
+			if memberName == "" {
+				memberName = getMemberNameFromPeerURL(peerURL)
+			}
+			if memberName == member.Name {
+				return node
+			}
+		}
+	}
+
+	return nil
+}
+
+// pickNotReadyMember selects from the current live snapshot: a live learner
+// mapped to its EtcdMember first, otherwise the lowest-ordinal member that
+// isn't Ready yet. state.members is assumed sorted by ordinal, so the first
+// match in the second pass is the lowest-ordinal one.
+func pickNotReadyMember(
+	state *reconcileState,
+) *ecv1alpha1.EtcdMember {
+	for i := range state.members {
+		member := &state.members[i]
+		if member.Status.Phase == ecv1alpha1.EtcdMemberReady {
+			continue
+		}
+		if etcdNode := findEtcdNodeForEtcdMember(state, member); etcdNode != nil && etcdNode.IsLearner {
+			return member
+		}
+	}
+	for i := range state.members {
+		member := &state.members[i]
+		if member.Status.Phase != ecv1alpha1.EtcdMemberReady {
+			return member
+		}
+	}
+	return nil
+}
+
+// findHealthStatusForEtcdMember looks up the member's health entry in the
+// reconcile snapshot by its deterministic Pod (= etcd member) name.
+func findHealthStatusForEtcdMember(state *reconcileState, member *ecv1alpha1.EtcdMember) (*etcdutils.EpHealth, error) {
+	memberName := memberPodName(state.cluster.Name, member.Spec.Ordinal)
+	if state.health != nil {
+		if memberHealthStatus, ok := state.health.Members[memberName]; ok {
+			return &memberHealthStatus, nil
+		}
+		return nil, fmt.Errorf("health status is not found for member %s", memberName)
+	}
+	return nil, fmt.Errorf("cannot find the health status for member %s as the health report is empty", memberName)
+}
+
+// renderInitialCluster renders ETCD_INITIAL_CLUSTER from the cluster's
+// EtcdMembers, assuming they are consistent with the live etcd membership.
+// It never infers topology from an ordinal range.
+func renderInitialCluster(cluster *ecv1alpha1.EtcdCluster, members []ecv1alpha1.EtcdMember) string {
+	entries := make([]string, 0, len(members))
+	for i := range members {
+		name, peerURL := peerEndpointForOrdinalIndex(cluster, members[i].Spec.Ordinal)
+		entries = append(entries, fmt.Sprintf("%s=%s", name, peerURL))
+	}
+
+	sort.Strings(entries)
+	return strings.Join(entries, ",")
+}
+
 // etcdMemberName returns the deterministic name for a member's EtcdMember
 // object, matching today's Pod naming so both stay stable and human-readable.
 func etcdMemberName(clusterName string, ordinal int) string {
@@ -40,10 +431,13 @@ func etcdMemberName(clusterName string, ordinal int) string {
 }
 
 // listOwnedMembers returns all EtcdMembers owned by ec, sorted in ascending
-// ordinal order.
+// ordinal order. The label selector and namespace filter members belonging to the cluster.
 func listOwnedMembers(ctx context.Context, c client.Client, ec *ecv1alpha1.EtcdCluster) ([]ecv1alpha1.EtcdMember, error) {
 	memberList := &ecv1alpha1.EtcdMemberList{}
-	if err := c.List(ctx, memberList, client.InNamespace(ec.Namespace)); err != nil {
+	if err := c.List(ctx, memberList,
+		client.InNamespace(ec.Namespace),
+		client.MatchingLabels(clusterNameLabels(ec.Name)),
+	); err != nil {
 		return nil, fmt.Errorf("failed to list EtcdMembers for cluster %s: %w", ec.Name, err)
 	}
 
@@ -84,8 +478,7 @@ func nextOrdinal(existing []int) int {
 }
 
 // allReady reports whether every member is Phase: Ready. Vacuously true for
-// zero members, which is what lets bootstrap (creating ordinal 0) proceed
-// through the §4.2 readiness gate with no special-case code.
+// zero members.
 func allReady(members []ecv1alpha1.EtcdMember) bool {
 	for _, m := range members {
 		if m.Status.Phase != ecv1alpha1.EtcdMemberReady {
@@ -93,33 +486,6 @@ func allReady(members []ecv1alpha1.EtcdMember) bool {
 		}
 	}
 	return true
-}
-
-// pickNotReadyMember returns the not-Ready member the dispatcher's §4.9 item
-// 8 should advance next: an existing learner always wins (requirement 11, so
-// a different member's Replacing rejoin never attempts a second
-// MemberAdd(learner) while one is already pending); otherwise the
-// lowest-ordinal not-Ready member (members is sorted by ordinal already, per
-// listOwnedMembers). Members already claimed by an earlier dispatch step —
-// Recreating (item 5) or Terminating/DeletionTimestamp set (item 7) — are
-// not this step's concern.
-func pickNotReadyMember(members []ecv1alpha1.EtcdMember) *ecv1alpha1.EtcdMember {
-	for i := range members {
-		if members[i].Status.IsLearner {
-			return &members[i]
-		}
-	}
-	for i := range members {
-		m := &members[i]
-		if m.DeletionTimestamp != nil {
-			continue
-		}
-		switch m.Status.Phase {
-		case ecv1alpha1.EtcdMemberPending, ecv1alpha1.EtcdMemberProvisioning, ecv1alpha1.EtcdMemberReplacing:
-			return m
-		}
-	}
-	return nil
 }
 
 // createEtcdMember creates the EtcdMember object for the given ordinal,
@@ -131,6 +497,7 @@ func createEtcdMember(ctx context.Context, c client.Client, ec *ecv1alpha1.EtcdC
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       etcdMemberName(ec.Name, ordinal),
 			Namespace:  ec.Namespace,
+			Labels:     clusterNameLabels(ec.Name),
 			Finalizers: []string{memberCleanupFinalizer},
 		},
 		Spec: ecv1alpha1.EtcdMemberSpec{

--- a/internal/controller/etcdmember_test.go
+++ b/internal/controller/etcdmember_test.go
@@ -18,6 +18,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	ecv1alpha1 "go.etcd.io/etcd-operator/api/v1alpha1"
 )
@@ -75,4 +79,49 @@ func TestAllReady(t *testing.T) {
 	assert.True(t, allReady(nil), "zero members should be vacuously ready")
 	assert.True(t, allReady([]ecv1alpha1.EtcdMember{ready, ready}))
 	assert.False(t, allReady([]ecv1alpha1.EtcdMember{ready, pending}))
+}
+
+func TestListOwnedMembers(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, ecv1alpha1.AddToScheme(scheme))
+
+	ec := &ecv1alpha1.EtcdCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-cluster", Namespace: "default", UID: "cluster-uid"},
+	}
+	foreign := &ecv1alpha1.EtcdCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-cluster", Namespace: ec.Namespace, UID: "foreign-uid"},
+	}
+	makeMember := func(cluster *ecv1alpha1.EtcdCluster, ordinal int, labelCluster string) ecv1alpha1.EtcdMember {
+		return ecv1alpha1.EtcdMember{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      etcdMemberName(labelCluster, ordinal),
+				Namespace: cluster.Namespace,
+				Labels:    map[string]string{clusterNameLabel: labelCluster},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: ecv1alpha1.GroupVersion.String(),
+					Kind:       "EtcdCluster",
+					Name:       cluster.Name,
+					UID:        cluster.UID,
+					Controller: new(true),
+				}},
+			},
+			Spec: ecv1alpha1.EtcdMemberSpec{ClusterName: cluster.Name, Ordinal: ordinal},
+		}
+	}
+	member0 := makeMember(ec, 0, ec.Name)
+	member2 := makeMember(ec, 2, ec.Name)
+	otherMember := makeMember(foreign, 0, foreign.Name)
+	// Carries this cluster's selected label but is controlled by a foreign
+	// cluster: the selector lets it through, the ownership check must not.
+	spoofed := makeMember(foreign, 1, ec.Name)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(ec, foreign, &member0, &member2, &otherMember, &spoofed).
+		Build()
+
+	members, err := listOwnedMembers(t.Context(), fakeClient, ec)
+	require.NoError(t, err)
+	require.Len(t, members, 2)
+	assert.Equal(t, "my-cluster-0", members[0].Name)
+	assert.Equal(t, "my-cluster-2", members[1].Name)
 }

--- a/internal/controller/pods.go
+++ b/internal/controller/pods.go
@@ -60,9 +60,12 @@ func podOrdinal(podName, clusterName string) int {
 	return ordinal
 }
 
-// listOwnedPods returns all Pods that are owned (via OwnerReference) by ec,
-// sorted in ascending ordinal order.
-func listOwnedPods(ctx context.Context, c client.Client, ec *ecv1alpha1.EtcdCluster) ([]*corev1.Pod, error) {
+// listOwnedPods returns all Pods controlled by one of the given EtcdMembers,
+// sorted by name. EtcdCluster never owns Pods directly; a Pod belongs to the
+// cluster when its controlling EtcdMember is in members. Checking against
+// this already-fetched slice avoids re-reading each Pod's controlling
+// EtcdMember from the API server.
+func listOwnedPods(ctx context.Context, c client.Client, ec *ecv1alpha1.EtcdCluster, members []ecv1alpha1.EtcdMember) ([]*corev1.Pod, error) {
 	podList := &corev1.PodList{}
 	if err := c.List(ctx, podList,
 		client.InNamespace(ec.Namespace),
@@ -71,17 +74,32 @@ func listOwnedPods(ctx context.Context, c client.Client, ec *ecv1alpha1.EtcdClus
 		return nil, fmt.Errorf("failed to list pods for cluster %s: %w", ec.Name, err)
 	}
 
-	var owned []*corev1.Pod
+	owned := []*corev1.Pod{}
 	for i := range podList.Items {
-		if metav1.IsControlledBy(&podList.Items[i], ec) {
-			owned = append(owned, &podList.Items[i])
+		pod := &podList.Items[i]
+		if podIsControlledByClusterMember(pod, members) {
+			owned = append(owned, pod)
 		}
 	}
 
 	sort.Slice(owned, func(i, j int) bool {
-		return podOrdinal(owned[i].Name, ec.Name) < podOrdinal(owned[j].Name, ec.Name)
+		return owned[i].Name < owned[j].Name
 	})
 	return owned, nil
+}
+
+func podIsControlledByClusterMember(pod *corev1.Pod, members []ecv1alpha1.EtcdMember) bool {
+	owner := metav1.GetControllerOf(pod)
+	if owner == nil || owner.APIVersion != ecv1alpha1.GroupVersion.String() || owner.Kind != "EtcdMember" {
+		return false
+	}
+
+	for i := range members {
+		if members[i].Name == owner.Name {
+			return true
+		}
+	}
+	return false
 }
 
 // isPodReady returns true when the Pod's Ready condition is True.
@@ -276,8 +294,16 @@ const (
 	HashMetadataKey = "operator.etcd.io/spec-hash"
 )
 
-// buildMemberPod constructs the Pod object for a single etcd member.
-func buildMemberPod(ec *ecv1alpha1.EtcdCluster, podName string, initialClusterState etcdClusterState, initialCluster string) *corev1.Pod {
+// buildMemberPod constructs the Pod object for a single EtcdMember using the
+// authoritative topology selected by its lifecycle reconciliation.
+func buildMemberPod(
+	ec *ecv1alpha1.EtcdCluster,
+	member *ecv1alpha1.EtcdMember,
+	initialClusterState etcdClusterState,
+	initialCluster string,
+	scheme *runtime.Scheme,
+) (*corev1.Pod, error) {
+	podName := memberPodName(ec.Name, member.Spec.Ordinal)
 	// Start with custom labels then overwrite with the mandatory defaults so
 	// that the headless-service selector is always satisfied.
 	labels := make(map[string]string)
@@ -314,7 +340,7 @@ func buildMemberPod(ec *ecv1alpha1.EtcdCluster, podName string, initialClusterSt
 
 	container := corev1.Container{
 		Name:    "etcd",
-		Image:   fmt.Sprintf("%s:%s", ec.Spec.ImageRegistry, ec.Spec.Version),
+		Image:   fmt.Sprintf("%s:%s", ec.Spec.ImageRegistry, member.Spec.Version),
 		Command: []string{"/usr/local/bin/etcd"},
 		Args:    createArgs(ec.Name, ec.Spec.EtcdOptions, clusterTLSEnabled(ec)),
 		Env:     envVars,
@@ -400,7 +426,7 @@ func buildMemberPod(ec *ecv1alpha1.EtcdCluster, podName string, initialClusterSt
 		)
 	}
 
-	return &corev1.Pod{
+	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        podName,
 			Namespace:   ec.Namespace,
@@ -409,43 +435,39 @@ func buildMemberPod(ec *ecv1alpha1.EtcdCluster, podName string, initialClusterSt
 		},
 		Spec: podSpec,
 	}
+	if err := controllerutil.SetControllerReference(member, pod, scheme); err != nil {
+		return nil, fmt.Errorf("setting EtcdMember owner on Pod %q: %w", podName, err)
+	}
+	return pod, nil
 }
 
-// createMemberPod creates a single etcd member Pod (and, if needed, its PVC)
-// for the given ordinal index.  It does not wait for the pod to become ready;
-// the caller is responsible for requeueing until the pod is healthy.
-func createMemberPod(ctx context.Context, logger logr.Logger, c client.Client, ec *ecv1alpha1.EtcdCluster, ordinal int, scheme *runtime.Scheme) error {
-	podName := memberPodName(ec.Name, ordinal)
+// createMemberPod creates a single etcd member Pod for the given EtcdMember
+// and authoritative topology. Certificates and the member's PVC are
+// idempotent prerequisites provisioned earlier by reconcileProvisioning. It
+// does not wait for the Pod to become ready; the caller requeues until live
+// etcd health converges.
+func createMemberPod(
+	ctx context.Context,
+	logger logr.Logger,
+	c client.Client,
+	ec *ecv1alpha1.EtcdCluster,
+	member *ecv1alpha1.EtcdMember,
+	initialClusterState etcdClusterState,
+	initialCluster string,
+	scheme *runtime.Scheme,
+) error {
+	podName := memberPodName(ec.Name, member.Spec.Ordinal)
 
-	// Ensure TLS certificates exist before the pod mounts them.
-	if err := applyEtcdMemberCerts(ctx, ec, c); err != nil {
+	pod, err := buildMemberPod(ec, member, initialClusterState, initialCluster, scheme)
+	if err != nil {
 		return err
 	}
 
-	// Create per-member PVC for ReadWriteOnce storage.
-	if ec.Spec.StorageSpec != nil && ec.Spec.StorageSpec.AccessModes != corev1.ReadWriteMany {
-		if err := createPVCForMember(ctx, c, ec, podName, scheme); err != nil {
-			return err
-		}
-	}
-
-	state := etcdClusterStateExisting
-	if ordinal == 0 {
-		state = etcdClusterStateNew
-	}
-
-	// Build the initial-cluster value: all peers from ordinal 0 to this one.
-	var clusterParts []string
-	for i := range ordinal + 1 {
-		name, peerURL := peerEndpointForOrdinalIndex(ec, i)
-		clusterParts = append(clusterParts, fmt.Sprintf("%s=%s", name, peerURL))
-	}
-
-	pod := buildMemberPod(ec, podName, state, strings.Join(clusterParts, ","))
-	if err := controllerutil.SetControllerReference(ec, pod, scheme); err != nil {
-		return err
-	}
-
-	logger.Info("Creating member pod", "name", podName, "ordinal", ordinal, "state", state)
+	logger.Info(
+		"Creating member pod",
+		"name", podName,
+		"ordinal", member.Spec.Ordinal,
+		"state", initialClusterState,
+	)
 	return c.Create(ctx, pod)
 }

--- a/internal/controller/pods_test.go
+++ b/internal/controller/pods_test.go
@@ -36,49 +36,74 @@ func TestListOwnedPods(t *testing.T) {
 		Spec:       ecv1alpha1.EtcdClusterSpec{Size: 3, Version: "3.5.17"},
 	}
 
-	makePod := func(name, uid string, owned bool) *corev1.Pod {
-		pod := &corev1.Pod{
+	makePod := func(name string) *corev1.Pod {
+		return &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: "default",
 				Labels:    etcdClusterLabels(ec),
 			},
 		}
-		if owned {
-			pod.OwnerReferences = []metav1.OwnerReference{{
-				APIVersion: ecv1alpha1.GroupVersion.String(),
-				Kind:       "EtcdCluster",
-				Name:       ec.Name,
-				UID:        types.UID(uid),
-				Controller: pointerToBool(true),
-			}}
+	}
+	makeMember := func(name string, ordinal int, clusterUID string) *ecv1alpha1.EtcdMember {
+		return &ecv1alpha1.EtcdMember{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: ec.Namespace,
+				UID:       types.UID("member-" + name),
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: ecv1alpha1.GroupVersion.String(),
+					Kind:       "EtcdCluster",
+					Name:       ec.Name,
+					UID:        types.UID(clusterUID),
+					Controller: new(true),
+				}},
+			},
+			Spec: ecv1alpha1.EtcdMemberSpec{ClusterName: ec.Name, Ordinal: ordinal, Version: ec.Spec.Version},
 		}
+	}
+	// Pod owners are always EtcdMembers; the EtcdCluster never owns Pods
+	// directly.
+	makeMemberOwnedPod := func(name string, member *ecv1alpha1.EtcdMember) *corev1.Pod {
+		pod := makePod(name)
+		pod.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: ecv1alpha1.GroupVersion.String(),
+			Kind:       "EtcdMember",
+			Name:       member.Name,
+			UID:        member.UID,
+			Controller: new(true),
+		}}
 		return pod
 	}
 
-	t.Run("returns only owned pods sorted by ordinal", func(t *testing.T) {
+	t.Run("returns pods of the given members and ignores foreign or orphan pods", func(t *testing.T) {
 		ctx := t.Context()
-		pod0 := makePod("my-cluster-0", "abc", true)
-		pod2 := makePod("my-cluster-2", "abc", true)
-		pod1 := makePod("my-cluster-1", "abc", true)
-		foreign := makePod("my-cluster-3", "different-uid", false)
+		member0 := makeMember("my-cluster-0", 0, "abc")
+		member2 := makeMember("my-cluster-2", 2, "abc")
+		pod0 := makeMemberOwnedPod("my-cluster-0", member0)
+		pod2 := makeMemberOwnedPod("my-cluster-2", member2)
+		// Controlled by a member of a different cluster, which is absent
+		// from the caller's members list (listOwnedMembers filters it out).
+		foreignMember := makeMember("my-cluster-3", 3, "different-cluster-uid")
+		foreign := makeMemberOwnedPod("my-cluster-3", foreignMember)
+		// Carries the cluster labels but has no controller owner.
+		orphan := makePod("my-cluster-5")
 
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).
-			WithObjects(ec, pod0, pod1, pod2, foreign).Build()
+			WithObjects(ec, pod2, pod0, foreign, orphan).Build()
 
-		pods, err := listOwnedPods(ctx, fakeClient, ec)
+		pods, err := listOwnedPods(ctx, fakeClient, ec, []ecv1alpha1.EtcdMember{*member0, *member2})
 		require.NoError(t, err)
-		require.Len(t, pods, 3)
+		require.Len(t, pods, 2)
 		assert.Equal(t, "my-cluster-0", pods[0].Name)
-		assert.Equal(t, "my-cluster-1", pods[1].Name)
-		assert.Equal(t, "my-cluster-2", pods[2].Name)
+		assert.Equal(t, "my-cluster-2", pods[1].Name)
 	})
 
 	t.Run("returns empty slice when no pods exist", func(t *testing.T) {
 		ctx := t.Context()
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec).Build()
 
-		pods, err := listOwnedPods(ctx, fakeClient, ec)
+		pods, err := listOwnedPods(ctx, fakeClient, ec, nil)
 		require.NoError(t, err)
 		assert.Empty(t, pods)
 	})
@@ -87,6 +112,54 @@ func TestListOwnedPods(t *testing.T) {
 // ---------------------------------------------------------------------------
 // createMemberPod
 // ---------------------------------------------------------------------------
+
+func TestBuildMemberPodUsesLifecycleInputs(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, ecv1alpha1.AddToScheme(scheme))
+
+	cluster := &ecv1alpha1.EtcdCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "etcd", Namespace: "default", UID: "cluster-uid"},
+		Spec: ecv1alpha1.EtcdClusterSpec{
+			Version:       "3.5.17",
+			ImageRegistry: "registry.example/etcd",
+		},
+	}
+	member := &ecv1alpha1.EtcdMember{
+		ObjectMeta: metav1.ObjectMeta{Name: "etcd-1", Namespace: cluster.Namespace, UID: "member-uid"},
+		Spec: ecv1alpha1.EtcdMemberSpec{
+			ClusterName: cluster.Name,
+			Ordinal:     1,
+			Version:     "3.6.2",
+		},
+	}
+	builder, ok := any(buildMemberPod).(func(
+		*ecv1alpha1.EtcdCluster,
+		*ecv1alpha1.EtcdMember,
+		etcdClusterState,
+		string,
+		*runtime.Scheme,
+	) (*corev1.Pod, error))
+	require.True(t, ok, "buildMemberPod should accept the target EtcdMember and explicit topology")
+
+	for _, state := range []etcdClusterState{etcdClusterStateNew, etcdClusterStateExisting} {
+		t.Run(string(state), func(t *testing.T) {
+			const initialCluster = "etcd-0=http://peer-0:2380,etcd-1=http://peer-1:2380"
+			pod, err := builder(cluster, member, state, initialCluster, scheme)
+			require.NoError(t, err)
+
+			env := envVarsToMap(pod)
+			assert.Equal(t, string(state), env["ETCD_INITIAL_CLUSTER_STATE"])
+			assert.Equal(t, initialCluster, env["ETCD_INITIAL_CLUSTER"])
+			require.Len(t, pod.Spec.Containers, 1)
+			assert.Equal(t, "registry.example/etcd:3.6.2", pod.Spec.Containers[0].Image)
+			require.Len(t, pod.OwnerReferences, 1)
+			assert.Equal(t, member.Name, pod.OwnerReferences[0].Name)
+			assert.Equal(t, "EtcdMember", pod.OwnerReferences[0].Kind)
+			assert.True(t, *pod.OwnerReferences[0].Controller)
+		})
+	}
+}
 
 func TestCreateMemberPod(t *testing.T) {
 	scheme := runtime.NewScheme()
@@ -102,7 +175,18 @@ func TestCreateMemberPod(t *testing.T) {
 
 	t.Run("creates pod-0 with state=new", func(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec).Build()
-		err := createMemberPod(ctx, logger, fakeClient, ec, 0, scheme)
+		member := testMemberForCluster(ec, 0)
+		_, peerURL := peerEndpointForOrdinalIndex(ec, 0)
+		err := createMemberPod(
+			ctx,
+			logger,
+			fakeClient,
+			ec,
+			member,
+			etcdClusterStateNew,
+			member.Name+"="+peerURL,
+			scheme,
+		)
 		require.NoError(t, err)
 
 		pod := &corev1.Pod{}
@@ -116,12 +200,27 @@ func TestCreateMemberPod(t *testing.T) {
 		assert.Equal(t, etcdDataDir, envMap["ETCD_DATA_DIR"])
 
 		require.Len(t, pod.OwnerReferences, 1)
-		assert.Equal(t, ec.Name, pod.OwnerReferences[0].Name)
+		assert.Equal(t, member.Name, pod.OwnerReferences[0].Name)
 	})
 
 	t.Run("creates pod-2 with state=existing and full initial cluster", func(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec).Build()
-		err := createMemberPod(ctx, logger, fakeClient, ec, 2, scheme)
+		member := testMemberForCluster(ec, 2)
+		clusterParts := make([]string, 0, 3)
+		for ordinal := range 3 {
+			name, peerURL := peerEndpointForOrdinalIndex(ec, ordinal)
+			clusterParts = append(clusterParts, name+"="+peerURL)
+		}
+		err := createMemberPod(
+			ctx,
+			logger,
+			fakeClient,
+			ec,
+			member,
+			etcdClusterStateExisting,
+			strings.Join(clusterParts, ","),
+			scheme,
+		)
 		require.NoError(t, err)
 
 		pod := &corev1.Pod{}
@@ -133,6 +232,21 @@ func TestCreateMemberPod(t *testing.T) {
 		assert.Contains(t, envMap["ETCD_INITIAL_CLUSTER"], "test-etcd-1=")
 		assert.Contains(t, envMap["ETCD_INITIAL_CLUSTER"], "test-etcd-2=")
 	})
+}
+
+func testMemberForCluster(ec *ecv1alpha1.EtcdCluster, ordinal int) *ecv1alpha1.EtcdMember {
+	return &ecv1alpha1.EtcdMember{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      etcdMemberName(ec.Name, ordinal),
+			Namespace: ec.Namespace,
+			UID:       types.UID(fmt.Sprintf("member-%d", ordinal)),
+		},
+		Spec: ecv1alpha1.EtcdMemberSpec{
+			ClusterName: ec.Name,
+			Ordinal:     ordinal,
+			Version:     ec.Spec.Version,
+		},
+	}
 }
 
 // envVarsToMap converts a container's env slice into a name→value map.
@@ -320,14 +434,24 @@ func TestCreateMemberPodWithAnnotations(t *testing.T) {
 
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec).Build()
 
-			err := createMemberPod(ctx, logger, fakeClient, ec, 0, scheme)
+			member := testMemberForCluster(ec, 0)
+			err := createMemberPod(
+				ctx,
+				logger,
+				fakeClient,
+				ec,
+				member,
+				etcdClusterStateNew,
+				"ignored",
+				scheme,
+			)
 			require.NoError(t, err)
 
 			pod := &corev1.Pod{}
 			require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: tt.clusterName + "-0", Namespace: "default"}, pod))
 
 			require.Len(t, pod.OwnerReferences, 1)
-			assert.Equal(t, ec.Name, pod.OwnerReferences[0].Name)
+			assert.Equal(t, member.Name, pod.OwnerReferences[0].Name)
 
 			// the operator can insert more annotations, but we can guarantee that the expected KVs would be there
 			for k, v := range tt.expectedAnnotations {
@@ -425,14 +549,24 @@ func TestCreateMemberPodWithLabels(t *testing.T) {
 			}
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec).Build()
 
-			err := createMemberPod(ctx, logger, fakeClient, ec, 0, scheme)
+			member := testMemberForCluster(ec, 0)
+			err := createMemberPod(
+				ctx,
+				logger,
+				fakeClient,
+				ec,
+				member,
+				etcdClusterStateNew,
+				"ignored",
+				scheme,
+			)
 			require.NoError(t, err)
 
 			pod := &corev1.Pod{}
 			require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: tt.clusterName + "-0", Namespace: "default"}, pod))
 			assert.Equal(t, tt.expectedLabels, pod.Labels)
 			require.Len(t, pod.OwnerReferences, 1)
-			assert.Equal(t, ec.Name, pod.OwnerReferences[0].Name)
+			assert.Equal(t, member.Name, pod.OwnerReferences[0].Name)
 		})
 	}
 }
@@ -690,6 +824,10 @@ func TestClientEndpointsFromPods(t *testing.T) {
 }
 
 func TestBuildMemberPodTLSVolumes(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, ecv1alpha1.AddToScheme(scheme))
+
 	mkCluster := func(tls *ecv1alpha1.TLSCertificate, storage *ecv1alpha1.StorageSpec) *ecv1alpha1.EtcdCluster {
 		return &ecv1alpha1.EtcdCluster{
 			ObjectMeta: metav1.ObjectMeta{Name: "tls-cluster", Namespace: "default", UID: "1"},
@@ -704,7 +842,8 @@ func TestBuildMemberPodTLSVolumes(t *testing.T) {
 
 	t.Run("TLS cluster mounts both secrets readonly and adds TLS args", func(t *testing.T) {
 		ec := mkCluster(&ecv1alpha1.TLSCertificate{Provider: "auto"}, nil)
-		pod := buildMemberPod(ec, "tls-cluster-0", etcdClusterStateNew, "ignored")
+		pod, err := buildMemberPod(ec, testMemberForCluster(ec, 0), etcdClusterStateNew, "ignored", scheme)
+		require.NoError(t, err)
 
 		container := pod.Spec.Containers[0]
 
@@ -740,7 +879,8 @@ func TestBuildMemberPodTLSVolumes(t *testing.T) {
 
 	t.Run("non-TLS cluster adds no secret mounts and stays http", func(t *testing.T) {
 		ec := mkCluster(nil, nil)
-		pod := buildMemberPod(ec, "tls-cluster-0", etcdClusterStateNew, "ignored")
+		pod, err := buildMemberPod(ec, testMemberForCluster(ec, 0), etcdClusterStateNew, "ignored", scheme)
+		require.NoError(t, err)
 
 		for _, m := range pod.Spec.Containers[0].VolumeMounts {
 			assert.NotEqual(t, "server-secret", m.Name, "non-TLS pod must not mount server-secret")

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/url"
 	"slices"
 	"strings"
 	"time"
@@ -58,9 +59,22 @@ func etcdClusterLabels(ec *ecv1alpha1.EtcdCluster) map[string]string {
 	}
 }
 
+// clusterNameLabel marks cluster-owned objects with their EtcdCluster's name,
+// letting owned objects be selected by label.
+const clusterNameLabel = "operator.etcd.io/cluster"
+
+// clusterNameLabels returns the label set that marks objects (EtcdMembers,
+// PVCs) with the name of the cluster they belong to, letting them be
+// selected by label.
+func clusterNameLabels(clusterName string) map[string]string {
+	return map[string]string{clusterNameLabel: clusterName}
+}
+
 // createPVCForMember creates a PVC for the given pod if one does not already
 // exist.  Naming mirrors StatefulSet VolumeClaimTemplates: "{volumeName}-{podName}".
-func createPVCForMember(ctx context.Context, c client.Client, ec *ecv1alpha1.EtcdCluster, podName string, scheme *runtime.Scheme) error {
+// The PVC is owned by the EtcdMember and labeled with the cluster name so
+// per-cluster PVCs can be listed by label selector.
+func createPVCForMember(ctx context.Context, c client.Client, ec *ecv1alpha1.EtcdCluster, member *ecv1alpha1.EtcdMember, podName string, scheme *runtime.Scheme) error {
 	pvcName := pvcNameForMember(podName)
 
 	existing := &corev1.PersistentVolumeClaim{}
@@ -85,6 +99,7 @@ func createPVCForMember(ctx context.Context, c client.Client, ec *ecv1alpha1.Etc
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pvcName,
 			Namespace: ec.Namespace,
+			Labels:    clusterNameLabels(ec.Name),
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
@@ -103,7 +118,7 @@ func createPVCForMember(ctx context.Context, c client.Client, ec *ecv1alpha1.Etc
 		pvc.Spec.StorageClassName = &ec.Spec.StorageSpec.StorageClassName
 	}
 
-	if err := controllerutil.SetControllerReference(ec, pvc, scheme); err != nil {
+	if err := controllerutil.SetControllerReference(member, pvc, scheme); err != nil {
 		return err
 	}
 
@@ -201,6 +216,22 @@ func peerEndpointForOrdinalIndex(ec *ecv1alpha1.EtcdCluster, index int) (string,
 	name := fmt.Sprintf("%s-%d", ec.Name, index)
 	return name, fmt.Sprintf("%s://%s-%d.%s.%s.svc.cluster.local:2380",
 		clusterScheme(clusterTLSEnabled(ec)), ec.Name, index, ec.Name, ec.Namespace)
+}
+
+// getMemberNameFromPeerURL returns the {cluster}-{ordinal} member name
+// encoded in a peer URL of the shape produced by peerEndpointForOrdinalIndex
+// — the hostname label before its first ".". Returns "" if the URL has no
+// host.
+func getMemberNameFromPeerURL(peerURL string) string {
+	u, err := url.Parse(peerURL)
+	if err != nil {
+		return ""
+	}
+	host := u.Hostname()
+	if idx := strings.Index(host, "."); idx != -1 {
+		return host[:idx]
+	}
+	return host
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/controller/utils_test.go
+++ b/internal/controller/utils_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,10 +20,6 @@ import (
 	"go.etcd.io/etcd-operator/pkg/certificate"
 	certInterface "go.etcd.io/etcd-operator/pkg/certificate/interfaces"
 )
-
-func pointerToBool(value bool) *bool {
-	return &value
-}
 
 // ---------------------------------------------------------------------------
 // createHeadlessServiceIfNotExist
@@ -71,6 +68,75 @@ func TestCreateHeadlessServiceIfNotExist(t *testing.T) {
 	t.Run("does not create service if it already exists", func(t *testing.T) {
 		err := createHeadlessServiceIfNotExist(ctx, logger, fakeClient, ec, scheme)
 		assert.NoError(t, err)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// createPVCForMember
+// ---------------------------------------------------------------------------
+
+func TestCreatePVCForMember(t *testing.T) {
+	ctx := t.Context()
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = ecv1alpha1.AddToScheme(scheme)
+
+	newCluster := func() *ecv1alpha1.EtcdCluster {
+		return &ecv1alpha1.EtcdCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-etcd", Namespace: "default", UID: "1"},
+			Spec: ecv1alpha1.EtcdClusterSpec{
+				Size:    3,
+				Version: "3.5.17",
+				StorageSpec: &ecv1alpha1.StorageSpec{
+					VolumeSizeRequest: resource.MustParse("2Gi"),
+				},
+			},
+		}
+	}
+
+	t.Run("creates PVC owned by the EtcdMember with the cluster name label", func(t *testing.T) {
+		ec := newCluster()
+		member := testMemberForCluster(ec, 0)
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		err := createPVCForMember(ctx, fakeClient, ec, member, memberPodName(ec.Name, 0), scheme)
+		require.NoError(t, err)
+
+		pvc := &corev1.PersistentVolumeClaim{}
+		require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: "etcd-data-test-etcd-0", Namespace: "default"}, pvc))
+
+		require.Len(t, pvc.OwnerReferences, 1)
+		assert.Equal(t, member.Name, pvc.OwnerReferences[0].Name)
+		assert.Equal(t, "EtcdMember", pvc.OwnerReferences[0].Kind)
+		assert.True(t, *pvc.OwnerReferences[0].Controller)
+		assert.Equal(t, ec.Name, pvc.Labels[clusterNameLabel])
+		assert.Equal(t, resource.MustParse("2Gi"), *pvc.Spec.Resources.Requests.Storage())
+	})
+
+	t.Run("does not modify an existing PVC", func(t *testing.T) {
+		ec := newCluster()
+		member := testMemberForCluster(ec, 0)
+		existing := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "etcd-data-test-etcd-0", Namespace: "default"},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+
+		require.NoError(t, createPVCForMember(ctx, fakeClient, ec, member, memberPodName(ec.Name, 0), scheme))
+
+		pvc := &corev1.PersistentVolumeClaim{}
+		require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: "etcd-data-test-etcd-0", Namespace: "default"}, pvc))
+		assert.Empty(t, pvc.OwnerReferences)
+	})
+
+	t.Run("rejects VolumeSizeRequest below 1Mi", func(t *testing.T) {
+		ec := newCluster()
+		ec.Spec.StorageSpec.VolumeSizeRequest = resource.MustParse("1Ki")
+		member := testMemberForCluster(ec, 0)
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		err := createPVCForMember(ctx, fakeClient, ec, member, memberPodName(ec.Name, 0), scheme)
+		assert.ErrorContains(t, err, "VolumeSizeRequest must be at least 1Mi")
 	})
 }
 
@@ -322,6 +388,72 @@ func TestPeerEndpointForOrdinal(t *testing.T) {
 
 	assert.Equal(t, "http://test-cluster-0.test-cluster.default.svc.cluster.local:2380", httpURL)
 	assert.Equal(t, "https://test-cluster-0.test-cluster.default.svc.cluster.local:2380", httpsURL)
+}
+
+// ---------------------------------------------------------------------------
+// getMemberNameFromPeerURL — member name encoded in a peer URL
+// ---------------------------------------------------------------------------
+
+func TestGetMemberNameFromPeerURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		peerURL  string
+		wantName string
+	}{
+		{
+			name:     "http peer URL",
+			peerURL:  "http://etcd-0.etcd.default.svc.cluster.local:2380",
+			wantName: "etcd-0",
+		},
+		{
+			name:     "https peer URL",
+			peerURL:  "https://etcd-12.etcd.kube-system.svc.cluster.local:2380",
+			wantName: "etcd-12",
+		},
+		{
+			name:     "cluster name containing dashes and digits",
+			peerURL:  "http://my-cluster-2-1.my-cluster-2.default.svc.cluster.local:2380",
+			wantName: "my-cluster-2-1",
+		},
+		{
+			name:     "non-default DNS domain",
+			peerURL:  "http://etcd-1.etcd.prod.svc.my.custom.domain:2380",
+			wantName: "etcd-1",
+		},
+		{
+			name:     "hostname without dots",
+			peerURL:  "http://etcd-0:2380",
+			wantName: "etcd-0",
+		},
+		{
+			name:     "missing scheme has no host",
+			peerURL:  "etcd-0.etcd.default.svc.cluster.local:2380",
+			wantName: "",
+		},
+		{
+			name:     "empty input",
+			peerURL:  "",
+			wantName: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantName, getMemberNameFromPeerURL(tt.peerURL))
+		})
+	}
+}
+
+func TestGetMemberNameFromPeerURLRoundtrip(t *testing.T) {
+	cluster := &ecv1alpha1.EtcdCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-cluster", Namespace: "prod"},
+		Spec:       ecv1alpha1.EtcdClusterSpec{TLS: &ecv1alpha1.TLSCertificate{Provider: "auto"}},
+	}
+	for _, ordinal := range []int{0, 1, 42} {
+		wantName, peerURL := peerEndpointForOrdinalIndex(cluster, ordinal)
+		assert.Equal(t, wantName, getMemberNameFromPeerURL(peerURL),
+			"peer URL %q should round-trip", peerURL)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/test/e2e/auto_provider_test.go
+++ b/test/e2e/auto_provider_test.go
@@ -197,7 +197,7 @@ func TestClusterAutoCertCreation(t *testing.T) {
 
 	feature.Assess("Wait for etcd pods readiness",
 		func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-			if err := waitForPodReadiness(t, c, etcdClusterName, size); err != nil {
+			if err := waitForAllEtcdMemberReady(t, c, etcdCluster); err != nil {
 				t.Fatalf("etcd pods of cluster %s failed to reach readiness for %d replicas: %v", etcdClusterName, size, err)
 			}
 			return ctx

--- a/test/e2e/datapersistence_test.go
+++ b/test/e2e/datapersistence_test.go
@@ -83,7 +83,7 @@ func TestDataPersistence(t *testing.T) {
 
 	feature.Assess("Check if there exists one replica of the etcd pod",
 		func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-			if err := waitForPodReadiness(t, c, etcdClusterName, 1); err != nil {
+			if err := waitForAllEtcdMemberReady(t, c, etcdCluster); err != nil {
 				t.Fatalf("unable to find the replica of the etcd pod: %s", err)
 			}
 			return ctx
@@ -141,7 +141,7 @@ func TestDataPersistence(t *testing.T) {
 
 			client := c.Client()
 
-			if err := waitForPodReadiness(t, c, etcdClusterName, 1); err != nil {
+			if err := waitForAllEtcdMemberReady(t, c, etcdCluster); err != nil {
 				t.Fatalf("unable to scale the etcd pod back post pod deletion: %s", err)
 			}
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -128,6 +128,85 @@ func TestClusterHealthy(t *testing.T) {
 	_ = testEnv.Test(t, feature.Feature())
 }
 
+func TestNormalMemberProvisioning(t *testing.T) {
+	testCases := []struct {
+		name        string
+		initialSize int
+		desiredSize int
+	}{
+		{name: "CreateSize3", initialSize: 3, desiredSize: 3},
+		{name: "ScaleOutFrom1To3", initialSize: 1, desiredSize: 3},
+		{name: "ScaleOutFrom3To5", initialSize: 3, desiredSize: 5},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			feature := features.New(tc.name)
+			clusterName := "normal-" + strings.ToLower(tc.name)
+
+			feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+				createEtcdClusterWithPVC(ctx, t, c, clusterName, tc.initialSize)
+				if tc.initialSize < tc.desiredSize {
+					if err := waitForAllEtcdMemberReady(t, c, etcdClusterRef(clusterName, tc.initialSize)); err != nil {
+						t.Fatalf("initial members did not become Ready: %v", err)
+					}
+				}
+				return ctx
+			})
+
+			feature.Assess("provision members in ordinal order", func(
+				ctx context.Context,
+				t *testing.T,
+				c *envconf.Config,
+			) context.Context {
+				if tc.initialSize != tc.desiredSize {
+					scaleEtcdCluster(ctx, t, c, clusterName, tc.desiredSize)
+				}
+				if err := waitForAllEtcdMemberReady(t, c, etcdClusterRef(clusterName, tc.desiredSize)); err != nil {
+					t.Fatalf("EtcdMembers did not become Ready in order: %v", err)
+				}
+				return ctx
+			})
+
+			feature.Assess("all final members are voting", func(
+				ctx context.Context,
+				t *testing.T,
+				c *envconf.Config,
+			) context.Context {
+				var pods corev1.PodList
+				if err := c.Client().Resources().List(
+					ctx,
+					&pods,
+					resources.WithLabelSelector("app="+clusterName),
+				); err != nil {
+					t.Fatalf("failed to list final Pods: %v", err)
+				}
+				if len(pods.Items) != tc.desiredSize {
+					t.Fatalf("expected %d Pods, got %d", tc.desiredSize, len(pods.Items))
+				}
+
+				memberList := getEtcdMemberListPB(t, c, clusterName+"-0")
+				if len(memberList.Members) != tc.desiredSize {
+					t.Fatalf("expected %d live etcd members, got %d", tc.desiredSize, len(memberList.Members))
+				}
+				for _, member := range memberList.Members {
+					if member.IsLearner {
+						t.Fatalf("member %s (%d) remained a learner", member.Name, member.ID)
+					}
+				}
+				return ctx
+			})
+
+			feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
+				cleanupEtcdCluster(ctx, t, c, clusterName)
+				return ctx
+			})
+
+			_ = testEnv.Test(t, feature.Feature())
+		})
+	}
+}
+
 func TestScaling(t *testing.T) {
 	// TODO: scaleCluster only provisions ordinal 0 (bootstrap); join mechanics
 	// for ordinal >= 1 (MemberAdd as learner + cert/PVC/Pod + promote, §4.6)
@@ -172,7 +251,7 @@ func TestScaling(t *testing.T) {
 					}
 				}
 				createEtcdClusterWithPVC(ctx, t, c, etcdClusterName, tc.initialSize)
-				if err := waitForPodReadiness(t, c, etcdClusterName, tc.initialSize); err != nil {
+				if err := waitForAllEtcdMemberReady(t, c, etcdClusterRef(etcdClusterName, tc.initialSize)); err != nil {
 					t.Fatalf("etcd pods of cluster %s failed to reach readiness for %d replicas: %v",
 						etcdClusterName, tc.initialSize, err)
 				}
@@ -184,7 +263,7 @@ func TestScaling(t *testing.T) {
 				func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 					scaleEtcdCluster(ctx, t, c, etcdClusterName, tc.scaleTo)
 					// Wait until pod spec/status reflect the scaled replicas are ready
-					if err := waitForPodReadiness(t, c, etcdClusterName, tc.scaleTo); err != nil {
+					if err := waitForAllEtcdMemberReady(t, c, etcdClusterRef(etcdClusterName, tc.scaleTo)); err != nil {
 						t.Fatalf("could not scale the cluster to %d replicas: %s", tc.scaleTo, err)
 					}
 					return ctx
@@ -244,7 +323,7 @@ func TestPodRecovery(t *testing.T) {
 	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		clusterSize := 3
 		createEtcdClusterWithPVC(ctx, t, c, etcdClusterName, clusterSize)
-		if err := waitForPodReadiness(t, c, etcdClusterName, clusterSize); err != nil {
+		if err := waitForAllEtcdMemberReady(t, c, etcdClusterRef(etcdClusterName, clusterSize)); err != nil {
 			t.Fatalf("etcd pods of cluster %s failed to reach readiness for %d replicas: %v", etcdClusterName, clusterSize, err)
 		}
 		return ctx
@@ -298,7 +377,7 @@ func TestPodRecovery(t *testing.T) {
 			}
 
 			// Wait for all pod readiness
-			if err := waitForPodReadiness(t, c, etcdClusterName, initialReplicas); err != nil {
+			if err := waitForAllEtcdMemberReady(t, c, etcdClusterRef(etcdClusterName, initialReplicas)); err != nil {
 				t.Fatalf("etcd pods of cluster %s failed to reach readiness for %d replicas: %v",
 					etcdClusterName, initialReplicas, err)
 			}
@@ -360,7 +439,7 @@ func TestEtcdClusterFunctionality(t *testing.T) {
 	feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
 		clusterSize := 3
 		createEtcdClusterWithPVC(ctx, t, c, etcdClusterName, clusterSize)
-		if err := waitForPodReadiness(t, c, etcdClusterName, clusterSize); err != nil {
+		if err := waitForAllEtcdMemberReady(t, c, etcdClusterRef(etcdClusterName, clusterSize)); err != nil {
 			t.Fatalf("etcd pods of cluster %s failed to reach readiness for %d replicas: %v", etcdClusterName, clusterSize, err)
 		}
 		return ctx

--- a/test/e2e/etcd_options_test.go
+++ b/test/e2e/etcd_options_test.go
@@ -100,7 +100,7 @@ func TestEtcdOptions(t *testing.T) {
 
 	feature.Assess("Check if the etcd pod is created and the cluster has the desired replicas",
 		func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			if err := waitForPodReadiness(t, cfg, etcdCluster.Name, etcdCluster.Spec.Size); err != nil {
+			if err := waitForAllEtcdMemberReady(t, cfg, etcdCluster); err != nil {
 				t.Fatal(err)
 			}
 			return ctx

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -105,36 +105,105 @@ func createEtcdClusterWithPVC(ctx context.Context, t *testing.T, c *envconf.Conf
 	}
 }
 
-func waitForPodReadiness(t *testing.T, c *envconf.Config, name string, expectedReplicas int) error {
+// etcdClusterRef builds a minimal EtcdCluster reference in the e2e test
+// namespace, for wait helpers that only need the cluster's name and size.
+func etcdClusterRef(name string, size int) *ecv1alpha1.EtcdCluster {
+	return &ecv1alpha1.EtcdCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       ecv1alpha1.EtcdClusterSpec{Size: size},
+	}
+}
+
+// waitForAllEtcdMemberReady waits until the cluster converges to the size
+// recorded in ec.Spec.Size, checking every layer of readiness:
+//   - EtcdMember objects: exactly that many, all Phase Ready, provisioned
+//     strictly in ascending ordinal order (a higher ordinal appearing before
+//     every lower one is Ready fails immediately).
+//   - Pods: the same number of them, all Ready.
+//   - etcd membership itself, via the etcd client: that many members with no
+//     learner left unpromoted.
+func waitForAllEtcdMemberReady(t *testing.T, c *envconf.Config, ec *ecv1alpha1.EtcdCluster) error {
 	t.Helper()
-	label := fmt.Sprintf("app=%s", name)
+	expectedMembers := ec.Spec.Size
+	// Declared outside the polling closure so a failed Pod listing can still
+	// dump logs of the Pods observed on the previous pass.
 	var pods corev1.PodList
 	return wait.For(func(ctx context.Context) (bool, error) {
-		if err := c.Client().Resources().List(ctx, &pods, resources.WithLabelSelector(label)); err != nil {
-			t.Logf("failed to list pods by label %s, %s", label, err)
-			for _, pod := range pods.Items {
-				dumpPodLogs(context.TODO(), t, c, &pod, 500)
-			}
+		var memberList ecv1alpha1.EtcdMemberList
+		if err := c.Client().Resources().List(ctx, &memberList); err != nil {
+			t.Logf("failed to list EtcdMembers for %s: %v", ec.Name, err)
 			return false, nil
 		}
 
-		var readyCnt = 0
-		var unreadyPods []string
-		for _, pod := range pods.Items {
-			if !podReady(&pod) {
-				unreadyPods = append(unreadyPods, pod.Name)
-			} else {
-				readyCnt++
+		members := map[int]ecv1alpha1.EtcdMember{}
+		for i := range memberList.Items {
+			member := memberList.Items[i]
+			if member.Namespace == ec.Namespace && member.Spec.ClusterName == ec.Name {
+				members[member.Spec.Ordinal] = member
 			}
 		}
-		if readyCnt != expectedReplicas {
-			t.Logf("found pods(%d/%d/%d) by label(%s). unready pods: %s",
-				readyCnt, len(pods.Items), expectedReplicas, label, unreadyPods)
+
+		for ordinal := range members {
+			if ordinal >= expectedMembers {
+				return false, fmt.Errorf("unexpected EtcdMember ordinal %d for size %d", ordinal, expectedMembers)
+			}
+			for previousOrdinal := range ordinal {
+				previous, exists := members[previousOrdinal]
+				if !exists || previous.Status.Phase != ecv1alpha1.EtcdMemberReady {
+					return false, fmt.Errorf(
+						"EtcdMember %d appeared before ordinal %d was Ready",
+						ordinal,
+						previousOrdinal,
+					)
+				}
+			}
+		}
+
+		if len(members) != expectedMembers {
+			return false, nil
+		}
+		for ordinal := range expectedMembers {
+			member, exists := members[ordinal]
+			if !exists || member.Status.Phase != ecv1alpha1.EtcdMemberReady {
+				return false, nil
+			}
+		}
+
+		if err := c.Client().Resources().List(ctx, &pods, resources.WithLabelSelector("app="+ec.Name)); err != nil {
+			t.Logf("failed to list Pods for %s: %v", ec.Name, err)
+			for i := range pods.Items {
+				dumpPodLogs(ctx, t, c, &pods.Items[i], 500)
+			}
+			return false, nil
+		}
+		readyPods := 0
+		for i := range pods.Items {
+			if podReady(&pods.Items[i]) {
+				readyPods++
+			}
+		}
+		if readyPods != expectedMembers {
+			t.Logf("pods ready %d/%d for cluster %s", readyPods, expectedMembers, ec.Name)
 			return false, nil
 		}
 
+		// Pods are Ready, so the etcd client endpoint exists: the live
+		// membership must match the expected size with no learner left.
+		live, err := getEtcdMemberList(t, c, ec.Namespace, ec.Name+"-0", ec.Name, ec.Spec.TLS != nil)
+		if err != nil {
+			t.Logf("failed to get etcd member list for %s: %v", ec.Name, err)
+			return false, nil
+		}
+		if len(live.Members) != expectedMembers {
+			return false, nil
+		}
+		for _, member := range live.Members {
+			if member.IsLearner {
+				return false, nil
+			}
+		}
 		return true, nil
-	}, wait.WithTimeout(5*time.Minute), wait.WithInterval(10*time.Second))
+	}, wait.WithTimeout(5*time.Minute), wait.WithInterval(2*time.Second))
 }
 
 func podReady(pod *corev1.Pod) bool {
@@ -243,18 +312,37 @@ func getEtcdMembersName2IDMapping(t *testing.T, c *envconf.Config, podName strin
 	return memberMap
 }
 
-// getEtcdMemberListPB returns the etcdserverpb.MemberListResponse by calling etcdctl -w json.
-func getEtcdMemberListPB(t *testing.T, c *envconf.Config, podName string) *etcdserverpb.MemberListResponse {
+// getEtcdMemberList returns the etcdserverpb.MemberListResponse by calling
+// etcdctl -w json inside the given Pod, using the cluster's client
+// certificates when tlsEnabled.
+func getEtcdMemberList(
+	t *testing.T,
+	c *envconf.Config,
+	podNamespace, podName, clusterName string,
+	tlsEnabled bool,
+) (*etcdserverpb.MemberListResponse, error) {
 	t.Helper()
-	stdout, stderr, err := execInPod(t, c, podName, namespace, []string{"etcdctl", "member", "list", "-w", "json"})
+	cmd := append(etcdctlCmd(podName, clusterName, podNamespace, tlsEnabled), "member", "list", "-w", "json")
+	stdout, stderr, err := execInPod(t, c, podName, podNamespace, cmd)
 	if err != nil {
-		t.Fatalf("Failed to get etcd member list: %v, stderr: %s", err, stderr)
+		return nil, fmt.Errorf("etcd member list via %s: %w, stderr: %s", podName, err, stderr)
 	}
 	var memberList etcdserverpb.MemberListResponse
 	if err := json.Unmarshal([]byte(stdout), &memberList); err != nil {
-		t.Fatalf("Failed to parse etcd member list JSON: %v", err)
+		return nil, fmt.Errorf("parsing etcd member list JSON: %w", err)
 	}
-	return &memberList
+	return &memberList, nil
+}
+
+// getEtcdMemberListPB is the fatal-on-error wrapper around getEtcdMemberList
+// for non-TLS assertions that run after the target Pod is already Ready.
+func getEtcdMemberListPB(t *testing.T, c *envconf.Config, podName string) *etcdserverpb.MemberListResponse {
+	t.Helper()
+	memberList, err := getEtcdMemberList(t, c, namespace, podName, "", false)
+	if err != nil {
+		t.Fatalf("Failed to get etcd member list: %v", err)
+	}
+	return memberList
 }
 
 // waitForNoLearners waits until the member list has the expected number of members
@@ -417,7 +505,7 @@ func dumpPodLogs(ctx context.Context, t *testing.T, c *envconf.Config, pod *core
 		return
 	}
 	client := kubernetes.NewForConfigOrDie(c.Client().RESTConfig())
-	req := client.CoreV1().Pods(namespace).GetLogs(pod.Name, &corev1.PodLogOptions{TailLines: &tailLine})
+	req := client.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{TailLines: &tailLine})
 	stream, streamErr := req.Stream(ctx)
 	if streamErr != nil {
 		t.Logf("failed to stream log for pod %s/%s: %s", pod.Namespace, pod.Name, streamErr)


### PR DESCRIPTION
Resolve #469 , Link #362

Design notes:
- Why **empty string** is a valid provisioning phase of EtcdMember: object create and status write in `createEtcdMember` are two calls, and a crash in between leaves a phase-less object that must resume, not restart. See the comments in `reconcileEtcdMember` and `isProvisioningPhase`.
- `Owns(&corev1.Pod{})` covers legacy pods still controlled directly by the EtcdCluster. I am not sure if we should maintain the backward compatability. 
- Why `Replacing` counts as a provisioning phase: the desgin doc  defines it as "leaving, about to rejoin fresh" — the rejoin half reuses the join ladder.

/cc @ahrtr @nwnt @ArkaSaha30 @GunaKKIBM 