### PR TITLE
fix: hash only explicit pod-config fields in EtcdClusterHash

### DIFF
--- a/internal/controller/etcdcluster.go
+++ b/internal/controller/etcdcluster.go
@@ -13,19 +13,56 @@ const (
 	hashLength = 12
 )
 
+// clusterHashInput is the explicit set of EtcdClusterSpec fields that
+// determine the etcd Pod's configuration. Only these fields participate in
+// EtcdClusterHash; a new spec field must be added here deliberately to
+// become part of the hash. Fields intentionally left out:
+//   - Size: scaling is handled separately from configuration.
+//   - Version: upgrades roll one member at a time elsewhere.
+//   - PodTemplate.Metadata: applied in place without a Pod roll.
+//   - Paused, AllowVersionUpgradeOnRepair: operator knobs, not Pod config.
+//
+// Because the input is this private struct rather than EtcdClusterSpec
+// itself, cosmetic API changes (renaming unrelated fields, adding new
+// operator knobs) cannot change the hash; only changes here or to a
+// whitelisted nested type do.
+type clusterHashInput struct {
+	ImageRegistry string
+	StorageSpec   *v1alpha1.StorageSpec
+	TLS           *v1alpha1.TLSCertificate
+	EtcdOptions   []string
+	PodSpec       *v1alpha1.PodSpec
+}
+
+// EtcdClusterHash returns a stable hash over the fields of the cluster spec
+// that determine the etcd Pod's configuration (see clusterHashInput).
+// Changing any other spec field must not change the hash, so toggling
+// operator knobs or scaling the cluster never marks Pods as drifted; in
+// particular a PodTemplate without a Spec — metadata only — hashes like no
+// PodTemplate at all.
+//
+// NOTE: changing this function or any whitelisted nested type (StorageSpec,
+// TLSCertificate, PodSpec) changes every hash output. After an operator
+// upgrade, every existing Pod's stored hash annotation would then look
+// drifted, rolling the whole cluster once. TestEtcdClusterHashPinned fails
+// on such a change; when it does, revisit this function before updating its
+// pinned expected value.
 func EtcdClusterHash(ec *v1alpha1.EtcdCluster) string {
-	clusterSpec := ec.DeepCopy().Spec
-	// size is not used for calculating the hash
-	clusterSpec.Size = 0
-	// version is handled separately
-	clusterSpec.Version = ""
-	clusterSpec.EtcdOptions = createArgs(ec.Name, ec.Spec.EtcdOptions, clusterTLSEnabled(ec))
-	// we don't want to roll etcd pods when metadata is changed.
-	// instead, we'd do in-place update for them.
-	if clusterSpec.PodTemplate != nil {
-		clusterSpec.PodTemplate.Metadata = nil
+	input := clusterHashInput{
+		ImageRegistry: ec.Spec.ImageRegistry,
+		StorageSpec:   ec.Spec.StorageSpec,
+		TLS:           ec.Spec.TLS,
+		// Hash the effective argument list: operator default arguments
+		// (including the TLS-dependent ones) merged with the user's options,
+		// so the hash reflects what the etcd process actually runs.
+		EtcdOptions: createArgs(ec.Name, ec.Spec.EtcdOptions, clusterTLSEnabled(ec)),
 	}
-	deterministicString := dump.ForHash(clusterSpec)
+	if ec.Spec.PodTemplate != nil {
+		// Only Spec rolls Pods; Metadata is applied in place. A nil Spec
+		// (or a metadata-only PodTemplate) hashes like no PodTemplate.
+		input.PodSpec = ec.Spec.PodTemplate.Spec
+	}
+	deterministicString := dump.ForHash(input)
 	hasher := sha256.New()
 	hasher.Write([]byte(deterministicString))
 	return hex.EncodeToString(hasher.Sum(nil))[:hashLength]

--- a/internal/controller/etcdcluster_test.go
+++ b/internal/controller/etcdcluster_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"go.etcd.io/etcd-operator/api/v1alpha1"
@@ -29,9 +31,6 @@ func TestEtcdClusterHash(t *testing.T) {
 			},
 		},
 	}
-
-	// Calculate base hash once to use as a benchmark in assertions
-	baseHash := EtcdClusterHash(baseCluster)
 
 	// Helper inline functions to generate mutated clusters cleanly
 	withSize := func(size int) *v1alpha1.EtcdCluster {
@@ -67,10 +66,55 @@ func TestEtcdClusterHash(t *testing.T) {
 		c.Spec.Version = "v8.8.8"
 		return c
 	}
+	withPaused := func() *v1alpha1.EtcdCluster {
+		c := baseCluster.DeepCopy()
+		c.Spec.Paused = true
+		return c
+	}
+	withAllowVersionUpgradeOnRepair := func() *v1alpha1.EtcdCluster {
+		c := baseCluster.DeepCopy()
+		c.Spec.AllowVersionUpgradeOnRepair = true
+		return c
+	}
+	withStorageSpecChanged := func() *v1alpha1.EtcdCluster {
+		c := baseCluster.DeepCopy()
+		c.Spec.StorageSpec = &v1alpha1.StorageSpec{
+			AccessModes:       corev1.ReadWriteOnce,
+			VolumeSizeRequest: resource.MustParse("10Gi"),
+		}
+		return c
+	}
+	withTLSChanged := func() *v1alpha1.EtcdCluster {
+		c := baseCluster.DeepCopy()
+		c.Spec.TLS = &v1alpha1.TLSCertificate{Provider: "cert-manager"}
+		return c
+	}
+	withPodSpecChanged := func() *v1alpha1.EtcdCluster {
+		c := baseCluster.DeepCopy()
+		c.Spec.PodTemplate.Spec.Tolerations = []corev1.Toleration{
+			{Key: "dedicated", Operator: corev1.TolerationOpExists},
+		}
+		return c
+	}
+	withNilPodTemplate := func() *v1alpha1.EtcdCluster {
+		c := baseCluster.DeepCopy()
+		c.Spec.PodTemplate = nil
+		return c
+	}
+	withPodTemplateMetadataChanged := func() *v1alpha1.EtcdCluster {
+		c := withNilPodTemplate().DeepCopy()
+		c.Spec.PodTemplate = &v1alpha1.PodTemplate{
+			Metadata: &v1alpha1.PodMetadata{
+				Labels: map[string]string{"foo": "bar"},
+			},
+		}
+		return c
+	}
 
 	// Define our table-driven test cases
 	tests := []struct {
 		name         string
+		baseCluster  *v1alpha1.EtcdCluster
 		cluster      *v1alpha1.EtcdCluster
 		expectEqual  bool
 		expectedHash string // Used when checking explicit values, like base or exact match
@@ -78,46 +122,90 @@ func TestEtcdClusterHash(t *testing.T) {
 	}{
 		{
 			name:        "Deterministic - Identical configuration must return the identical hash",
+			baseCluster: baseCluster,
 			cluster:     baseCluster.DeepCopy(),
 			expectEqual: true,
 			checkLength: true,
 		},
 		{
 			name:        "Size Bypass - Scaling the cluster size must NOT change the hash",
+			baseCluster: baseCluster,
 			cluster:     withSize(9),
 			expectEqual: true,
 		},
 		{
 			name:        "Metadata Bypass - Modifying pod metadata must NOT change the hash",
+			baseCluster: baseCluster,
 			cluster:     withMetaChanged(),
 			expectEqual: true,
 		},
 		{
 			name:        "Core Spec Change - Modifying EtcdOptions must force a brand new hash",
+			baseCluster: baseCluster,
 			cluster:     withOptionsChanged(),
 			expectEqual: false,
 		},
 		{
 			name:        "Nil Guard Check - A missing PodTemplate must not panic and must hash cleanly",
+			baseCluster: baseCluster,
 			cluster:     withNilTemplate(),
 			expectEqual: false,
 			checkLength: true,
 		},
 		{
 			name:        "Version check - Modifying etcd version must NOT change the hash",
+			baseCluster: baseCluster,
 			cluster:     withVersionChanged(),
 			expectEqual: true,
 		},
 		{
 			name:        "Core Spec Change - Modifying ImageRegistry must force a brand new hash",
+			baseCluster: baseCluster,
 			cluster:     withImageRegistryChanged(),
 			expectEqual: false,
+		},
+		{
+			name:        "Core Spec Change - Modifying StorageSpec must force a brand new hash",
+			baseCluster: baseCluster,
+			cluster:     withStorageSpecChanged(),
+			expectEqual: false,
+		},
+		{
+			name:        "Core Spec Change - Modifying TLS configuration must force a brand new hash",
+			baseCluster: baseCluster,
+			cluster:     withTLSChanged(),
+			expectEqual: false,
+		},
+		{
+			name:        "Core Spec Change - Modifying PodTemplate scheduling spec must force a brand new hash",
+			baseCluster: baseCluster,
+			cluster:     withPodSpecChanged(),
+			expectEqual: false,
+		},
+		{
+			name:        "Paused Bypass - Toggling Paused must NOT change the hash",
+			baseCluster: baseCluster,
+			cluster:     withPaused(),
+			expectEqual: true,
+		},
+		{
+			name:        "AllowVersionUpgradeOnRepair Bypass - Toggling the repair-upgrade knob must NOT change the hash",
+			baseCluster: baseCluster,
+			cluster:     withAllowVersionUpgradeOnRepair(),
+			expectEqual: true,
+		},
+		{
+			name:        "PodTemplate.Metadata Bypass - Adding a metadata-only PodTemplate must NOT change the hash",
+			baseCluster: withNilPodTemplate(),
+			cluster:     withPodTemplateMetadataChanged(),
+			expectEqual: true,
 		},
 	}
 
 	// Loop through the table executing each row in isolation
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			baseHash := EtcdClusterHash(tt.baseCluster)
 			currentHash := EtcdClusterHash(tt.cluster)
 
 			if tt.checkLength {
@@ -131,4 +219,18 @@ func TestEtcdClusterHash(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestEtcdClusterHashPinned pins EtcdClusterHash's output for an empty
+// EtcdClusterSpec, so that any future change to the EtcdClusterSpec schema
+// fails this test. If it fails, revisit EtcdClusterHash to decide whether
+// the schema change should affect the hash before updating
+// expectedEmptySpecHash.
+func TestEtcdClusterHashPinned(t *testing.T) {
+	// Captured for an all-zero-value EtcdClusterSpec at commit
+	// 5483df641bf23347d98a56b8d966bc2c495edcb5.
+	const expectedEmptySpecHash = "f71305f40ce2"
+	currentHash := EtcdClusterHash(&v1alpha1.EtcdCluster{Spec: v1alpha1.EtcdClusterSpec{}})
+	assert.Equal(t, expectedEmptySpecHash, currentHash,
+		"hash input changed, see comment above before updating this constant")
 }


### PR DESCRIPTION
`EtcdClusterHash` only hash fields in `clusterHashInput`. 
/cc @ahrtr @nwnt 
Link to https://github.com/etcd-io/etcd-operator/pull/488