### PR TITLE
fix: clean up member alarms and resources during deletion

### DIFF
--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -526,23 +526,22 @@ func (r *EtcdClusterReconciler) ensureClusterFinalizer(ctx context.Context, s *r
 	return r.Update(ctx, s.cluster)
 }
 
-// finalizeCluster handles an EtcdCluster with DeletionTimestamp set: it
-// removes every EtcdMember it still owns — reusing the same interim
-// finalizer-clearing dispatch()'s Terminating-cleanup step uses for a
-// single Terminating member — and, once none remain, releases
-// clusterCleanupFinalizer so Kubernetes can finish deleting the EtcdCluster
-// itself.
-//
-// TODO: like that step, this skips the real six-step leave sequence (§4.6,
-// M3): members are removed without ever calling etcd's MemberRemove, so
-// deleting a cluster with live members can leave stale entries in etcd's
-// own membership list. Acceptable for now because the Pods backing those
-// members are torn down along with everything else, but M3 should replace
-// this loop with the real sequence rather than just deleting faster.
+// finalizeCluster performs Kubernetes-only cleanup for whole-cluster deletion.
+// Each member's Pod and PVC delete requests must succeed before its finalizer
+// is released. Once no members remain, the cluster's shared TLS certificate
+// Secrets are deleted and then the cluster's own finalizer is released,
+// letting the EtcdCluster object disappear. No live etcd calls are needed.
 func (r *EtcdClusterReconciler) finalizeCluster(ctx context.Context, s *reconcileState) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
 	if len(s.members) == 0 {
+		if err := deleteClusterCertificateSecrets(ctx, s.cluster, r.Client, []string{
+			getClientCertName(s.cluster.Name),
+			getServerCertName(s.cluster.Name),
+			getPeerCertName(s.cluster.Name),
+		}); err != nil {
+			return ctrl.Result{}, err
+		}
 		if controllerutil.RemoveFinalizer(s.cluster, clusterCleanupFinalizer) {
 			if err := r.Update(ctx, s.cluster); err != nil {
 				return ctrl.Result{}, err
@@ -553,26 +552,42 @@ func (r *EtcdClusterReconciler) finalizeCluster(ctx context.Context, s *reconcil
 
 	logger.Info("EtcdCluster is Terminating; deleting owned EtcdMembers", "remaining", len(s.members))
 	for i := range s.members {
-		m := &s.members[i]
-		if m.DeletionTimestamp == nil {
-			if err := r.Delete(ctx, m); err != nil && !errors.IsNotFound(err) {
-				return ctrl.Result{}, err
-			}
-			// Delete only sets DeletionTimestamp while the member finalizer is
-			// present. A later pass enters the branch below and releases it.
-			continue
-		}
-		if err := r.clearMemberFinalizer(ctx, m); err != nil {
-			return ctrl.Result{}, err
+		if err := r.finalizeClusterMember(ctx, &s.members[i]); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to finalize EtcdMember %q: %w", s.members[i].Name, err)
 		}
 	}
 	return ctrl.Result{RequeueAfter: requeueDuration}, nil
 }
 
+// finalizeClusterMember requests Pod and PVC deletion before releasing the member finalizer.
+func (r *EtcdClusterReconciler) finalizeClusterMember(ctx context.Context, member *ecv1alpha1.EtcdMember) error {
+	if member.DeletionTimestamp == nil {
+		if err := r.Delete(ctx, member); client.IgnoreNotFound(err) != nil {
+			return err
+		}
+	}
+
+	resources := []client.Object{
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: member.Name, Namespace: member.Namespace}},
+		&corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: pvcNameForMember(member.Name), Namespace: member.Namespace}},
+	}
+	for _, resource := range resources {
+		if err := r.Delete(ctx, resource); client.IgnoreNotFound(err) != nil {
+			return err
+		}
+	}
+
+	// Delete may have changed the member's resource version in this pass.
+	if err := r.Get(ctx, client.ObjectKeyFromObject(member), member); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	return client.IgnoreNotFound(r.clearMemberFinalizer(ctx, member))
+}
+
 // clearMemberFinalizer removes memberCleanupFinalizer from m, letting
 // Kubernetes finish deleting it. Normal single-member deletion calls this at
-// the end of §4.6's leave sequence; whole-cluster deletion calls it directly as
-// §4.13's explicit exception and relies on Kubernetes garbage collection.
+// the end of §4.6's leave sequence; whole-cluster deletion calls it after
+// successfully requesting deletion of the member's Pod and PVC.
 func (r *EtcdClusterReconciler) clearMemberFinalizer(ctx context.Context, m *ecv1alpha1.EtcdMember) error {
 	if !controllerutil.RemoveFinalizer(m, memberCleanupFinalizer) {
 		return nil

--- a/internal/controller/etcdcluster_controller_test.go
+++ b/internal/controller/etcdcluster_controller_test.go
@@ -1217,13 +1217,14 @@ func createClusterHealthWithLeader(ec *ecv1alpha1.EtcdCluster, size, leaderOrdin
 	}
 }
 
-// TestFinalizeCluster verifies the EtcdCluster deletion path: owned
-// EtcdMembers are removed one dispatch-step-7-style pass at a time, and only
-// once none remain does the cluster's own finalizer get released.
+// TestFinalizeCluster verifies ordered Kubernetes delete requests without
+// waiting for resource disappearance or consulting the etcd cluster, and
+// that the cluster's shared TLS certificate Secrets are deleted before the
+// cluster's own finalizer is released (design doc §4.13).
 func TestFinalizeCluster(t *testing.T) {
 	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = ecv1alpha1.AddToScheme(scheme)
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, ecv1alpha1.AddToScheme(scheme))
 
 	terminatingCluster := func() *ecv1alpha1.EtcdCluster {
 		now := metav1.Now()
@@ -1231,6 +1232,7 @@ func TestFinalizeCluster(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:              "etcd",
 				Namespace:         "default",
+				UID:               types.UID("cluster-uid"),
 				DeletionTimestamp: &now,
 				Finalizers:        []string{clusterCleanupFinalizer},
 			},
@@ -1238,147 +1240,109 @@ func TestFinalizeCluster(t *testing.T) {
 		}
 	}
 
-	t.Run("Deletes a live member and requeues", func(t *testing.T) {
+	memberFor := func(ec *ecv1alpha1.EtcdCluster, ordinal int) *ecv1alpha1.EtcdMember {
+		return &ecv1alpha1.EtcdMember{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       etcdMemberName(ec.Name, ordinal),
+				Namespace:  ec.Namespace,
+				UID:        types.UID(etcdMemberName(ec.Name, ordinal) + "-uid"),
+				Finalizers: []string{memberCleanupFinalizer},
+			},
+			Spec: ecv1alpha1.EtcdMemberSpec{
+				ClusterName: ec.Name,
+				Ordinal:     ordinal,
+				Version:     ec.Spec.Version,
+			},
+		}
+	}
+
+	// memberResources builds a member's owned Pod and PVC. No finalizers are
+	// attached, so Delete fully removes them and IsNotFound is the right
+	// post-condition.
+	memberResources := func(member *ecv1alpha1.EtcdMember) (*corev1.Pod, *corev1.PersistentVolumeClaim) {
+		owner := *metav1.NewControllerRef(member, ecv1alpha1.GroupVersion.WithKind("EtcdMember"))
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name: member.Name, Namespace: member.Namespace, OwnerReferences: []metav1.OwnerReference{owner},
+		}}
+		pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+			Name: pvcNameForMember(member.Name), Namespace: member.Namespace, OwnerReferences: []metav1.OwnerReference{owner},
+		}}
+		return pod, pvc
+	}
+
+	t.Run("Deletes every member's Pod and PVC before clearing its finalizer", func(t *testing.T) {
 		ctx := t.Context()
 		ec := terminatingCluster()
-		member := ecv1alpha1.EtcdMember{
-			ObjectMeta: metav1.ObjectMeta{Name: "etcd-0", Namespace: ec.Namespace, Finalizers: []string{memberCleanupFinalizer}},
-			Spec:       ecv1alpha1.EtcdMemberSpec{ClusterName: ec.Name, Ordinal: 0, Version: ec.Spec.Version},
-		}
-
-		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec, &member).Build()
+		member0, member1 := memberFor(ec, 0), memberFor(ec, 1)
+		pod0, pvc0 := memberResources(member0)
+		pod1, pvc1 := memberResources(member1)
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(ec, member0, member1, pod0, pvc0, pod1, pvc1).Build()
 		r := &EtcdClusterReconciler{Client: fakeClient, Scheme: scheme}
-		state := &reconcileState{cluster: ec, members: []ecv1alpha1.EtcdMember{member}}
+		state := &reconcileState{cluster: ec, members: []ecv1alpha1.EtcdMember{*member0, *member1}}
 
 		res, err := r.finalizeCluster(ctx, state)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, res)
 
-		got := &ecv1alpha1.EtcdMember{}
-		require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: "etcd-0", Namespace: ec.Namespace}, got))
-		assert.NotNil(t, got.DeletionTimestamp, "Delete should have been called on the still-live member")
-
-		// The cluster itself must still carry its finalizer: it's not done
-		// until the member is actually gone too.
+		// Each member and its owned Pod and PVC are gone; the cluster's own
+		// finalizer stays because finalizeCluster releases it only after
+		// every member has been removed.
+		for _, obj := range []client.Object{member0, member1, pod0, pvc0, pod1, pvc1} {
+			assert.True(t, apierrors.IsNotFound(fakeClient.Get(ctx, client.ObjectKeyFromObject(obj), obj)),
+				"expected %T %q to be deleted", obj, obj.GetName())
+		}
 		gotCluster := &ecv1alpha1.EtcdCluster{}
-		require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: "etcd", Namespace: "default"}, gotCluster))
-		assert.Equal(t, []string{clusterCleanupFinalizer}, gotCluster.Finalizers)
+		require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(ec), gotCluster))
+		assert.Contains(t, gotCluster.Finalizers, clusterCleanupFinalizer)
 	})
 
-	t.Run("Releases an already-Terminating member without directly deleting owned resources", func(t *testing.T) {
+	t.Run("Missing Pod and PVC do not block member finalization", func(t *testing.T) {
 		ctx := t.Context()
 		ec := terminatingCluster()
-		now := metav1.Now()
-		member := ecv1alpha1.EtcdMember{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:              "etcd-0",
-				Namespace:         ec.Namespace,
-				UID:               types.UID("member-0"),
-				DeletionTimestamp: &now,
-				Finalizers:        []string{memberCleanupFinalizer},
-			},
-			Spec: ecv1alpha1.EtcdMemberSpec{ClusterName: ec.Name, Ordinal: 0, Version: ec.Spec.Version},
-		}
-		memberOwner := *metav1.NewControllerRef(&member, ecv1alpha1.GroupVersion.WithKind("EtcdMember"))
-		pod := corev1.Pod{ObjectMeta: metav1.ObjectMeta{
-			Name: "etcd-0", Namespace: ec.Namespace, OwnerReferences: []metav1.OwnerReference{memberOwner},
-		}}
-		pvc := corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
-			Name: pvcNameForMember("etcd-0"), Namespace: ec.Namespace, OwnerReferences: []metav1.OwnerReference{memberOwner},
-		}}
-
-		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec, &member, &pod, &pvc).Build()
+		member := memberFor(ec, 0)
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec, member).Build()
 		r := &EtcdClusterReconciler{Client: fakeClient, Scheme: scheme}
-		state := &reconcileState{cluster: ec, members: []ecv1alpha1.EtcdMember{member}, pods: []*corev1.Pod{&pod}}
+		state := &reconcileState{cluster: ec, members: []ecv1alpha1.EtcdMember{*member}}
 
-		res, err := r.finalizeCluster(ctx, state)
-		assert.NoError(t, err)
-		assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, res)
-
-		// §4.13 deliberately bypasses the single-member leave sequence: once
-		// every member is leaving, its membership no longer needs protecting.
-		// Releasing the member finalizer lets the real API server's garbage
-		// collector remove these owner-referenced resources. The fake client
-		// does not emulate GC, so their continued presence here proves the
-		// controller did not delete them directly.
-		require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(&pod), &corev1.Pod{}))
-		require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(&pvc), &corev1.PersistentVolumeClaim{}))
-
-		// Removing the last finalizer lets the fake client finish deleting the
-		// EtcdMember itself.
-		got := &ecv1alpha1.EtcdMember{}
-		err = fakeClient.Get(ctx, client.ObjectKey{Name: "etcd-0", Namespace: ec.Namespace}, got)
-		if err == nil {
-			assert.Empty(t, got.Finalizers, "finalizeCluster must clear memberCleanupFinalizer directly")
-		} else {
-			assert.True(t, apierrors.IsNotFound(err), "clearing the last finalizer should let the fake client remove it")
-		}
+		_, err := r.finalizeCluster(ctx, state)
+		require.NoError(t, err)
+		assert.True(t, apierrors.IsNotFound(fakeClient.Get(ctx, client.ObjectKeyFromObject(member), &ecv1alpha1.EtcdMember{})))
+		// A stale snapshot of an already deleted member is also harmless.
+		_, err = r.finalizeCluster(ctx, state)
+		require.NoError(t, err)
 	})
 
-	t.Run("Handles live and Terminating members independently in the same pass", func(t *testing.T) {
+	// TODO: add coverage for resource deletion failures (Pod delete error,
+	// PVC delete error). Such an error must stop the per-member cleanup loop
+	// before clearing the member's finalizer and before moving to the next
+	// member, and the cleanup must recover on the next reconcile. See PR #506
+	// review thread.
+
+	t.Run("Deletes Secrets before releasing the cluster finalizer", func(t *testing.T) {
 		ctx := t.Context()
 		ec := terminatingCluster()
-		now := metav1.Now()
-		live := ecv1alpha1.EtcdMember{
-			ObjectMeta: metav1.ObjectMeta{Name: "etcd-0", Namespace: ec.Namespace, Finalizers: []string{memberCleanupFinalizer}},
-			Spec:       ecv1alpha1.EtcdMemberSpec{ClusterName: ec.Name, Ordinal: 0, Version: ec.Spec.Version},
+		// Exercise the cert-provider path; the default "auto" provider
+		// removes Secrets directly, which is what we verify below.
+		ec.Spec.TLS = &ecv1alpha1.TLSCertificate{}
+		owner := *metav1.NewControllerRef(ec, ecv1alpha1.GroupVersion.WithKind("EtcdCluster"))
+		secrets := make([]client.Object, 0, 3)
+		for _, name := range []string{getClientCertName(ec.Name), getServerCertName(ec.Name), getPeerCertName(ec.Name)} {
+			secrets = append(secrets, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name: name, Namespace: ec.Namespace, OwnerReferences: []metav1.OwnerReference{owner},
+			}})
 		}
-		terminating := ecv1alpha1.EtcdMember{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:              "etcd-1",
-				Namespace:         ec.Namespace,
-				DeletionTimestamp: &now,
-				Finalizers:        []string{memberCleanupFinalizer},
-			},
-			Spec: ecv1alpha1.EtcdMemberSpec{ClusterName: ec.Name, Ordinal: 1, Version: ec.Spec.Version},
-		}
-
-		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec, &live, &terminating).Build()
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(append([]client.Object{ec}, secrets...)...).Build()
 		r := &EtcdClusterReconciler{Client: fakeClient, Scheme: scheme}
-		state := &reconcileState{cluster: ec, members: []ecv1alpha1.EtcdMember{live, terminating}}
 
-		res, err := r.finalizeCluster(ctx, state)
-		assert.NoError(t, err)
-		assert.Equal(t, ctrl.Result{RequeueAfter: requeueDuration}, res)
-
-		// Live member only had Delete called: DeletionTimestamp is now set,
-		// memberCleanupFinalizer stays — its leave sequence runs on a later
-		// pass, after the member watch re-enters this loop.
-		gotLive := &ecv1alpha1.EtcdMember{}
-		require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: "etcd-0", Namespace: ec.Namespace}, gotLive))
-		assert.NotNil(t, gotLive.DeletionTimestamp)
-		assert.Contains(t, gotLive.Finalizers, memberCleanupFinalizer)
-
-		// Terminating member had its finalizer released directly; the fake
-		// client then removed the object without running the member leave
-		// sequence.
-		gotTerm := &ecv1alpha1.EtcdMember{}
-		err = fakeClient.Get(ctx, client.ObjectKey{Name: "etcd-1", Namespace: ec.Namespace}, gotTerm)
-		if err == nil {
-			assert.Empty(t, gotTerm.Finalizers)
-		} else {
-			assert.True(t, apierrors.IsNotFound(err), "clearing the last finalizer should let the fake client remove it")
-		}
-	})
-
-	t.Run("Releases the cluster's own finalizer once no members remain", func(t *testing.T) {
-		ctx := t.Context()
-		ec := terminatingCluster()
-
-		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ec).Build()
-		r := &EtcdClusterReconciler{Client: fakeClient, Scheme: scheme}
-		state := &reconcileState{cluster: ec}
-
-		res, err := r.finalizeCluster(ctx, state)
-		assert.NoError(t, err)
+		res, err := r.finalizeCluster(ctx, &reconcileState{cluster: ec})
+		require.NoError(t, err)
 		assert.Equal(t, ctrl.Result{}, res)
-
-		got := &ecv1alpha1.EtcdCluster{}
-		err = fakeClient.Get(ctx, client.ObjectKey{Name: "etcd", Namespace: "default"}, got)
-		if err == nil {
-			assert.Empty(t, got.Finalizers)
-		} else {
-			assert.True(t, apierrors.IsNotFound(err), "clearing the last finalizer should let the fake client remove it")
+		// The fake client does not run GC, so the only way Secrets disappear
+		// is if finalizeCluster explicitly deletes them.
+		assert.True(t, apierrors.IsNotFound(fakeClient.Get(ctx, client.ObjectKeyFromObject(ec), &ecv1alpha1.EtcdCluster{})))
+		for _, secret := range secrets {
+			assert.True(t, apierrors.IsNotFound(fakeClient.Get(ctx, client.ObjectKeyFromObject(secret), &corev1.Secret{})))
 		}
 	})
 }

--- a/internal/controller/etcdmember.go
+++ b/internal/controller/etcdmember.go
@@ -85,10 +85,12 @@ func (r *EtcdClusterReconciler) markMemberTerminating(ctx context.Context, membe
 }
 
 // cleanupEtcdMember is the §4.6 Terminating leave for one member: remove it
-// from etcd's live membership, delete its owned Pod and PVC, and finally
-// release memberCleanupFinalizer so Kubernetes can finish the deletion.
-// Every step is a no-op once done, so re-entering after an interruption
-// (operator restart, transient etcd error) resumes harmlessly.
+// from etcd's live membership, disarm its alarms, delete its owned Pod and PVC,
+// and finally release memberCleanupFinalizer so Kubernetes can finish the deletion.
+// Membership and resource cleanup are no-ops once done, so re-entering after
+// an interruption (operator restart, transient etcd error) resumes harmlessly.
+// Alarm cleanup currently requires the pre-removal membership snapshot;
+// retrying it across reconciles needs the removed ID to be retained separately.
 //
 // Leadership transfer is intentionally not done here. When etcd's own
 // MemberRemove drops this member from the cluster's Membership, the
@@ -102,6 +104,10 @@ func (r *EtcdClusterReconciler) markMemberTerminating(ctx context.Context, membe
 // in a follow-up (failure must not stop the sequence).
 func (r *EtcdClusterReconciler) cleanupEtcdMember(ctx context.Context, s *reconcileState, member *ecv1alpha1.EtcdMember) (ctrl.Result, error) {
 	if err := removeEtcdNode(s, member); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if err := disarmForEtcdMember(s, member); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -142,6 +148,26 @@ func removeEtcdNode(s *reconcileState, member *ecv1alpha1.EtcdMember) error {
 	cfg := etcdutils.ClientConfig{Endpoints: endpoints, TLS: s.tlsConfig}
 	if err := etcdutils.RemoveMember(cfg, etcdNode.ID); err != nil {
 		return fmt.Errorf("failed to remove the etcd node for EtcdMember %q: %w", member.Name, err)
+	}
+	return nil
+}
+
+// disarmForEtcdMember disarms the member's alarms from the reconcile snapshot.
+func disarmForEtcdMember(s *reconcileState, member *ecv1alpha1.EtcdMember) error {
+	var alarms []*etcdserverpb.AlarmMember
+	if etcdNode := findEtcdNodeForEtcdMember(s, member); etcdNode != nil && s.health != nil {
+		for _, alarm := range s.health.Alarms {
+			if alarm.MemberID == etcdNode.ID {
+				alarms = append(alarms, alarm)
+			}
+		}
+	}
+	if len(alarms) > 0 {
+		endpoints := clientEndpointsFromPods(s.cluster.Name, s.cluster.Namespace, s.pods, clusterTLSEnabled(s.cluster))
+		cfg := etcdutils.ClientConfig{Endpoints: endpoints, TLS: s.tlsConfig}
+		if err := etcdutils.AlarmDisarm(cfg, alarms); err != nil {
+			return fmt.Errorf("failed to disarm alarms for EtcdMember %q: %w", member.Name, err)
+		}
 	}
 	return nil
 }

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -336,13 +336,20 @@ func createAutoCertificateConfig(ec *ecv1alpha1.EtcdCluster) (*certInterface.Con
 	}, nil
 }
 
+// getCertificateProvider returns the cert provider matching providerType, or
+// an error if the type is unknown. An empty providerType defaults to "auto",
+// matching the convention used elsewhere when no provider is set on the
+// cluster spec.
+func getCertificateProvider(providerType string, c client.Client) (certInterface.Provider, error) {
+	if providerType == "" {
+		providerType = string(certificate.Auto)
+	}
+	return certificate.NewProvider(certificate.ProviderType(providerType), c)
+}
+
 func createCertificate(ec *ecv1alpha1.EtcdCluster, ctx context.Context, c client.Client, certName string) error {
 	providerName := ec.Spec.TLS.Provider
-	if providerName == "" {
-		providerName = string(certificate.Auto)
-	}
-
-	cert, certErr := certificate.NewProvider(certificate.ProviderType(providerName), c)
+	cert, certErr := getCertificateProvider(providerName, c)
 	if certErr != nil {
 		return certErr
 	}
@@ -411,6 +418,32 @@ func applyEtcdMemberCerts(ctx context.Context, ec *ecv1alpha1.EtcdCluster, c cli
 			return err
 		}
 		return createPeerCertificate(ctx, ec, c)
+	}
+	return nil
+}
+
+// deleteClusterCertificateSecrets removes the cluster's TLS certificate
+// Secrets listed in certNames via the cluster's cert provider.
+//
+// The actual cleanup is delegated to the cert provider: "auto" removes the
+// Secret directly; "cert-manager" first deletes the Certificate CR and then
+// the Secret (cert-manager does not auto-clean its Secrets). Each provider's
+// DeleteCertificateSecret is NotFound-tolerant: certs that were never
+// created, or were already removed, are silently skipped.
+//
+// Returns nil immediately if the cluster has no TLS configured.
+func deleteClusterCertificateSecrets(ctx context.Context, ec *ecv1alpha1.EtcdCluster, c client.Client, certNames []string) error {
+	if ec.Spec.TLS == nil {
+		return nil
+	}
+	provider, err := getCertificateProvider(ec.Spec.TLS.Provider, c)
+	if err != nil {
+		return fmt.Errorf("unknown TLS certificate provider %q: %w", ec.Spec.TLS.Provider, err)
+	}
+	for _, name := range certNames {
+		if err := provider.DeleteCertificateSecret(ctx, client.ObjectKey{Name: name, Namespace: ec.Namespace}); err != nil {
+			return fmt.Errorf("failed to delete certificate %q: %w", name, err)
+		}
 	}
 	return nil
 }

--- a/internal/etcdutils/etcdutils.go
+++ b/internal/etcdutils/etcdutils.go
@@ -81,6 +81,28 @@ func AlarmList(cfg ClientConfig) (*clientv3.AlarmResponse, error) {
 	return c.AlarmList(ctx)
 }
 
+// AlarmDisarm disarms each of the supplied alarms.
+func AlarmDisarm(cfg ClientConfig, alarms []*etcdserverpb.AlarmMember) error {
+	if len(alarms) == 0 {
+		return nil
+	}
+
+	c, err := clientv3.New(cfg.buildConfig())
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer func() { closeAndCancel(c, cancel) }()
+
+	for _, alarm := range alarms {
+		if _, err := c.AlarmDisarm(ctx, (*clientv3.AlarmMember)(alarm)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // ClusterHealth aggregates the results of a single health-check pass over an
 // etcd cluster: overall cluster health, per-member health, and any active
 // alarms.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -128,85 +128,6 @@ func TestClusterHealthy(t *testing.T) {
 	_ = testEnv.Test(t, feature.Feature())
 }
 
-func TestNormalMemberProvisioning(t *testing.T) {
-	testCases := []struct {
-		name        string
-		initialSize int
-		desiredSize int
-	}{
-		{name: "CreateSize3", initialSize: 3, desiredSize: 3},
-		{name: "ScaleOutFrom1To3", initialSize: 1, desiredSize: 3},
-		{name: "ScaleOutFrom3To5", initialSize: 3, desiredSize: 5},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			feature := features.New(tc.name)
-			clusterName := "normal-" + strings.ToLower(tc.name)
-
-			feature.Setup(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-				createEtcdClusterWithPVC(ctx, t, c, clusterName, tc.initialSize)
-				if tc.initialSize < tc.desiredSize {
-					if err := waitForAllEtcdMemberReady(t, c, etcdClusterRef(clusterName, tc.initialSize)); err != nil {
-						t.Fatalf("initial members did not become Ready: %v", err)
-					}
-				}
-				return ctx
-			})
-
-			feature.Assess("provision members in ordinal order", func(
-				ctx context.Context,
-				t *testing.T,
-				c *envconf.Config,
-			) context.Context {
-				if tc.initialSize != tc.desiredSize {
-					scaleEtcdCluster(ctx, t, c, clusterName, tc.desiredSize)
-				}
-				if err := waitForAllEtcdMemberReady(t, c, etcdClusterRef(clusterName, tc.desiredSize)); err != nil {
-					t.Fatalf("EtcdMembers did not become Ready in order: %v", err)
-				}
-				return ctx
-			})
-
-			feature.Assess("all final members are voting", func(
-				ctx context.Context,
-				t *testing.T,
-				c *envconf.Config,
-			) context.Context {
-				var pods corev1.PodList
-				if err := c.Client().Resources().List(
-					ctx,
-					&pods,
-					resources.WithLabelSelector("app="+clusterName),
-				); err != nil {
-					t.Fatalf("failed to list final Pods: %v", err)
-				}
-				if len(pods.Items) != tc.desiredSize {
-					t.Fatalf("expected %d Pods, got %d", tc.desiredSize, len(pods.Items))
-				}
-
-				memberList := getEtcdMemberListPB(t, c, clusterName+"-0")
-				if len(memberList.Members) != tc.desiredSize {
-					t.Fatalf("expected %d live etcd members, got %d", tc.desiredSize, len(memberList.Members))
-				}
-				for _, member := range memberList.Members {
-					if member.IsLearner {
-						t.Fatalf("member %s (%d) remained a learner", member.Name, member.ID)
-					}
-				}
-				return ctx
-			})
-
-			feature.Teardown(func(ctx context.Context, t *testing.T, c *envconf.Config) context.Context {
-				cleanupEtcdCluster(ctx, t, c, clusterName)
-				return ctx
-			})
-
-			_ = testEnv.Test(t, feature.Feature())
-		})
-	}
-}
-
 func TestScaling(t *testing.T) {
 	testCases := []struct {
 		name            string
@@ -227,6 +148,8 @@ func TestScaling(t *testing.T) {
 			initialSize: 1, scaleTo: 3, expectedMembers: 3,
 			failpoint: "exceptionAfterMemberAdd", term: "panic",
 		},
+		{name: "ScaleOutFrom3To5", initialSize: 3, scaleTo: 5, expectedMembers: 5},
+		{name: "ScaleInFrom5To3", initialSize: 5, scaleTo: 3, expectedMembers: 3},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Changes as per https://github.com/etcd-io/etcd-operator/issues/471#issuecomment-5573767115:
- disarm alarms when cleaning up EtcdMember resources.
- delete Pod and PVC of each member when terminating a EtcdCluster.
- Remove `TestNormalMemberProvisioning` and add cases to `TestScaling`

/cc @ahrtr 