### PR TITLE
feat: add pod config drift detection

### DIFF
--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -262,8 +263,9 @@ func (r *EtcdClusterReconciler) validateSpec(ctx context.Context, s *reconcileSt
 			if currentVersion != targetVersion {
 				canParse, err := validateEtcdUpgradePath(etcdversions.AllVersions, currentVersion, targetVersion)
 				if !canParse {
-					logger.Info("error when parsing reconcile versions; it is your responsibility "+
-						"to validate if the upgrade path is supported",
+					logger.Info(
+						"error when parsing reconcile versions; it is your responsibility "+
+							"to validate if the upgrade path is supported",
 						"current", currentVersion,
 						"target", targetVersion,
 						"error", err,
@@ -271,7 +273,8 @@ func (r *EtcdClusterReconciler) validateSpec(ctx context.Context, s *reconcileSt
 					return nil
 				}
 				if err != nil {
-					logger.Error(err, "unsupported upgrade path between current and target versions",
+					logger.Error(
+						err, "unsupported upgrade path between current and target versions",
 						"current", currentVersion,
 						"target", targetVersion,
 					)
@@ -527,13 +530,43 @@ func (r *EtcdClusterReconciler) clearMemberFinalizer(ctx context.Context, m *ecv
 }
 
 // updateConfig compares each member's running configuration against
-// EtcdCluster.Spec and recreates the first Pod whose config has drifted.
+// EtcdCluster.Spec and recreates the first member whose Pod config has drifted.
 //
 // TODO: §4.6's Pod-recovery ladder (its config-drift branch) covers
 // this once M3 lands; recreating one member at a time, highest ordinal
 // first, transferring leadership first if needed (§4.5).
 func (r *EtcdClusterReconciler) updateConfig(ctx context.Context, s *reconcileState) (ctrl.Result, error) {
-	return ctrl.Result{}, nil
+	logger := log.FromContext(ctx)
+	hash := EtcdClusterHash(s.cluster)
+
+	var healthInfo map[string]etcdutils.EpHealth
+	if s.health != nil {
+		healthInfo = s.health.Members
+	}
+
+	member := pickMemberToUpdate(s.members, s.pods, hash, healthInfo)
+	if member == nil {
+		return ctrl.Result{}, nil
+	}
+
+	logger.Info("a member with outdated config found", "member", member.Name)
+	member.Status.Phase = ecv1alpha1.EtcdMemberRecreating
+	if err := r.Status().Update(ctx, member); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{RequeueAfter: requeueDuration}, nil
+}
+
+// findConfigDriftingPod finds the pod with the highest ordinal that has its config hash
+// not matched with the expected hash. It returns nil when all pods match the hash.
+// This function assumes that the pods slice is already sorted.
+func findConfigDriftingPod(pods []*corev1.Pod, expectedHash string) *corev1.Pod {
+	for _, p := range slices.Backward(pods) {
+		if p.Annotations == nil || p.Annotations[HashMetadataKey] != expectedHash {
+			return p
+		}
+	}
+	return nil
 }
 
 // scaleCluster grows or shrinks the cluster by one member at a time towards
@@ -595,7 +628,8 @@ func (r *EtcdClusterReconciler) upgradeCluster(ctx context.Context, s *reconcile
 		return ctrl.Result{}, nil
 	}
 
-	logger.Info("[Upgrade] marking member for recreation",
+	logger.Info(
+		"[Upgrade] marking member for recreation",
 		"member", memberToUpgrade.Name,
 		"targetVersion", targetVersion, "currentVersion", memberToUpgrade.Spec.Version,
 	)
@@ -719,7 +753,8 @@ func (r *EtcdClusterReconciler) updateConditions(s *reconcileState) {
 		} else {
 			availableCondition.Message = fmt.Sprintf(
 				"Etcd cluster has %d/%d healthy members, quorum requires %d",
-				healthyCount, len(s.memberListResp.Members), quorum)
+				healthyCount, len(s.memberListResp.Members), quorum,
+			)
 		}
 	}
 

--- a/internal/controller/etcdcluster_controller_test.go
+++ b/internal/controller/etcdcluster_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -732,10 +733,371 @@ func TestEnsureClusterFinalizer(t *testing.T) {
 	})
 }
 
-// TestFinalizeCluster verifies the EtcdCluster deletion path: live members
-// are deleted, already-Terminating members have their finalizers released
-// directly so Kubernetes GC can remove their owned resources, and only once
-// no members remain does the cluster's own finalizer get released.
+func TestFindConfigDriftingPod(t *testing.T) {
+	const expectedHash = "abc123def456"
+	const differentHash = "fed654cba321"
+
+	makePod := func(name, annotationHash string) *corev1.Pod {
+		p := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+			},
+		}
+		if annotationHash != "" {
+			p.Annotations = map[string]string{HashMetadataKey: annotationHash}
+		}
+		return p
+	}
+
+	tests := []struct {
+		name           string
+		pods           []*corev1.Pod
+		expectedHash   string
+		expectedResult *corev1.Pod // nil means no drifted pod found
+	}{
+		{
+			name:           "no pods returns nil",
+			pods:           nil,
+			expectedHash:   expectedHash,
+			expectedResult: nil,
+		},
+		{
+			name:           "empty slice returns nil",
+			pods:           []*corev1.Pod{},
+			expectedHash:   expectedHash,
+			expectedResult: nil,
+		},
+		{
+			name: "all pods matching expected hash returns nil",
+			pods: []*corev1.Pod{
+				makePod("etcd-0", expectedHash),
+				makePod("etcd-1", expectedHash),
+				makePod("etcd-2", expectedHash),
+			},
+			expectedHash:   expectedHash,
+			expectedResult: nil,
+		},
+		{
+			name: "highest ordinal drifted pod is returned",
+			pods: []*corev1.Pod{
+				makePod("etcd-0", expectedHash),
+				makePod("etcd-1", expectedHash),
+				makePod("etcd-2", differentHash), // highest ordinal drifted
+			},
+			expectedHash:   expectedHash,
+			expectedResult: makePod("etcd-2", differentHash),
+		},
+		{
+			name: "middle ordinal drifted pod is returned when higher matches",
+			pods: []*corev1.Pod{
+				makePod("etcd-0", expectedHash),
+				makePod("etcd-1", differentHash), // middle ordinal drifted
+				makePod("etcd-2", expectedHash),
+			},
+			expectedHash:   expectedHash,
+			expectedResult: makePod("etcd-1", differentHash),
+		},
+		{
+			name: "lowest ordinal drifted pod is returned when all higher match",
+			pods: []*corev1.Pod{
+				makePod("etcd-0", differentHash), // lowest ordinal drifted
+				makePod("etcd-1", expectedHash),
+				makePod("etcd-2", expectedHash),
+			},
+			expectedHash:   expectedHash,
+			expectedResult: makePod("etcd-0", differentHash),
+		},
+		{
+			name: "multiple drifted pods - highest ordinal wins",
+			pods: []*corev1.Pod{
+				makePod("etcd-0", differentHash),
+				makePod("etcd-1", differentHash),
+				makePod("etcd-2", differentHash),
+			},
+			expectedHash:   expectedHash,
+			expectedResult: makePod("etcd-2", differentHash),
+		},
+		{
+			name: "pod without annotation is treated as drifted",
+			pods: []*corev1.Pod{
+				makePod("etcd-0", expectedHash),
+				makePod("etcd-1", ""), // missing annotation
+				makePod("etcd-2", expectedHash),
+			},
+			expectedHash:   expectedHash,
+			expectedResult: makePod("etcd-1", ""),
+		},
+		{
+			name: "single pod matching returns nil",
+			pods: []*corev1.Pod{
+				makePod("etcd-0", expectedHash),
+			},
+			expectedHash:   expectedHash,
+			expectedResult: nil,
+		},
+		{
+			name: "single pod not matching returns that pod",
+			pods: []*corev1.Pod{
+				makePod("etcd-0", differentHash),
+			},
+			expectedHash:   expectedHash,
+			expectedResult: makePod("etcd-0", differentHash),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := findConfigDriftingPod(tt.pods, tt.expectedHash)
+			if tt.expectedResult == nil {
+				assert.Nil(t, result, "expected no drifted pod")
+			} else {
+				require.NotNil(t, result, "expected drifted pod")
+				assert.Equal(t, tt.expectedResult.Name, result.Name)
+				// Also verify annotations match
+				if tt.expectedResult.Annotations == nil {
+					assert.Nil(t, result.Annotations)
+				} else {
+					assert.Equal(t, tt.expectedResult.Annotations[HashMetadataKey], result.Annotations[HashMetadataKey])
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateConfig(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, ecv1alpha1.AddToScheme(scheme))
+
+	ec := &ecv1alpha1.EtcdCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "etcd", Namespace: "default", UID: "1"},
+		Spec:       ecv1alpha1.EtcdClusterSpec{Size: 3, Version: "3.5.17"},
+	}
+	expectedHash := EtcdClusterHash(ec)
+	staleHash := "stale-hash-000001"
+
+	// Cluster of size 1 for single-node tests
+	ecSize1 := &ecv1alpha1.EtcdCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "etcd", Namespace: "default", UID: "1"},
+		Spec:       ecv1alpha1.EtcdClusterSpec{Size: 1, Version: "3.5.17"},
+	}
+	expectedHashSize1 := EtcdClusterHash(ecSize1)
+
+	tests := []struct {
+		name           string
+		pods           []*corev1.Pod
+		members        []ecv1alpha1.EtcdMember
+		health         *etcdutils.ClusterHealth
+		expectedResult ctrl.Result
+		wantRecreating []int
+	}{
+		{
+			name: "no drifted pods is a no-op",
+			pods: []*corev1.Pod{
+				makeConfigDriftPod(ec, 0, expectedHash),
+				makeConfigDriftPod(ec, 1, expectedHash),
+				makeConfigDriftPod(ec, 2, expectedHash),
+			},
+			members:        createReadyMembers(ec, 3),
+			health:         createClusterHealthWithLeader(ec, 3, 2),
+			expectedResult: ctrl.Result{},
+			wantRecreating: nil,
+		},
+		{
+			name: "marks the matching member Recreating and requeues",
+			pods: []*corev1.Pod{
+				makeConfigDriftPod(ec, 0, expectedHash),
+				makeConfigDriftPod(ec, 1, staleHash), // middle ordinal drifted
+				makeConfigDriftPod(ec, 2, expectedHash),
+			},
+			members:        createReadyMembers(ec, 3),
+			health:         createClusterHealthWithLeader(ec, 3, 2),
+			expectedResult: ctrl.Result{RequeueAfter: requeueDuration},
+			wantRecreating: []int{1},
+		},
+		{
+			name: "highest ordinal drifted pod is the one recreated",
+			pods: []*corev1.Pod{
+				makeConfigDriftPod(ec, 0, staleHash),
+				makeConfigDriftPod(ec, 1, staleHash), // leader drifter
+				makeConfigDriftPod(ec, 2, staleHash),
+			},
+			members:        createReadyMembers(ec, 3),
+			health:         createClusterHealthWithLeader(ec, 3, 1),
+			expectedResult: ctrl.Result{RequeueAfter: requeueDuration},
+			wantRecreating: []int{2},
+		},
+		{
+			name: "pod with nil annotations is treated as drift",
+			pods: []*corev1.Pod{
+				makeConfigDriftPod(ec, 0, expectedHash),
+				makeConfigDriftPod(ec, 1, ""), // nil annotations
+				makeConfigDriftPod(ec, 2, expectedHash),
+			},
+			members:        createReadyMembers(ec, 3),
+			health:         createClusterHealthWithLeader(ec, 3, 2),
+			expectedResult: ctrl.Result{RequeueAfter: requeueDuration},
+			wantRecreating: []int{1},
+		},
+		{
+			name: "drifted pod with no matching member is a no-op",
+			pods: []*corev1.Pod{
+				makeConfigDriftPod(ec, 0, expectedHash),
+				makeConfigDriftPod(ec, 1, staleHash),
+			},
+			// no EtcdMember exists for ordinal 1, so there is nothing to update
+			members:        []ecv1alpha1.EtcdMember{createReadyMembers(ec, 3)[0]},
+			health:         createClusterHealthWithLeader(ec, 3, 0),
+			expectedResult: ctrl.Result{},
+			wantRecreating: nil,
+		},
+		{
+			name: "defers a leader drifter when a lower-ordinal member also drifts",
+			pods: []*corev1.Pod{
+				makeConfigDriftPod(ec, 0, expectedHash),
+				makeConfigDriftPod(ec, 1, staleHash),
+				makeConfigDriftPod(ec, 2, staleHash),
+			},
+			members:        createReadyMembers(ec, 3),
+			health:         createClusterHealthWithLeader(ec, 3, 2),
+			expectedResult: ctrl.Result{RequeueAfter: requeueDuration},
+			wantRecreating: []int{1},
+		},
+		{
+			name: "recreates the leader when it is the only drifted pod",
+			pods: []*corev1.Pod{
+				makeConfigDriftPod(ec, 0, expectedHash),
+				makeConfigDriftPod(ec, 1, expectedHash),
+				makeConfigDriftPod(ec, 2, staleHash),
+			},
+			members:        createReadyMembers(ec, 3),
+			health:         createClusterHealthWithLeader(ec, 3, 2),
+			expectedResult: ctrl.Result{RequeueAfter: requeueDuration},
+			wantRecreating: []int{2},
+		},
+		{
+			name: "size 1 - no drifted pods is a no-op",
+			pods: []*corev1.Pod{
+				makeConfigDriftPod(ecSize1, 0, expectedHashSize1),
+			},
+			members:        createReadyMembers(ecSize1, 1),
+			health:         createClusterHealthWithLeader(ecSize1, 1, 0),
+			expectedResult: ctrl.Result{},
+			wantRecreating: nil,
+		},
+		{
+			name: "size 1 - single drifted pod marks the only member Recreating",
+			pods: []*corev1.Pod{
+				makeConfigDriftPod(ecSize1, 0, staleHash),
+			},
+			members:        createReadyMembers(ecSize1, 1),
+			health:         createClusterHealthWithLeader(ecSize1, 1, 0),
+			expectedResult: ctrl.Result{RequeueAfter: requeueDuration},
+			wantRecreating: []int{0},
+		},
+		{
+			name: "size 1 - single pod with nil annotations is treated as drift",
+			pods: []*corev1.Pod{
+				makeConfigDriftPod(ecSize1, 0, ""),
+			},
+			members:        createReadyMembers(ecSize1, 1),
+			health:         createClusterHealthWithLeader(ecSize1, 1, 0),
+			expectedResult: ctrl.Result{RequeueAfter: requeueDuration},
+			wantRecreating: []int{0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+
+			objs := make([]client.Object, 0, len(tt.members))
+			for i := range tt.members {
+				objs = append(objs, &tt.members[i])
+			}
+			r := &EtcdClusterReconciler{
+				Client: fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithStatusSubresource(&ecv1alpha1.EtcdMember{}).
+					WithObjects(objs...).
+					Build(),
+				Scheme: scheme,
+			}
+
+			state := &reconcileState{
+				cluster: ec,
+				members: tt.members,
+				pods:    tt.pods,
+				health:  tt.health,
+			}
+
+			res, err := r.updateConfig(ctx, state)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedResult, res)
+
+			for i := range tt.members {
+				m := &ecv1alpha1.EtcdMember{}
+				require.NoError(t, r.Get(ctx, client.ObjectKey{Name: tt.members[i].Name, Namespace: ec.Namespace}, m))
+				want := ecv1alpha1.EtcdMemberReady
+				if slices.Contains(tt.wantRecreating, tt.members[i].Spec.Ordinal) {
+					want = ecv1alpha1.EtcdMemberRecreating
+				}
+				assert.Equal(t, want, m.Status.Phase, "member %s phase", m.Name)
+			}
+		})
+	}
+}
+
+func createMemberWithPhase(ec *ecv1alpha1.EtcdCluster, ordinal int, phase ecv1alpha1.EtcdMemberPhase) *ecv1alpha1.EtcdMember {
+	m := testMemberForCluster(ec, ordinal)
+	m.Status.Phase = phase
+	return m
+}
+
+func makeConfigDriftPod(ec *ecv1alpha1.EtcdCluster, ordinal int, hash string) *corev1.Pod {
+	p := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      etcdMemberName(ec.Name, ordinal),
+			Namespace: ec.Namespace,
+		},
+	}
+	if hash != "" {
+		p.Annotations = map[string]string{HashMetadataKey: hash}
+	}
+	return p
+}
+
+func createReadyMembers(ec *ecv1alpha1.EtcdCluster, count int) []ecv1alpha1.EtcdMember {
+	members := make([]ecv1alpha1.EtcdMember, 0, count)
+	for ordinal := range count {
+		members = append(members, *createMemberWithPhase(ec, ordinal, ecv1alpha1.EtcdMemberReady))
+	}
+	return members
+}
+
+func createClusterHealthWithLeader(ec *ecv1alpha1.EtcdCluster, size, leaderOrdinal int) *etcdutils.ClusterHealth {
+	leaderID := uint64(leaderOrdinal)
+	members := make(map[string]etcdutils.EpHealth, size)
+	for ordinal := range size {
+		name := etcdMemberName(ec.Name, ordinal)
+		members[name] = etcdutils.EpHealth{
+			Name: name,
+			Status: &clientv3.StatusResponse{
+				Header: &etcdserverpb.ResponseHeader{MemberId: uint64(ordinal)},
+				Leader: leaderID,
+			},
+		}
+	}
+	return &etcdutils.ClusterHealth{
+		Healthy: true,
+		Members: members,
+	}
+}
+
+// TestFinalizeCluster verifies the EtcdCluster deletion path: owned
+// EtcdMembers are removed one dispatch-step-7-style pass at a time, and only
+// once none remain does the cluster's own finalizer get released.
 func TestFinalizeCluster(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)

--- a/internal/controller/etcdmember.go
+++ b/internal/controller/etcdmember.go
@@ -17,6 +17,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -588,7 +589,8 @@ func etcdMemberName(clusterName string, ordinal int) string {
 // ordinal order. The label selector and namespace filter members belonging to the cluster.
 func listOwnedMembers(ctx context.Context, c client.Client, ec *ecv1alpha1.EtcdCluster) ([]ecv1alpha1.EtcdMember, error) {
 	memberList := &ecv1alpha1.EtcdMemberList{}
-	if err := c.List(ctx, memberList,
+	if err := c.List(
+		ctx, memberList,
 		client.InNamespace(ec.Namespace),
 		client.MatchingLabels(clusterNameLabels(ec.Name)),
 	); err != nil {
@@ -674,4 +676,30 @@ func createEtcdMember(ctx context.Context, c client.Client, ec *ecv1alpha1.EtcdC
 		return nil, err
 	}
 	return member, nil
+}
+
+// pickMemberToUpdate returns the member whose Pod has the highest ordinal with
+// a stored config hash different from expectedHash, skipping the leader when
+// another member is also drifted. Returns nil when no member has an outdated
+// config, or when the drifted Pod has no matching EtcdMember.
+func pickMemberToUpdate(members []ecv1alpha1.EtcdMember, pods []*corev1.Pod, expectedHash string, healthInfo map[string]etcdutils.EpHealth) *ecv1alpha1.EtcdMember {
+	drifter := findConfigDriftingPod(pods, expectedHash)
+	if drifter == nil {
+		return nil
+	}
+
+	// if the drifter is a leader, try finding another drifter first
+	if drifter.Name == findLeaderName(healthInfo) {
+		d := slices.Index(pods, drifter)
+		if another := findConfigDriftingPod(pods[:d], expectedHash); another != nil {
+			drifter = another
+		}
+	}
+
+	for i := range members {
+		if members[i].Name == drifter.Name {
+			return &members[i]
+		}
+	}
+	return nil
 }

--- a/internal/controller/etcdmember_test.go
+++ b/internal/controller/etcdmember_test.go
@@ -543,3 +543,149 @@ func TestMarkMemberTerminating(t *testing.T) {
 	// Already Terminating: no error, no write needed.
 	assert.NoError(t, r.markMemberTerminating(ctx, member))
 }
+
+func TestPickMemberToUpdate(t *testing.T) {
+	expectedHash := "abc123def456"
+	staleHash := "fed654cba321"
+	ec := &ecv1alpha1.EtcdCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "etcd", Namespace: "default", UID: "1"},
+		Spec:       ecv1alpha1.EtcdClusterSpec{Size: 3, Version: "3.5.17"},
+	}
+
+	// healthWithLeader returns the EpHealth map with the given ordinal as leader.
+	healthWithLeader := func(leaderOrdinal int) map[string]etcdutils.EpHealth {
+		return createClusterHealthWithLeader(ec, 3, leaderOrdinal).Members
+	}
+
+	tests := []struct {
+		name    string
+		members []ecv1alpha1.EtcdMember
+		pods    []*corev1.Pod
+		health  map[string]etcdutils.EpHealth
+		want    *ecv1alpha1.EtcdMember
+	}{
+		{
+			name:    "no pods returns nil",
+			members: createReadyMembers(ec, 3),
+			want:    nil,
+		},
+		{
+			name:    "all pods matching expected hash returns nil",
+			members: createReadyMembers(ec, 3),
+			pods: []*corev1.Pod{
+				makeConfigDriftPod(ec, 0, expectedHash),
+				makeConfigDriftPod(ec, 1, expectedHash),
+				makeConfigDriftPod(ec, 2, expectedHash),
+			},
+			want: nil,
+		},
+		{
+			name:    "highest ordinal drifted pod returns its member",
+			members: createReadyMembers(ec, 3),
+			pods: []*corev1.Pod{
+				makeConfigDriftPod(ec, 0, expectedHash),
+				makeConfigDriftPod(ec, 1, expectedHash),
+				makeConfigDriftPod(ec, 2, staleHash),
+			},
+			want: &createReadyMembers(ec, 3)[2],
+		},
+		{
+			name:    "middle ordinal drifted pod is picked when higher matches",
+			members: createReadyMembers(ec, 3),
+			pods: []*corev1.Pod{
+				makeConfigDriftPod(ec, 0, expectedHash),
+				makeConfigDriftPod(ec, 1, staleHash),
+				makeConfigDriftPod(ec, 2, expectedHash),
+			},
+			want: &createReadyMembers(ec, 3)[1],
+		},
+		{
+			name:    "pod without annotation is treated as drift",
+			members: createReadyMembers(ec, 3),
+			pods: []*corev1.Pod{
+				makeConfigDriftPod(ec, 0, expectedHash),
+				makeConfigDriftPod(ec, 1, ""), // no annotation
+				makeConfigDriftPod(ec, 2, expectedHash),
+			},
+			want: &createReadyMembers(ec, 3)[1],
+		},
+		{
+			name:    "skips the leader when another member is also drifted",
+			members: createReadyMembers(ec, 3),
+			pods: []*corev1.Pod{
+				makeConfigDriftPod(ec, 0, expectedHash),
+				makeConfigDriftPod(ec, 1, staleHash),
+				makeConfigDriftPod(ec, 2, staleHash),
+			},
+			health: healthWithLeader(2),
+			want:   &createReadyMembers(ec, 3)[1],
+		},
+		{
+			name:    "returns the leader when it is the only drifted pod",
+			members: createReadyMembers(ec, 3),
+			pods: []*corev1.Pod{
+				makeConfigDriftPod(ec, 0, expectedHash),
+				makeConfigDriftPod(ec, 1, expectedHash),
+				makeConfigDriftPod(ec, 2, staleHash),
+			},
+			health: healthWithLeader(2),
+			want:   &createReadyMembers(ec, 3)[2],
+		},
+		{
+			name:    "unknown leader does not defer the highest drifted pod",
+			members: createReadyMembers(ec, 3),
+			pods: []*corev1.Pod{
+				makeConfigDriftPod(ec, 0, staleHash),
+				makeConfigDriftPod(ec, 1, staleHash),
+				makeConfigDriftPod(ec, 2, staleHash),
+			},
+			want: &createReadyMembers(ec, 3)[2],
+		},
+		{
+			name:    "a drifted pod above the leader is not deferred",
+			members: createReadyMembers(ec, 3),
+			pods: []*corev1.Pod{
+				makeConfigDriftPod(ec, 0, staleHash),
+				makeConfigDriftPod(ec, 1, staleHash),
+				makeConfigDriftPod(ec, 2, staleHash),
+			},
+			health: healthWithLeader(0),
+			want:   &createReadyMembers(ec, 3)[2],
+		},
+		{
+			name:    "drifted pod with no matching member returns nil",
+			members: createReadyMembers(ec, 1),
+			pods: []*corev1.Pod{
+				makeConfigDriftPod(ec, 0, expectedHash),
+				makeConfigDriftPod(ec, 1, staleHash),
+			},
+			health: healthWithLeader(0),
+			want:   nil,
+		},
+		{
+			name:    "single matching pod returns nil",
+			members: createReadyMembers(ec, 1),
+			pods: []*corev1.Pod{
+				makeConfigDriftPod(ec, 0, expectedHash),
+			},
+			health: healthWithLeader(0),
+			want:   nil,
+		},
+		{
+			name:    "single drifted pod returns the only member",
+			members: createReadyMembers(ec, 1),
+			pods: []*corev1.Pod{
+				makeConfigDriftPod(ec, 0, staleHash),
+			},
+			health: healthWithLeader(0),
+			want:   &createReadyMembers(ec, 1)[0],
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pickMemberToUpdate(tt.members, tt.pods, expectedHash, tt.health)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Fix #411. Implement `updateConfig` config drift detection part.  After detected, the controller updates the corresponding `EtcdMember`'s phase to Recreating.  The reconciliation of Recreating logic will be implemented in phase 3.

cc @ahrtr @silentred 